### PR TITLE
fix: update package description and keywords

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -2,15 +2,16 @@
   "name": "@promptowl/contextnest-cli",
   "version": "0.11.1",
   "repository": { "type": "git", "url": "https://github.com/PromptOwl/ContextNest.git", "directory": "packages/cli" },
-  "description": "CLI for structured AI agent knowledge bases — versioned documents, deterministic queries, integrity verification, and MCP integration",
+  "description": "CLI for governed, versioned, AI-ready context — versioned documents, deterministic queries, integrity verification, and MCP integration for AI agents",
   "homepage": "https://github.com/PromptOwl/ContextNest",
   "author": "PromptOwl <hello@promptowl.ai> (https://promptowl.ai)",
   "bugs": { "url": "https://github.com/PromptOwl/ContextNest/issues" },
   "keywords": [
-    "ai", "llm", "context", "knowledge-base", "mcp",
-    "rag", "ai-agents", "versioning", "claude",
-    "cursor", "windsurf", "copilot", "gemini",
-    "context-management", "markdown"
+    "context", "governance", "mcp", "agents", "rag",
+    "ai", "llm", "knowledge-base", "versioning",
+    "claude", "cursor", "windsurf", "copilot",
+    "gemini", "markdown",
+    "contextnest", "context-engineering", "ai-context"
   ],
   "type": "module",
   "bin": {

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -2,15 +2,16 @@
   "name": "@promptowl/contextnest-engine",
   "version": "0.4.1",
   "repository": { "type": "git", "url": "https://github.com/PromptOwl/ContextNest.git", "directory": "packages/engine" },
-  "description": "Core engine for AI agent knowledge bases — selectors, versioning, graph traversal, integrity verification, and context management for LLMs",
+  "description": "Core engine for governed, versioned, AI-ready context — selectors, hash-chain versioning, graph traversal, and integrity verification for LLMs and agents",
   "homepage": "https://github.com/PromptOwl/ContextNest",
   "author": "PromptOwl <hello@promptowl.ai> (https://promptowl.ai)",
   "bugs": { "url": "https://github.com/PromptOwl/ContextNest/issues" },
   "keywords": [
-    "ai", "llm", "context", "knowledge-base",
-    "versioning", "hash-chain", "integrity",
-    "selector", "graph-traversal", "markdown",
-    "ai-agents", "context-management"
+    "context", "governance", "mcp", "agents", "rag",
+    "ai", "llm", "knowledge-base", "versioning",
+    "hash-chain", "integrity", "selector",
+    "graph-traversal", "markdown",
+    "contextnest", "context-engineering", "ai-context"
   ],
   "type": "module",
   "main": "dist/index.js",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -2,15 +2,16 @@
   "name": "@promptowl/contextnest-mcp-server",
   "version": "0.2.10",
   "repository": { "type": "git", "url": "https://github.com/PromptOwl/ContextNest.git", "directory": "packages/mcp-server" },
-  "description": "MCP server for AI agent access to structured knowledge bases — works with Claude, Cursor, Gemini, Copilot, and Windsurf",
+  "description": "MCP server for governed, versioned, AI-ready context — gives Claude, Cursor, Gemini, Copilot, and Windsurf access to structured knowledge bases",
   "homepage": "https://github.com/PromptOwl/ContextNest",
   "author": "PromptOwl <hello@promptowl.ai> (https://promptowl.ai)",
   "bugs": { "url": "https://github.com/PromptOwl/ContextNest/issues" },
   "keywords": [
-    "mcp", "model-context-protocol", "ai-agents",
-    "claude", "claude-code", "cursor", "gemini",
-    "knowledge-base", "context", "llm",
-    "mcp-server", "ai-tools"
+    "context", "governance", "mcp", "agents", "rag",
+    "model-context-protocol", "mcp-server", "claude",
+    "claude-code", "cursor", "gemini", "windsurf",
+    "copilot", "knowledge-base", "llm",
+    "contextnest", "context-engineering", "ai-context"
   ],
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

Align npm metadata across all three published packages (`engine`, `cli`, `mcp-server`) to one message: **governed, versioned, AI-ready context**. Sharpens npm-page first impression and improves keyword discoverability.

## What I changed

**Descriptions** — unified core tagline, package role kept:

- `engine` → "Core engine for governed, versioned, AI-ready context — selectors, hash-chain versioning, graph traversal, and integrity verification for LLMs and agents"
- `cli` → "CLI for governed, versioned, AI-ready context — versioned documents, deterministic queries, integrity verification, and MCP integration for AI agents"
- `mcp-server` → "MCP server for governed, versioned, AI-ready context — gives Claude, Cursor, Gemini, Copilot, and Windsurf access to structured knowledge bases"

**Keywords** — shared lead set in every package: `context`, `governance`, `mcp`, `agents`, `rag`. Plus 3 common discovery terms across all three: `contextnest` (brand), `context-engineering`, `ai-context`. Package-specific terms retained.

Metadata only — no code, function, or behavior change.

## Impact

- Consistent positioning across npm pages.
- Better search hits via shared core + cross-package keywords.
- Zero runtime/build impact; no version bump needed unless republishing.
