### PR TITLE
Hiren f/cu 86ahakd6z/clearing context nest engine

### DIFF
--- a/packages/engine/src/__tests__/engine.test.ts
+++ b/packages/engine/src/__tests__/engine.test.ts
@@ -30,7 +30,7 @@ import {
   generateIndexMd,
   DocumentNotFoundError,
 } from "../index.js";
-import type { ContextNode, Frontmatter } from "../index.js";
+import type { ContextNode } from "../index.js";
 
 const FIXTURES = join(__dirname, "../../../../fixtures/minimal-vault");
 
@@ -819,7 +819,7 @@ describe("NestStorage.deleteDocument", () => {
   let tempStorage: NestStorage;
 
   beforeAll(async () => {
-    const { mkdtemp, rm } = await import("node:fs/promises");
+    const { mkdtemp } = await import("node:fs/promises");
     const { tmpdir } = await import("node:os");
     tempVault = await mkdtemp(join(tmpdir(), "contextnest-delete-test-"));
     tempStorage = new NestStorage(tempVault);

--- a/packages/engine/src/checkpoint.ts
+++ b/packages/engine/src/checkpoint.ts
@@ -11,6 +11,20 @@ import type {
 import { computeCheckpointHash } from "./integrity.js";
 import { NestStorage } from "./storage.js";
 
+/** Latest checkpoint object, or null if history empty/missing. */
+export function getLatestCheckpoint(
+  history: CheckpointHistory | null | undefined,
+): Checkpoint | null {
+  return history?.checkpoints?.at(-1) ?? null;
+}
+
+/** Latest checkpoint number, or 0 if history empty/missing. */
+export function getLatestCheckpointNumber(
+  history: CheckpointHistory | null | undefined,
+): number {
+  return getLatestCheckpoint(history)?.checkpoint ?? 0;
+}
+
 export class CheckpointManager {
   constructor(private storage: NestStorage) {}
 
@@ -27,10 +41,7 @@ export class CheckpointManager {
       checkpoints: [],
     };
 
-    const previousCheckpoint =
-      history.checkpoints.length > 0
-        ? history.checkpoints[history.checkpoints.length - 1]
-        : null;
+    const previousCheckpoint = getLatestCheckpoint(history);
 
     const checkpointNumber = previousCheckpoint
       ? previousCheckpoint.checkpoint + 1

--- a/packages/engine/src/graph-query-engine.ts
+++ b/packages/engine/src/graph-query-engine.ts
@@ -20,10 +20,11 @@ import { PackLoader } from "./packs.js";
 import { ContextInjector } from "./injection.js";
 import { GraphTraverser } from "./graph-traverser.js";
 import { generateContextYaml } from "./index-generator.js";
-import { stripTagPrefix } from "./parser.js";
+import { isPublished } from "./parser.js";
+import { getLatestCheckpoint, getLatestCheckpointNumber } from "./checkpoint.js";
 import { parseSelector } from "./selector/parser.js";
 import { evaluateFromIndex } from "./selector/index-evaluator.js";
-import { topologicalSortSources } from "./source-graph.js";
+import { orderSourceNodesTopologically } from "./source-graph.js";
 import { TraceLogger } from "./tracing.js";
 
 export interface GraphQueryOptions {
@@ -110,7 +111,7 @@ export class GraphQueryEngine {
     const sourceNodes: ContextNode[] = [];
 
     for (const doc of docMap.values()) {
-      if (!options.includeDrafts && doc.frontmatter.status !== "published") {
+      if (!options.includeDrafts && !isPublished(doc)) {
         continue;
       }
       if (doc.frontmatter.type === "source") {
@@ -121,19 +122,11 @@ export class GraphQueryEngine {
     }
 
     // 5. Order source nodes topologically
-    let orderedSourceNodes: ContextNode[] = [];
-    if (sourceNodes.length > 0) {
-      const sortedIds = topologicalSortSources(sourceNodes);
-      const sourceMap = new Map(sourceNodes.map((n) => [n.id, n]));
-      orderedSourceNodes = sortedIds
-        .map((id) => sourceMap.get(id))
-        .filter((n): n is ContextNode => n !== undefined);
-    }
+    const orderedSourceNodes = orderSourceNodesTopologically(sourceNodes);
 
     // 6. Log traces
     const checkpointHistory = await this.storage.readCheckpointHistory();
-    const currentCheckpoint =
-      checkpointHistory?.checkpoints?.at(-1)?.checkpoint ?? 0;
+    const currentCheckpoint = getLatestCheckpointNumber(checkpointHistory);
 
     for (const doc of [...regularDocs, ...orderedSourceNodes]) {
       traceLogger.logAccess({
@@ -164,8 +157,8 @@ export class GraphQueryEngine {
       const docs = await this.storage.discoverDocuments();
       const config = await this.storage.readConfig();
       const checkpointHistory = await this.storage.readCheckpointHistory();
-      const latestCheckpoint = checkpointHistory?.checkpoints?.at(-1) ?? null;
-      const published = docs.filter((d) => d.frontmatter.status === "published");
+      const latestCheckpoint = getLatestCheckpoint(checkpointHistory);
+      const published = docs.filter(isPublished);
 
       const contextYaml = generateContextYaml(published, config, latestCheckpoint);
       await this.storage.writeContextYaml(contextYaml);
@@ -185,8 +178,7 @@ export class GraphQueryEngine {
     const docs = await this.storage.discoverDocuments();
     const packs = await this.storage.readPacks();
     const checkpointHistory = await this.storage.readCheckpointHistory();
-    const currentCheckpoint =
-      checkpointHistory?.checkpoints?.at(-1)?.checkpoint ?? 0;
+    const currentCheckpoint = getLatestCheckpointNumber(checkpointHistory);
 
     const resolver = new Resolver({ documents: docs });
     const packLoader = new PackLoader(packs);

--- a/packages/engine/src/graph-query-engine.ts
+++ b/packages/engine/src/graph-query-engine.ts
@@ -12,7 +12,6 @@ import type {
   ContextNode,
   ContextYaml,
   GraphQueryResult,
-  TraceEntry,
 } from "./types.js";
 import { NestStorage } from "./storage.js";
 import { Resolver } from "./resolver.js";
@@ -69,7 +68,7 @@ export class GraphQueryEngine {
     }
 
     // Full mode: existing behavior
-    return this.fullQuery(selector, options);
+    return this.fullQuery(selector);
   }
 
   private async graphQuery(
@@ -171,10 +170,7 @@ export class GraphQueryEngine {
   }
 
   /** Fallback: full-load mode (existing behavior) */
-  private async fullQuery(
-    selector: string,
-    options: GraphQueryOptions,
-  ): Promise<GraphQueryResult> {
+  private async fullQuery(selector: string): Promise<GraphQueryResult> {
     const docs = await this.storage.discoverDocuments();
     const packs = await this.storage.readPacks();
     const checkpointHistory = await this.storage.readCheckpointHistory();

--- a/packages/engine/src/index-md-generator.ts
+++ b/packages/engine/src/index-md-generator.ts
@@ -4,6 +4,7 @@
  */
 
 import type { ContextNode } from "./types.js";
+import { isPublished } from "./parser.js";
 
 /**
  * Generate an INDEX.md for a folder.
@@ -109,8 +110,8 @@ export function generateIndexMd(
   }
 
   // Statistics
-  const published = documents.filter((d) => d.frontmatter.status === "published").length;
-  const draft = documents.filter((d) => d.frontmatter.status !== "published").length;
+  const published = documents.filter(isPublished).length;
+  const draft = documents.filter((d) => !isPublished(d)).length;
   lines.push("## Statistics");
   lines.push("");
   lines.push(`- Total documents: ${documents.length}`);

--- a/packages/engine/src/injection.ts
+++ b/packages/engine/src/injection.ts
@@ -9,7 +9,7 @@ import { Resolver } from "./resolver.js";
 import { PackLoader } from "./packs.js";
 import { parseSelector } from "./selector/parser.js";
 import { evaluate } from "./selector/evaluator.js";
-import { topologicalSortSources } from "./source-graph.js";
+import { orderSourceNodesTopologically } from "./source-graph.js";
 import { TraceLogger } from "./tracing.js";
 
 export interface InjectorOptions {
@@ -56,16 +56,7 @@ export class ContextInjector {
     }
 
     // Order source nodes topologically for hydration
-    let orderedSourceNodes: ContextNode[];
-    if (sourceNodes.length > 0) {
-      const sortedIds = topologicalSortSources(sourceNodes);
-      const sourceMap = new Map(sourceNodes.map((n) => [n.id, n]));
-      orderedSourceNodes = sortedIds
-        .map((id) => sourceMap.get(id))
-        .filter((n): n is ContextNode => n !== undefined);
-    } else {
-      orderedSourceNodes = [];
-    }
+    const orderedSourceNodes = orderSourceNodesTopologically(sourceNodes);
 
     // Log access traces for all returned documents
     for (const doc of [...regularDocs, ...orderedSourceNodes]) {

--- a/packages/engine/src/injection.ts
+++ b/packages/engine/src/injection.ts
@@ -4,7 +4,7 @@
  * and returns documents with trace entries.
  */
 
-import type { ContextNode, ResolvedResult, Checkpoint } from "./types.js";
+import type { ContextNode, ResolvedResult } from "./types.js";
 import { Resolver } from "./resolver.js";
 import { PackLoader } from "./packs.js";
 import { parseSelector } from "./selector/parser.js";

--- a/packages/engine/src/integrity.ts
+++ b/packages/engine/src/integrity.ts
@@ -3,7 +3,7 @@
  */
 
 import { createHash } from "node:crypto";
-import type { VersionEntry, Checkpoint, VerificationReport, DocumentHistory } from "./types.js";
+import type { Checkpoint, VerificationReport, DocumentHistory } from "./types.js";
 
 const GENESIS_SENTINEL = "contextnest:genesis:v1";
 

--- a/packages/engine/src/parser.ts
+++ b/packages/engine/src/parser.ts
@@ -128,9 +128,7 @@ export function serializeDocument(node: ContextNode): string {
  * Per §1.5: SHA-256 of all content after the closing --- of frontmatter, including the leading newline.
  */
 export function getChecksumContent(rawContent: string): string {
-  const parsed = matter(rawContent);
-  // gray-matter's content is everything after frontmatter
-  // We need to include the leading newline
+  // Everything after closing frontmatter delimiter, including leading newline.
   const fmEnd = rawContent.indexOf("---", rawContent.indexOf("---") + 3);
   if (fmEnd === -1) return rawContent;
   return rawContent.slice(fmEnd + 3);

--- a/packages/engine/src/parser.ts
+++ b/packages/engine/src/parser.ts
@@ -20,6 +20,11 @@ export function stripTagPrefix(tags: string[]): string[] {
   return tags.filter((tag) => typeof tag === "string").map((tag) => (tag.startsWith("#") ? tag.slice(1) : tag));
 }
 
+/** Predicate: document is in `published` status. */
+export function isPublished(node: ContextNode): boolean {
+  return node.frontmatter.status === "published";
+}
+
 /**
  * Parse a Context Nest document from its file content.
  * Returns the parsed ContextNode with validated frontmatter.

--- a/packages/engine/src/publish.ts
+++ b/packages/engine/src/publish.ts
@@ -3,13 +3,12 @@
  * Ties together versioning, integrity, checkpoints, and index regeneration.
  */
 
-import { createHash } from "node:crypto";
 import type { ContextNode, VersionEntry } from "./types.js";
 import { NestStorage } from "./storage.js";
 import { VersionManager } from "./versioning.js";
 import { CheckpointManager } from "./checkpoint.js";
-import { parseDocument, serializeDocument, getChecksumContent } from "./parser.js";
-import { normalizeForHash } from "./integrity.js";
+import { serializeDocument, getChecksumContent, isPublished } from "./parser.js";
+import { computeContentHash } from "./integrity.js";
 
 export interface PublishOptions {
   editedBy: string;
@@ -43,9 +42,7 @@ export async function publishDocument(
 
   // Compute document body checksum
   const serialized = serializeDocument(node);
-  const bodyContent = normalizeForHash(getChecksumContent(serialized));
-  const checksum = createHash("sha256").update(bodyContent, "utf-8").digest("hex");
-  node.frontmatter.checksum = `sha256:${checksum}`;
+  node.frontmatter.checksum = computeContentHash(getChecksumContent(serialized));
 
   // Re-serialize with updated frontmatter
   const finalContent = serializeDocument(node);
@@ -71,9 +68,7 @@ export async function publishDocument(
 
   // Gather all published documents for checkpoint
   const allDocs = await storage.discoverDocuments();
-  const publishedDocs = allDocs.filter(
-    (d) => d.frontmatter.status === "published",
-  );
+  const publishedDocs = allDocs.filter(isPublished);
 
   // Gather all document histories
   const histories = await storage.findAllHistories();

--- a/packages/engine/src/resolver.ts
+++ b/packages/engine/src/resolver.ts
@@ -5,7 +5,8 @@
 import MiniSearch from "minisearch";
 import type { ContextNode, ContextNestUri, Checkpoint } from "./types.js";
 import { extractSection } from "./inline.js";
-import { DocumentNotFoundError, FederationNotSupportedError } from "./errors.js";
+import { stripTagPrefix, isPublished } from "./parser.js";
+import { FederationNotSupportedError } from "./errors.js";
 
 export interface ResolverOptions {
   /** All documents in the vault */
@@ -34,8 +35,7 @@ export class Resolver {
       this.documents.set(doc.id, doc);
 
       // Build tag index
-      for (const tag of doc.frontmatter.tags || []) {
-        const normalized = tag.startsWith("#") ? tag.slice(1) : tag;
+      for (const normalized of stripTagPrefix(doc.frontmatter.tags || [])) {
         if (!this.tagIndex.has(normalized)) {
           this.tagIndex.set(normalized, new Set());
         }
@@ -51,7 +51,7 @@ export class Resolver {
     });
 
     const searchDocs = options.documents
-      .filter((d) => d.frontmatter.status === "published")
+      .filter(isPublished)
       .map((d) => ({
         id: d.id,
         title: d.frontmatter.title,
@@ -103,7 +103,7 @@ export class Resolver {
     const doc = this.documents.get(uri.path);
     if (!doc) return [];
 
-    if (!options.includeDrafts && doc.frontmatter.status !== "published") {
+    if (!options.includeDrafts && !isPublished(doc)) {
       return [];
     }
 
@@ -148,7 +148,7 @@ export class Resolver {
 
     return [...docIds]
       .map((id) => this.documents.get(id)!)
-      .filter((d) => options.includeDrafts || d.frontmatter.status === "published");
+      .filter((d) => options.includeDrafts || isPublished(d));
   }
 
   private resolveFolder(
@@ -160,7 +160,7 @@ export class Resolver {
       .filter(
         (d) =>
           (d.id.startsWith(prefix) || d.id.startsWith(uri.path)) &&
-          (options.includeDrafts || d.frontmatter.status === "published"),
+          (options.includeDrafts || isPublished(d)),
       );
   }
 
@@ -180,9 +180,7 @@ export class Resolver {
 
   /** Get all published documents */
   getPublishedDocuments(): ContextNode[] {
-    return [...this.documents.values()].filter(
-      (d) => d.frontmatter.status === "published",
-    );
+    return [...this.documents.values()].filter(isPublished);
   }
 
   /** Get all documents */

--- a/packages/engine/src/selector/evaluator.ts
+++ b/packages/engine/src/selector/evaluator.ts
@@ -7,6 +7,7 @@ import type { SelectorNode } from "./parser.js";
 import type { ContextNode, Pack } from "../types.js";
 import { parseUri } from "../uri.js";
 import { Resolver } from "../resolver.js";
+import { stripTagPrefix } from "../parser.js";
 
 export interface EvaluatorOptions {
   resolver: Resolver;
@@ -67,9 +68,7 @@ async function evaluateNode(
 function evaluateTag(tag: string, docs: ContextNode[]): Set<string> {
   const result = new Set<string>();
   for (const doc of docs) {
-    const docTags = (doc.frontmatter.tags || []).map((t) =>
-      t.startsWith("#") ? t.slice(1) : t,
-    );
+    const docTags = stripTagPrefix(doc.frontmatter.tags || []);
     if (docTags.includes(tag)) {
       result.add(doc.id);
     }

--- a/packages/engine/src/source-graph.ts
+++ b/packages/engine/src/source-graph.ts
@@ -67,6 +67,22 @@ export function topologicalSortSources(
 }
 
 /**
+ * Order source nodes by topological sort, returning the actual ContextNodes.
+ * Empty input → empty output. Wraps `topologicalSortSources` so callers do not
+ * have to rebuild the id-to-node map themselves.
+ */
+export function orderSourceNodesTopologically(
+  sources: ContextNode[],
+): ContextNode[] {
+  if (sources.length === 0) return [];
+  const sortedIds = topologicalSortSources(sources);
+  const sourceMap = new Map(sources.map((n) => [n.id, n]));
+  return sortedIds
+    .map((id) => sourceMap.get(id))
+    .filter((n): n is ContextNode => n !== undefined);
+}
+
+/**
  * Detect cycles in the dependency graph.
  * Returns the first cycle found as an array of node IDs, or null if acyclic.
  */

--- a/packages/engine/src/storage.ts
+++ b/packages/engine/src/storage.ts
@@ -3,8 +3,8 @@
  * Supports both structured and Obsidian-compatible layouts (§1.1).
  */
 
-import { readFile, writeFile, mkdir, stat, readdir, unlink, rm } from "node:fs/promises";
-import { join, relative, extname, dirname, basename } from "node:path";
+import { readFile, writeFile, mkdir, stat, unlink, rm } from "node:fs/promises";
+import { join, dirname, basename } from "node:path";
 import fg from "fast-glob";
 import yaml from "js-yaml";
 import { parseDocument } from "./parser.js";
@@ -17,7 +17,7 @@ import type {
   Pack,
   ContextYaml,
 } from "./types.js";
-import { DocumentNotFoundError, ConfigError } from "./errors.js";
+import { DocumentNotFoundError } from "./errors.js";
 import { packSchema, documentHistorySchema, checkpointHistorySchema } from "./schemas.js";
 
 export type LayoutMode = "structured" | "obsidian";


### PR DESCRIPTION
## Summary

Internal refactor of `@promptowl/contextnest-engine`. Consolidates repeated logic into shared helpers and drops dead imports. No public API change, no behavior change.

## What Changed

**Duplication → helpers** (all internal, not exported):
- `isPublished(node)` — replaces 9 inline `frontmatter.status === "published"` checks.
- `getLatestCheckpoint` / `getLatestCheckpointNumber` — replace 4 hand-rolled `checkpoints?.at(-1)` accesses (including one using `.length - 1`).
- `orderSourceNodesTopologically(sources)` — replaces 2 identical topo-sort + id-map blocks.
- Reuse existing `stripTagPrefix()` and `computeContentHash()` at sites that had reimplemented them inline.

**Dead code removed:**
- Unused type/module imports across `graph-query-engine`, `injection`, `integrity`, `storage`, and tests.
- Unused `parsed` local in `parser.ts:getChecksumContent`.
- Unused `options` param on private `fullQuery`.

Exports flagged as "only used by tests" were kept to avoid breaking existing npm consumers.

## Impact

- **Public API:** unchanged. No SemVer bump.
- **Behavior:** unchanged. SHA-256 chain continuity verified via `ctx verify` on a real vault after multiple post-refactor publishes.
- **Tests:** 133/133 pass across all packages. End-to-end CLI flow validated.
- **Codebase:** ~37 duplicated lines removed; 8 unused symbols dropped.
- **Risk:** low — internal only, no schema or integrity changes.
