### PR TITLE
feat: agents now actively maintain the nest

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@promptowl/contextnest-cli",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "repository": { "type": "git", "url": "https://github.com/PromptOwl/ContextNest.git", "directory": "packages/cli" },
   "description": "CLI for structured AI agent knowledge bases — versioned documents, deterministic queries, integrity verification, and MCP integration",
   "homepage": "https://github.com/PromptOwl/ContextNest",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -159,6 +159,14 @@ program
         process.exit(1);
       }
 
+      // Persist the starter's maintenance directive into config so
+      // `ctx index` can surface it into CLAUDE.md / GEMINI.md / etc.
+      const initialConfig = await storage.readConfig();
+      if (initialConfig) {
+        initialConfig.agent_maintenance_directive = starter.getMaintenanceDirective();
+        await storage.writeConfig(initialConfig);
+      }
+
       // Write starter nodes
       for (const node of starter.nodes) {
         await storage.writeDocument(node.path, node.content);

--- a/packages/cli/src/starters/__tests__/maintenance-directive.test.ts
+++ b/packages/cli/src/starters/__tests__/maintenance-directive.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import {
+  getDefaultMaintenanceDirective,
+  getDeveloperMaintenanceDirective,
+  getPersonalMaintenanceDirective,
+} from "../agent-config-base.js";
+import { getStarter, listStarters } from "../index.js";
+
+describe("maintenance directives — content shape", () => {
+  it("default directive is aggressive and capture-first", () => {
+    const d = getDefaultMaintenanceDirective();
+    expect(d).toContain("KEEPING IT USEFUL");
+    expect(d).toContain("Capture aggressively");
+    expect(d).toContain("Multiple nodes per session is normal");
+    expect(d).toContain("Under-capture is the failure mode");
+    expect(d).toContain("You do not need permission to capture");
+  });
+
+  it("developer directive emphasizes codebase-flavored capture", () => {
+    const d = getDeveloperMaintenanceDirective();
+    expect(d).toContain("engineering knowledge");
+    expect(d).toContain("Architecture decisions");
+    expect(d).toContain("Things you learned about this codebase");
+    expect(d).toContain("Capture aggressively");
+  });
+
+  it("personal directive emphasizes ideas/learning over codebase", () => {
+    const d = getPersonalMaintenanceDirective();
+    expect(d).toContain("personal second brain");
+    expect(d).toContain("Things the user is thinking about");
+    expect(d).toContain("Things they learned");
+    expect(d).not.toContain("codebase");
+  });
+});
+
+describe("Starter.getMaintenanceDirective() wiring", () => {
+  it("developer starter returns the developer directive", () => {
+    const s = getStarter("developer");
+    expect(s).toBeDefined();
+    expect(s!.getMaintenanceDirective()).toContain("engineering knowledge");
+  });
+
+  it("personal starter returns the personal directive", () => {
+    const s = getStarter("personal");
+    expect(s!.getMaintenanceDirective()).toContain("personal second brain");
+  });
+
+  it("every starter has getMaintenanceDirective and returns non-empty content", () => {
+    for (const s of listStarters()) {
+      const d = s.getMaintenanceDirective();
+      expect(typeof d).toBe("string");
+      expect(d.length).toBeGreaterThan(100);
+      expect(d).toContain("Maintaining This Nest");
+    }
+  });
+
+  it("non-developer / non-personal starters use the default directive", () => {
+    const exec = getStarter("executive");
+    expect(exec!.getMaintenanceDirective()).toBe(getDefaultMaintenanceDirective());
+    const team = getStarter("team");
+    expect(team!.getMaintenanceDirective()).toBe(getDefaultMaintenanceDirective());
+  });
+});

--- a/packages/cli/src/starters/agent-config-base.ts
+++ b/packages/cli/src/starters/agent-config-base.ts
@@ -216,3 +216,144 @@ export function getPersonalPostInitPrompt(): PostInitPrompt {
     instructions: PERSONAL_INSTRUCTIONS,
   };
 }
