### PR TITLE
Polish engine README (agentic discovery)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **A structured second brain for your AI agents. Start solo, scale safely.**
 
-**by [PromptOwl](https://promptowl.ai)** | [Website](https://promptowl.ai) | [Whitepaper](https://promptowl.ai/resources/contextnest-whitepaper/) | [Specification](https://github.com/PromptOwl/ContextNest-spec) | [Discord](https://discord.gg/fxcSQ5gq)
+**by [PromptOwl](https://promptowl.ai)** | [Website](https://promptowl.ai) | [Whitepaper](https://promptowl.ai/resources/contextnest-whitepaper/) | [Specification](https://github.com/PromptOwl/context-nest-spec) | [Discord](https://discord.gg/fxcSQ5gq)
 
 Context Nest turns scattered knowledge — your repos, docs, Slack threads, tribal know-how — into a structured, queryable brain your AI agents can use.
 
@@ -82,9 +82,9 @@ After `ctx init`, the CLI prints a starter-specific instruction block to stdout.
 
 | Package | Description | License |
 |---|---|---|
-| [`@promptowl/contextnest-cli`](https://www.npmjs.com/package/@promptowl/contextnest-cli) | Command-line tool (`ctx`) | AGPL-3.0 |
-| [`@promptowl/contextnest-engine`](https://www.npmjs.com/package/@promptowl/contextnest-engine) | Core library — parsing, storage, versioning, integrity | AGPL-3.0 |
-| [`@promptowl/contextnest-mcp-server`](https://www.npmjs.com/package/@promptowl/contextnest-mcp-server) | MCP server for AI agent access | AGPL-3.0 |
+| [@promptowl/contextnest-cli](https://www.npmjs.com/package/@promptowl/contextnest-cli) | Command-line tool (`ctx`) | AGPL-3.0 |
+| [@promptowl/contextnest-engine](https://www.npmjs.com/package/@promptowl/contextnest-engine) | Core library — parsing, storage, versioning, integrity | AGPL-3.0 |
+| [@promptowl/contextnest-mcp-server](https://www.npmjs.com/package/@promptowl/contextnest-mcp-server) | MCP server for AI agent access | AGPL-3.0 |
 
 ## Prerequisites
 
@@ -379,7 +379,7 @@ ctx query "#api + status:published"       # Intersection
 
 ## MCP Server
 
-The MCP server exposes vault operations as tools for AI agents over stdio transport.
+The MCP server exposes vault operations as 19 tools for AI agents over stdio transport.
 
 ### Running the server
 
@@ -450,6 +450,15 @@ Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_
 | `delete_document` | Delete a document and its version history |
 | `publish_document` | Explicitly publish a document (bump version, create checkpoint) |
 
+**Drift governance tools** (resolve out-of-band edits without touching the canonical doc or hash chain until approved):
+
+| Tool | Description |
+|---|---|
+| `stage_drift_suggestion` | Capture a drifted live file as a staged suggestion under `_suggestions/` |
+| `list_suggestions` | List all staged suggestions for a document |
+| `approve_suggestion` | Apply a suggestion: patch, bump version, write new canonical bytes, archive |
+| `reject_suggestion` | Reject a suggestion: archive with required reason, emit a chain event |
+
 ---
 
 ## Development
@@ -480,9 +489,9 @@ ctx verify                         # 8. Verify integrity
 
 All packages are licensed under **AGPL-3.0**:
 
-- **CLI** ([`@promptowl/contextnest-cli`](https://www.npmjs.com/package/@promptowl/contextnest-cli)): **AGPL-3.0**
-- **Engine** ([`@promptowl/contextnest-engine`](https://www.npmjs.com/package/@promptowl/contextnest-engine)): **AGPL-3.0**
-- **MCP Server** ([`@promptowl/contextnest-mcp-server`](https://www.npmjs.com/package/@promptowl/contextnest-mcp-server)): **AGPL-3.0**
+- **CLI** ([@promptowl/contextnest-cli](https://www.npmjs.com/package/@promptowl/contextnest-cli)): **AGPL-3.0**
+- **Engine** ([@promptowl/contextnest-engine](https://www.npmjs.com/package/@promptowl/contextnest-engine)): **AGPL-3.0**
+- **MCP Server** ([@promptowl/contextnest-mcp-server](https://www.npmjs.com/package/@promptowl/contextnest-mcp-server)): **AGPL-3.0**
 - **Specification** ([CONTEXT_NEST_SPEC.md](CONTEXT_NEST_SPEC.md)): **Apache-2.0** — open standard
 
 AGPL-3.0 ensures all improvements stay open source. You are free to use, modify, and distribute Context Nest, but modifications to the source must be shared under the same license. Commercial licensing is available from [PromptOwl](https://promptowl.ai) for organizations that need to embed or redistribute without AGPL obligations.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -4,6 +4,10 @@
 
 **by [PromptOwl](https://promptowl.ai)** | [Website](https://promptowl.ai) | [Whitepaper](https://promptowl.ai/resources/contextnest-whitepaper/) | [Specification](https://github.com/PromptOwl/context-nest-spec) | [Discord](https://discord.gg/fxcSQ5gq)
 
+[![npm](https://img.shields.io/npm/v/@promptowl/contextnest-cli.svg)](https://www.npmjs.com/package/@promptowl/contextnest-cli)
+[![License: AGPL-3.0](https://img.shields.io/badge/license-AGPL--3.0-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
+[![SOC 2 Type 2](https://img.shields.io/badge/SOC%202-Type%202-green.svg)](https://promptowl.ai)
+
 Command-line tool for [Context Nest](https://github.com/PromptOwl/ContextNest) — turn scattered knowledge into a structured, queryable brain your AI agents can use. Same instinct as the Obsidian-brain pattern, but with typed graph structure, ~100× cheaper queries (~500 tokens vs 50k), a sharing path, and governed change history when you need it.
 
 ## Install
@@ -158,8 +162,8 @@ See [@promptowl/contextnest-mcp-server](https://www.npmjs.com/package/@promptowl
 
 | Package | Description |
 |---------|-------------|
-| [`@promptowl/contextnest-engine`](https://www.npmjs.com/package/@promptowl/contextnest-engine) | Core library — parsing, storage, versioning, graph traversal |
-| [`@promptowl/contextnest-mcp-server`](https://www.npmjs.com/package/@promptowl/contextnest-mcp-server) | MCP server for AI agent access |
+| [@promptowl/contextnest-engine](https://www.npmjs.com/package/@promptowl/contextnest-engine) | Core library — parsing, storage, versioning, graph traversal |
+| [@promptowl/contextnest-mcp-server](https://www.npmjs.com/package/@promptowl/contextnest-mcp-server) | MCP server for AI agent access |
 
 ## Links
 

--- a/packages/engine/README.md
+++ b/packages/engine/README.md
@@ -1,6 +1,12 @@
 # @promptowl/contextnest-engine
 
-Core engine for [Context Nest](https://github.com/PromptOwl/ContextNest) — structured, versioned context vaults for AI agents.
+The governed, versioned context engine for AI agents — **not a memory store.**
+
+[![npm](https://img.shields.io/npm/v/@promptowl/contextnest-engine.svg)](https://www.npmjs.com/package/@promptowl/contextnest-engine)
+[![License: AGPL-3.0](https://img.shields.io/badge/license-AGPL--3.0-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
+[![SOC 2 Type 2](https://img.shields.io/badge/SOC%202-Type%202-green.svg)](https://promptowl.ai)
+
+The core engine behind [Context Nest](https://github.com/PromptOwl/ContextNest). It turns a folder of markdown into a typed, queryable document graph where every change is hash-chained and auditable. Where a memory store appends opaque blobs and hopes for recall, this engine gives agents a deterministic query grammar, graph traversal, and a byte-level audit trail — the same vault onboards one developer in ten minutes and passes a SOC 2 review when that day comes.
 
 ## Install
 
@@ -8,22 +14,7 @@ Core engine for [Context Nest](https://github.com/PromptOwl/ContextNest) — str
 npm install @promptowl/contextnest-engine
 ```
 
-## What It Does
-
-The engine provides the core building blocks for Context Nest vaults:
-
-- **Storage** — Read/write documents, version histories, checkpoints, and config from the vault file system
-- **Parsing & Validation** — Parse markdown documents with YAML frontmatter, validate against the spec (including skill and source node rules)
-- **Selector Grammar** — Deterministic query language for selecting documents by tag, type, URI, pack, and boolean combinations
-- **Skill Nodes** — First-class support for `type: skill` nodes with trigger, inputs, tools_required, output_format, and guard_rails
-- **Graph Traversal** — Hop-based BFS traversal using `context.yaml` as a lightweight graph index, with priority-weighted edges
-- **URI Resolution** — Resolve `contextnest://` URIs to documents, tags, folders, or search results
-- **Versioning** — Hash-chained version history with keyframe + diff reconstruction
-- **Integrity** — SHA-256 content hashes, chain hashes, and checkpoint verification
-- **Index Generation** — Generate `context.yaml` (document graph) and `INDEX.md` files
-- **Agent Config Generation** — Auto-generate CLAUDE.md, GEMINI.md, .cursorrules, etc. so AI tools discover the vault
-
-## Quick Example
+## Quickstart
 
 ```typescript
 import { NestStorage, GraphQueryEngine } from "@promptowl/contextnest-engine";
@@ -31,16 +22,67 @@ import { NestStorage, GraphQueryEngine } from "@promptowl/contextnest-engine";
 const storage = new NestStorage("/path/to/vault");
 const engine = new GraphQueryEngine(storage);
 
-// Query with graph traversal (default: 2 hops)
-const result = await engine.query('#engineering + type:document', { hops: 3 });
-
-// Query skill nodes
-const skills = await engine.query('type:skill + #engineering', { hops: 2 });
+// Deterministic selector + graph traversal (default: 2 hops).
+// Selectors match document metadata first — no file bodies loaded —
+// then BFS over relationship edges, loading bodies only for reached nodes.
+const result = await engine.query("#engineering + type:document", { hops: 3 });
 
 for (const doc of result.documents) {
   console.log(`${doc.id}: ${doc.frontmatter.title}`);
 }
 ```
+
+## Worked Example
+
+Read a vault, query its engineering skills, then verify the whole vault's integrity.
+
+```typescript
+import {
+  NestStorage,
+  GraphQueryEngine,
+  CheckpointManager,
+} from "@promptowl/contextnest-engine";
+
+const storage = new NestStorage("./my-vault");
+const engine = new GraphQueryEngine(storage);
+
+// 1. Pull every skill node tagged #engineering, 2 hops of related context.
+const skills = await engine.query("type:skill + #engineering", { hops: 2 });
+console.log(`Found ${skills.documents.length} engineering skills`);
+
+for (const skill of skills.documents) {
+  const { title } = skill.frontmatter;
+  const trigger = skill.frontmatter.skill?.trigger ?? "(no trigger)";
+  console.log(`- ${title} — triggers ${trigger}`);
+}
+
+// 2. Verify the hash chain across the entire vault before trusting it.
+const checkpoints = new CheckpointManager(storage);
+const report = await checkpoints.verify();
+console.log(report.valid ? "Integrity OK" : `Tampering: ${report.errors}`);
+```
+
+## What It Does
+
+- **Selector Grammar** — Deterministic query language: select by tag, type, URI, pack, status, and boolean combinations (`type:skill + #engineering`)
+- **Graph Traversal** — Hop-based BFS over `context.yaml` as a lightweight graph index, with priority-weighted edges
+- **Skill Nodes** — First-class `type: skill` nodes with trigger, inputs, tools_required, output_format, and guard_rails
+- **Versioning** — Hash-chained version history with keyframe + diff reconstruction
+- **Integrity** — SHA-256 content hashes, chain hashes, and checkpoint verification down to the byte
+- **URI Resolution** — Resolve `contextnest://` URIs to documents, tags, folders, or search results
+- **Storage** — Read/write documents, version histories, checkpoints, and config from the vault file system
+- **Parsing & Validation** — Markdown + YAML frontmatter, validated against the spec (skill and source node rules)
+- **Index Generation** — Generate `context.yaml` (document graph) and `INDEX.md`
+- **Agent Config Generation** — Auto-generate CLAUDE.md, GEMINI.md, .cursorrules, etc. so AI tools discover the vault
+
+## Graph Traversal
+
+The engine evaluates selectors against document metadata (no bodies loaded), then traverses relationship edges via BFS for N hops, loading bodies only for reached nodes.
+
+- `depends_on` edges and edges to hub nodes are free (always traversed)
+- `reference` edges cost 1 hop
+- Edges with explicit `priority: 0` in frontmatter are free
+- Adaptive expansion retries with more hops if too few results
 
 ## Key Exports
 
@@ -49,32 +91,34 @@ for (const doc of result.documents) {
 | `NestStorage` | File system abstraction for vault operations |
 | `GraphQueryEngine` | Graph-aware query orchestrator (recommended) |
 | `GraphTraverser` | BFS traversal with priority-weighted edge costs |
-| `Resolver` | URI resolution against in-memory document set |
+| `Resolver` | URI resolution against an in-memory document set |
 | `ContextInjector` | Legacy full-load query orchestrator |
 | `VersionManager` | Document version history management |
 | `CheckpointManager` | Vault-wide checkpoint management |
 | `generateContextYaml` | Generate the `context.yaml` graph index |
 | `generateAgentConfigs` | Generate AI tool config files |
 | `parseSelector` | Parse selector query strings into AST |
-| `evaluateFromIndex` | Evaluate selectors against lightweight index (no bodies) |
+| `evaluateFromIndex` | Evaluate selectors against the lightweight index (no bodies) |
 | `publishDocument` | Publish a document (bump version, checkpoint) |
 
-## Graph Traversal
+## Part of Context Nest
 
-The engine uses `context.yaml` as a pre-built graph index. Queries evaluate selectors against document metadata (no file bodies loaded), then traverse relationship edges via BFS for N hops, and only load bodies for reached nodes.
+The engine is the library layer. Most users reach it through one of these:
 
-- `depends_on` edges and edges to hub nodes are free (always traversed)
-- `reference` edges cost 1 hop
-- Edges with explicit `priority: 0` in frontmatter metadata are free
-- Adaptive expansion retries with more hops if too few results
+| Surface | What it is |
+|---|---|
+| [@promptowl/contextnest-cli](https://www.npmjs.com/package/@promptowl/contextnest-cli) | The `ctx` command — `ctx init`, `ctx query`, `ctx verify` |
+| [@promptowl/contextnest-mcp-server](https://www.npmjs.com/package/@promptowl/contextnest-mcp-server) | MCP server exposing 19 vault tools to Claude, Cursor, Gemini, and Copilot |
+| [Claude integration](https://github.com/PromptOwl/ContextNest#mcp-server) | Drop-in MCP config for Claude Code and Claude Desktop |
 
 ## Links
 
 - [Context Nest repo](https://github.com/PromptOwl/ContextNest)
 - [Specification](https://github.com/PromptOwl/context-nest-spec)
+- [Whitepaper](https://promptowl.ai/resources/contextnest-whitepaper/)
 - [PromptOwl](https://promptowl.ai)
 - [Discord](https://discord.gg/fxcSQ5gq)
 
 ## License
 
-AGPL-3.0
+AGPL-3.0. Commercial licensing available from [PromptOwl](https://promptowl.ai) for embedding without AGPL obligations.

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -1,6 +1,10 @@
 # @promptowl/contextnest-mcp-server
 
-MCP server for [Context Nest](https://github.com/PromptOwl/ContextNest) — gives AI agents direct access to your context vault via the [Model Context Protocol](https://modelcontextprotocol.io). Supports all node types including documents, source nodes, and skill nodes.
+[![npm](https://img.shields.io/npm/v/@promptowl/contextnest-mcp-server.svg)](https://www.npmjs.com/package/@promptowl/contextnest-mcp-server)
+[![License: AGPL-3.0](https://img.shields.io/badge/license-AGPL--3.0-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
+[![SOC 2 Type 2](https://img.shields.io/badge/SOC%202-Type%202-green.svg)](https://promptowl.ai)
+
+MCP server for [Context Nest](https://github.com/PromptOwl/ContextNest) — gives AI agents direct access to your context vault via the [Model Context Protocol](https://modelcontextprotocol.io). Supports all node types including documents, source nodes, and skill nodes. Exposes **19 tools** over stdio transport.
 
 ## Install
 
@@ -68,6 +72,19 @@ CONTEXTNEST_VAULT_PATH=/path/to/vault contextnest-mcp
 | `read_version` | Reconstruct a specific version of a document |
 | `verify_integrity` | Verify all hash chains in the vault |
 | `list_checkpoints` | List recent checkpoints |
+
+### Drift Governance
+
+When a live file drifts from its last-approved bytes, these tools capture and resolve the change without touching the canonical document or hash chain until approved:
+
+| Tool | Description |
+|------|-------------|
+| `stage_drift_suggestion` | Capture an out-of-band edit as a staged suggestion under `_suggestions/` (does not modify canonical doc or chain) |
+| `list_suggestions` | List all staged suggestions for a document |
+| `approve_suggestion` | Apply a staged suggestion: patch, bump version, write new canonical bytes, archive under `_archive/approved/` |
+| `reject_suggestion` | Reject a staged suggestion: archive under `_archive/rejected/`, emit a chain event (reason required for audit trail) |
+
+Typical flow: `verify_integrity` detects drift → `stage_drift_suggestion` → `list_suggestions` → `approve_suggestion` or `reject_suggestion`.
 
 ### Graph Traversal
 


### PR DESCRIPTION
## Summary

Docs-only. Refresh all 4 READMEs to match current package surface. Fix broken package links. No code change.

## What Changed

- **Root README** — MCP tools 15 → **19**. Add Drift Governance group (`stage_drift_suggestion`, `list_suggestions`, `approve_suggestion`, `reject_suggestion`). Fix backtick-in-link labels → full `@promptowl/...` clickable links.
- **engine README** — Rewrite as storefront: value prop, badges (npm · AGPL-3.0 · SOC 2 Type 2), install + quickstart, worked example, package links.
- **cli README** — Add badges. Fix broken package links.
- **mcp-server README** — Add badges. Tools 15 → **19** + Drift Governance section.

## Impact

- Docs match real 19 MCP tools (drift governance was undocumented).
- Links render + carry exact name `@promptowl/contextnest-*`.
- No code/dep/version change — safe merge, no release.