+
+// ─── Maintenance directives (emitted into CLAUDE.md / GEMINI.md / etc.) ──────
+//
+// These get written into .context/config.yaml at init time and surfaced into
+// the agent config managed section on every `ctx index`. The agent reads them
+// every session — they are the lever that keeps the nest growing instead of
+// rotting.
+//
+// Tone: aggressive. Capture-first. Don't gate on user permission. Multiple
+// nodes per session is normal. Under-capture is the failure mode, not over-
+// capture. Tailored per starter: developer = codebase-flavored; personal =
+// ideas/learning-flavored; default = generic.
+
+const DEFAULT_MAINTENANCE_DIRECTIVE = `## Maintaining This Nest
+
+This project has a Context Nest vault. As the agent working with the user on
+this project, YOU are responsible for KEEPING IT USEFUL. This is not optional —
+without active maintenance the nest decays and the user loses the second-brain
+value they installed it for.
+
+Capture aggressively. Multiple nodes per session is normal and expected.
+Under-capture is the failure mode here, not over-capture.
+
+What to capture:
+
+- **Information you uncovered** — anything the next session would benefit
+  from knowing without rediscovering.
+- **Decisions** the user makes (and the reasoning). Even small ones.
+- **Gotchas, surprises, and tribal knowledge** — anything that took more
+  than a moment to figure out, or that the user said in passing worth not
+  losing.
+- **Answers** worked out together that would help next time the same
+  question comes up.
+- **References** the user shared (URLs, file paths, screenshots, pasted
+  threads) — anchor them in a node so they don't disappear into chat.
+
+How to capture:
+
+- You do not need permission to capture. You may capture without asking.
+  Mention what you're capturing in passing if it's substantive — do not
+  gate the capture on a yes/no from the user.
+- Use \`ctx add nodes/<slug> --type document --title "<title>" --tags
+  "<tags>"\` to create. Write the body with the Write tool. Keep nodes
+  tight — 100-300 words is usually plenty.
+- Show what you wrote only if asked, or if the content is ambiguous.
+- Every change is hash-chained and versioned silently. The user can inspect
+  or revert later. There is no cost to capturing too much; there is real
+  cost to capturing too little.
+`;
+
+const DEVELOPER_MAINTENANCE_DIRECTIVE = `## Maintaining This Nest
+
+This project has a Context Nest vault for engineering knowledge. As the
+agent working with the user on this codebase, YOU are responsible for
+KEEPING IT USEFUL. This is not optional — without active maintenance the
+nest decays and the user loses the cheaper-agent-sessions, surviving-
+tribal-knowledge value they installed it for.
+
+Capture aggressively. Multiple nodes per session is normal and expected.
+Under-capture is the failure mode here, not over-capture.
+
+What to capture (engineering specifically):
+
+- **Architecture decisions** — every "we're going to do X because Y" is
+  worth a node. Mini-ADRs for the small stuff too, not just the big calls.
+- **Things you learned about this codebase** to do the current task —
+  conventions, hidden coupling, why a file is structured oddly, what a
+  cryptic helper actually does. The next agent session needs to know.
+- **Gotchas and surprises** — the env var that breaks things if missing,
+  the deploy step that's not in the README, the test that's flaky for a
+  specific reason.
+- **Answers to questions** the user asked about how something works.
+  Capture both the question and the answer so next time you (or another
+  teammate's agent) can find it.
+- **References** the user shared — PR URLs, Slack threads, related
+  files, screenshots — anchor them in a node alongside the why.
+
+How to capture:
+
+- You do not need permission to capture. You may capture without asking.
+  Mention what you're capturing in passing if it's substantive — do not
+  gate the capture on a yes/no from the user.
+- Use \`ctx add nodes/<slug> --type document --title "<title>" --tags
+  "<tags>"\` to create. Write the body with the Write tool. Keep nodes
+  tight — 100-300 words is usually plenty.
+- Show what you wrote only if asked, or if the content is ambiguous.
+- Every change is hash-chained and versioned silently. The user can
+  inspect or revert later. There is no cost to capturing too much; there
+  is real cost to capturing too little.
+`;
+
+const PERSONAL_MAINTENANCE_DIRECTIVE = `## Maintaining This Nest
+
+This is the user's personal second brain. As the agent working with them,
+YOU are responsible for KEEPING IT USEFUL. This is not optional — without
+active maintenance the nest decays and the user loses the second-brain
+value they installed it for.
+
+Capture aggressively. Multiple nodes per session is normal and expected.
+Under-capture is the failure mode here, not over-capture.
+
+What to capture:
+
+- **Things the user is thinking about** — half-formed ideas, working
+  hypotheses, frames they're trying out. Capture them while they're
+  forming, not after they've calcified.
+- **Decisions they made** (and the reasoning) — life, work, projects,
+  finances, learning paths. Mini-ADRs for personal life.
+- **Things they learned** — concepts, frameworks, vocabulary, mental
+  models. If they explained something to you, capture it so they can find
+  it later.
+- **Answers to questions** you worked out together. Personal Q&A is
+  usually high-signal and easy to lose.
+- **References they shared** — articles, books, papers, talks, threads —
+  with their take on each, not just the link.
+
+How to capture:
+
+- You do not need permission to capture. You may capture without asking.
+  Mention what you're capturing in passing if it's substantive — do not
+  gate the capture on a yes/no from the user.
+- Use \`ctx add nodes/<slug> --type document --title "<title>" --tags
+  "<tags>"\` to create. Write the body with the Write tool. Keep nodes
+  tight — 100-300 words is usually plenty.
+- Show what you wrote only if asked, or if the content is ambiguous.
+- Every change is hash-chained and versioned silently. The user can
+  inspect or revert later. There is no cost to capturing too much; there
+  is real cost to capturing too little.
+`;
+
+export function getDefaultMaintenanceDirective(): string {
+  return DEFAULT_MAINTENANCE_DIRECTIVE;
+}
+
+export function getDeveloperMaintenanceDirective(): string {
+  return DEVELOPER_MAINTENANCE_DIRECTIVE;
+}
+
+export function getPersonalMaintenanceDirective(): string {
+  return PERSONAL_MAINTENANCE_DIRECTIVE;
+}

--- a/packages/cli/src/starters/index.ts
+++ b/packages/cli/src/starters/index.ts
@@ -6,7 +6,14 @@
  * that AI agents read from stdout to interactively generate a tailored CONTEXT.md.
  */
 
-import { getPostInitPrompt, getDeveloperPostInitPrompt, getPersonalPostInitPrompt } from "./agent-config-base.js";
+import {
+  getPostInitPrompt,
+  getDeveloperPostInitPrompt,
+  getPersonalPostInitPrompt,
+  getDefaultMaintenanceDirective,
+  getDeveloperMaintenanceDirective,
+  getPersonalMaintenanceDirective,
+} from "./agent-config-base.js";
 import type { PostInitPrompt } from "./agent-config-base.js";
 
 export interface StarterNode {
@@ -30,6 +37,12 @@ export interface Starter {
   nodes: StarterNode[];
   packs: StarterPack[];
   getPrompt(): PostInitPrompt;
+  /**
+   * Maintenance directive written to .context/config.yaml at init time.
+   * `ctx index` reads it and emits it into the agent config managed
+   * section so every session reminds the agent to keep the nest growing.
+   */
+  getMaintenanceDirective(): string;
 }
 
 // ─── Developer Starter ─────────────────────────────────────────────────────────
@@ -253,6 +266,9 @@ agent_instructions: >
   getPrompt() {
     return getDeveloperPostInitPrompt();
   },
+  getMaintenanceDirective() {
+    return getDeveloperMaintenanceDirective();
+  },
 };
 
 // ─── Executive Starter ──────────────────────────────────────────────────────────
@@ -457,6 +473,9 @@ agent_instructions: >
   ],
   getPrompt() {
     return getPostInitPrompt(this.id, this.description);
+  },
+  getMaintenanceDirective() {
+    return getDefaultMaintenanceDirective();
   },
 };
 
@@ -680,6 +699,9 @@ agent_instructions: >
   getPrompt() {
     return getPostInitPrompt(this.id, this.description);
   },
+  getMaintenanceDirective() {
+    return getDefaultMaintenanceDirective();
+  },
 };
 
 // ─── Team Starter ───────────────────────────────────────────────────────────────
@@ -879,6 +901,9 @@ agent_instructions: >
   ],
   getPrompt() {
     return getPostInitPrompt(this.id, this.description);
+  },
+  getMaintenanceDirective() {
+    return getDefaultMaintenanceDirective();
   },
 };
 
@@ -1111,6 +1136,9 @@ agent_instructions: >
   getPrompt() {
     return getPostInitPrompt(this.id, this.description);
   },
+  getMaintenanceDirective() {
+    return getDefaultMaintenanceDirective();
+  },
 };
 
 // ─── Personal Starter ──────────────────────────────────────────────────────────
@@ -1123,6 +1151,9 @@ const personal: Starter = {
   packs: [],
   getPrompt() {
     return getPersonalPostInitPrompt();
+  },
+  getMaintenanceDirective() {
+    return getPersonalMaintenanceDirective();
   },
 };
 

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@promptowl/contextnest-engine",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "repository": { "type": "git", "url": "https://github.com/PromptOwl/ContextNest.git", "directory": "packages/engine" },
   "description": "Core engine for AI agent knowledge bases — selectors, versioning, graph traversal, integrity verification, and context management for LLMs",
   "homepage": "https://github.com/PromptOwl/ContextNest",

--- a/packages/engine/src/__tests__/agent-configs-maintenance.test.ts
+++ b/packages/engine/src/__tests__/agent-configs-maintenance.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { generateAgentConfigs } from "../agent-configs.js";
+import type { ContextYaml, NestConfig } from "../types.js";
+
+const emptyContextYaml: ContextYaml = {
+  schema_version: 1,
+  generated_at: new Date().toISOString(),
+  documents: [],
+  relationships: [],
+  hubs: [],
+};
+
+describe("generateAgentConfigs — maintenance directive", () => {
+  it("emits the configured directive verbatim into all five agent files", () => {
+    const config: NestConfig = {
+      version: 1,
+      name: "Test Vault",
+      agent_maintenance_directive: "## Maintaining This Nest\n\nCustom directive for the test.",
+    };
+
+    const files = generateAgentConfigs({
+      config,
+      contextYaml: emptyContextYaml,
+      packs: [],
+      hasMcpServer: false,
+    });
+
+    expect(files.map((f) => f.path)).toEqual([
+      "CLAUDE.md",
+      "GEMINI.md",
+      ".cursorrules",
+      ".windsurfrules",
+      ".github/copilot-instructions.md",
+    ]);
+
+    for (const file of files) {
+      expect(file.content).toContain("Custom directive for the test.");
+    }
+  });
+
+  it("falls back to the default directive when config has no field set", () => {
+    const config: NestConfig = {
+      version: 1,
+      name: "Test Vault",
+    };
+
+    const [claude] = generateAgentConfigs({
+      config,
+      contextYaml: emptyContextYaml,
+      packs: [],
+      hasMcpServer: false,
+    });
+
+    // Default directive's distinguishing phrases
+    expect(claude.content).toContain("Maintaining This Nest");
+    expect(claude.content).toContain("Capture aggressively");
+    expect(claude.content).toContain("Under-capture is the failure mode");
+    expect(claude.content).toContain("You do not need permission to capture");
+  });
+
+  it("falls back to the default directive when config is null", () => {
+    const [claude] = generateAgentConfigs({
+      config: null,
+      contextYaml: emptyContextYaml,
+      packs: [],
+      hasMcpServer: false,
+    });
+
+    expect(claude.content).toContain("Capture aggressively");
+  });
+});

--- a/packages/engine/src/agent-configs.ts
+++ b/packages/engine/src/agent-configs.ts
@@ -12,6 +12,52 @@ import type { ContextYaml, NestConfig, Pack } from "./types.js";
 const SECTION_BEGIN = "<!-- BEGIN CONTEXT NEST (auto-generated, do not edit this section) -->";
 const SECTION_END = "<!-- END CONTEXT NEST -->";
 
+/**
+ * Fallback maintenance directive used when `config.agent_maintenance_directive`
+ * is not set (e.g., vaults initialized before this field existed). Starter-
+ * specific directives shipped via `cli/src/starters/agent-config-base.ts`
+ * override this when present in config.
+ */
+const DEFAULT_MAINTENANCE_DIRECTIVE = `## Maintaining This Nest
+
+This project has a Context Nest vault. As the agent working with the user on
+this project, YOU are responsible for KEEPING IT USEFUL. This is not optional —
+without active maintenance the nest decays and the user loses the second-brain
+value they installed it for.
+
+Capture aggressively. Multiple nodes per session is normal and expected.
+Under-capture is the failure mode here, not over-capture.
+
+What to capture:
+
+- **Information you uncovered** about the codebase, the domain, or how things
+  actually work — anything the next session would benefit from knowing
+  without rediscovering.
+- **Decisions** the user makes (architectural, technical, product) and the
+  reasoning behind them. Even small ones.
+- **Gotchas, surprises, and tribal knowledge** — anything that took more
+  than a moment to figure out, anything the user said in passing that's
+  worth not losing.
+- **Answers** you and the user worked out together that would be useful
+  next time the same question comes up.
+- **References** the user shared (URLs, file paths, screenshots, pasted
+  threads) — anchor them in a node so they don't disappear into chat history.
+
+How to capture:
+
+- You do not need permission to capture. You may capture without asking.
+  Mention what you're capturing in passing if it's substantive — do not gate
+  the capture on a yes/no from the user.
+- Use \`ctx add nodes/<slug> --type document --title "<title>" --tags
+  "<tags>"\` to create. Write the body with the Write tool. Keep nodes tight —
+  100-300 words is usually plenty.
+- Show what you wrote only if asked, or if the content is ambiguous and
+  the user should review.
+- Every change is hash-chained and versioned silently. The user can inspect
+  or revert later. There is no cost to capturing too much; there is real
+  cost to capturing too little.
+`;
+
 export interface AgentConfigInput {
   config: NestConfig | null;
   contextYaml: ContextYaml;
@@ -100,6 +146,11 @@ function buildCoreInstructions(input: AgentConfigInput): string {
   lines.push('ctx query "#tag" --hops 3        # Deeper graph traversal');
   lines.push('ctx query "#tag" --full           # Load everything (large vaults)');
   lines.push("```");
+  lines.push("");
+
+  // Maintenance directive — read from config, fall back to default
+  const directive = config?.agent_maintenance_directive ?? DEFAULT_MAINTENANCE_DIRECTIVE;
+  lines.push(directive.trim());
   lines.push("");
 
   // Key documents (hubs)

--- a/packages/engine/src/schemas.ts
+++ b/packages/engine/src/schemas.ts
@@ -144,6 +144,7 @@ export const nestConfigSchema = z.object({
       auto_index: z.boolean().optional(),
     })
     .optional(),
+  agent_maintenance_directive: z.string().optional(),
 });
 
 export const packSchema = z.object({

--- a/packages/engine/src/types.ts
+++ b/packages/engine/src/types.ts
@@ -213,6 +213,16 @@ export interface NestConfig {
     promptowl_data_room_id?: string;
     auto_index?: boolean;
   };
+  /**
+   * Agent maintenance directive — emitted into the managed section of
+   * CLAUDE.md / GEMINI.md / .cursorrules / .windsurfrules /
+   * .github/copilot-instructions.md by `ctx index`. Tells the agent
+   * working with this vault that it's responsible for keeping the nest
+   * useful (capturing new information, decisions, gotchas) without
+   * waiting to be asked. Set per-starter at init time. If absent at
+   * index time, a sensible default is used.
+   */
+  agent_maintenance_directive?: string;
 }
 
 /** Trace entry for document access (§9.2) */


### PR DESCRIPTION
## Summary

Adds an aggressive maintenance directive emitted into every generated agent config (CLAUDE.md / GEMINI.md / .cursorrules / .windsurfrules / .github/copilot-instructions.md) so agents capture new information, decisions, gotchas, and learnings as they go — without waiting to be asked. Under-capture was the silent failure mode.

- New optional `NestConfig.agent_maintenance_directive`. Persisted to `.context/config.yaml` at init time. Surfaced via `ctx index` into every agent config.
- Per-starter directive via `Starter.getMaintenanceDirective()`. Developer = codebase-flavored. Personal = ideas/learning-flavored. Other four = shared default.
- Engine fallback for vaults initialized before the field existed.
- Tone: aggressive. "You do not need permission to capture", "multiple nodes per session is normal", "under-capture is the failure mode".

Engine 0.4.0 → 0.4.1 (additive). CLI 0.11.0 → 0.11.1 (consumes new engine field + writes directive at init). Both published to npm.

## Test plan

- [x] 133 tests pass (10 new: 3 engine, 7 cli)
- [x] End-to-end smoke: `ctx init --starter developer` writes directive to `.context/config.yaml`, `ctx index` surfaces it into CLAUDE.md
- [x] `@promptowl/contextnest-engine@0.4.1` published
- [x] `@promptowl/contextnest-cli@0.11.1` published
- [x] Global install upgraded and `ctx --version` reports 0.11.1