### PR TITLE
Polish CLI + mcp-server READMEs (agentic discovery)

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -2,6 +2,8 @@
 
 **A structured second brain for your AI agents. Start solo, scale safely.**
 
+**Governed context, not memory** — typed, versioned, hash-chained.
+
 **by [PromptOwl](https://promptowl.ai)** | [Website](https://promptowl.ai) | [Whitepaper](https://promptowl.ai/resources/contextnest-whitepaper/) | [Specification](https://github.com/PromptOwl/context-nest-spec) | [Discord](https://discord.gg/fxcSQ5gq)
 
 [![npm](https://img.shields.io/npm/v/@promptowl/contextnest-cli.svg)](https://www.npmjs.com/package/@promptowl/contextnest-cli)
@@ -115,6 +117,12 @@ Edge priorities:
 
 ## Selectors
 
+Grammar, one line:
+
+```
+#tag  type:X  status:X  pack:id  contextnest://path   ·   combine with + (AND)  | (OR)  - (NOT)  ( ) to group
+```
+
 ```bash
 ctx query "#engineering"                   # All docs with a tag
 ctx query "type:document"                  # All docs of a type
@@ -150,20 +158,28 @@ Your hand-written content in these files is preserved — only the Context Nest 
 
 ## MCP Server
 
-For direct AI agent access via the Model Context Protocol:
+For direct AI agent access via the Model Context Protocol — **19 tools** over stdio (resolve, search, read/create/update/publish documents, drift governance, integrity verification, and more):
 
 ```bash
+# Run it directly, no install
+npx -y @promptowl/contextnest-mcp-server /path/to/your/vault
+
+# Or install globally
 npm install -g @promptowl/contextnest-mcp-server
 ```
 
-See [@promptowl/contextnest-mcp-server](https://www.npmjs.com/package/@promptowl/contextnest-mcp-server) for setup instructions.
+See [@promptowl/contextnest-mcp-server](https://www.npmjs.com/package/@promptowl/contextnest-mcp-server) for the full tool list and client setup (Claude Desktop, Claude Code, Cursor, Gemini CLI, Windsurf).
 
-## Related Packages
+## Ecosystem
 
-| Package | Description |
-|---------|-------------|
-| [@promptowl/contextnest-engine](https://www.npmjs.com/package/@promptowl/contextnest-engine) | Core library — parsing, storage, versioning, graph traversal |
-| [@promptowl/contextnest-mcp-server](https://www.npmjs.com/package/@promptowl/contextnest-mcp-server) | MCP server for AI agent access |
+Four ways into the same vault — same file format, same governed history:
+
+| | What it is | Get it |
+|---|---|---|
+| **CLI** (`ctx`) | Build and query the vault from the terminal (this package) | [@promptowl/contextnest-cli](https://www.npmjs.com/package/@promptowl/contextnest-cli) |
+| **MCP server** | Agent access over the Model Context Protocol — 19 tools | [@promptowl/contextnest-mcp-server](https://www.npmjs.com/package/@promptowl/contextnest-mcp-server) |
+| **Engine** | Core library — parsing, storage, versioning, graph traversal | [@promptowl/contextnest-engine](https://www.npmjs.com/package/@promptowl/contextnest-engine) |
+| **PromptOwl cloud** | Hosted packs, marketplace, SSO, approvals, role-scoped publishing | [promptowl.ai](https://promptowl.ai) |
 
 ## Links
 

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -1,12 +1,24 @@
 # @promptowl/contextnest-mcp-server
 
+**Governed context for your AI agents — not memory.**
+
+**by [PromptOwl](https://promptowl.ai)** | [Website](https://promptowl.ai) | [Whitepaper](https://promptowl.ai/resources/contextnest-whitepaper/) | [Specification](https://github.com/PromptOwl/context-nest-spec) | [Discord](https://discord.gg/fxcSQ5gq)
+
 [![npm](https://img.shields.io/npm/v/@promptowl/contextnest-mcp-server.svg)](https://www.npmjs.com/package/@promptowl/contextnest-mcp-server)
 [![License: AGPL-3.0](https://img.shields.io/badge/license-AGPL--3.0-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
 [![SOC 2 Type 2](https://img.shields.io/badge/SOC%202-Type%202-green.svg)](https://promptowl.ai)
 
-MCP server for [Context Nest](https://github.com/PromptOwl/ContextNest) — gives AI agents direct access to your context vault via the [Model Context Protocol](https://modelcontextprotocol.io). Supports all node types including documents, source nodes, and skill nodes. Exposes **19 tools** over stdio transport.
+MCP server for [Context Nest](https://github.com/PromptOwl/ContextNest) — gives AI agents direct access to your context vault via the [Model Context Protocol](https://modelcontextprotocol.io). Every node is typed, versioned, and hash-chained, so what the agent reads is **governed and auditable, not a fuzzy memory blob**. Supports all node types — documents, source nodes, and skill nodes. Exposes **19 tools** over stdio transport.
 
 ## Install
+
+Run it directly, no install:
+
+```bash
+npx -y @promptowl/contextnest-mcp-server /path/to/your/vault
+```
+
+Or install globally:
 
 ```bash
 npm install -g @promptowl/contextnest-mcp-server
@@ -86,6 +98,16 @@ When a live file drifts from its last-approved bytes, these tools capture and re
 
 Typical flow: `verify_integrity` detects drift → `stage_drift_suggestion` → `list_suggestions` → `approve_suggestion` or `reject_suggestion`.
 
+### Selector Grammar
+
+The `resolve` tool takes a selector. One-liner:
+
+```
+#tag  type:X  status:X  pack:id  contextnest://path   ·   combine with + (AND)  | (OR)  - (NOT)  ( ) to group
+```
+
+Example: `resolve({ selector: "(#api | #auth) + status:published - #deprecated" })`. Full grammar in the [specification](https://github.com/PromptOwl/context-nest-spec).
+
 ### Graph Traversal
 
 The `resolve`, `search`, and `read_pack` tools support graph-aware queries:
@@ -103,13 +125,27 @@ list_documents({ type: "skill" })                    → all skill nodes
 create_document({ type: "skill", trigger: "..." })   → create a new skill
 ```
 
+## Ecosystem
+
+The MCP server is one of four ways into the same vault — same file format, same governed history:
+
+| | What it is | Get it |
+|---|---|---|
+| **CLI** (`ctx`) | Build and query the vault from the terminal | [`@promptowl/contextnest-cli`](https://www.npmjs.com/package/@promptowl/contextnest-cli) |
+| **MCP server** | Agent access over the Model Context Protocol (this package) | [`@promptowl/contextnest-mcp-server`](https://www.npmjs.com/package/@promptowl/contextnest-mcp-server) |
+| **Engine** | Core library — parsing, storage, versioning, graph traversal | [`@promptowl/contextnest-engine`](https://www.npmjs.com/package/@promptowl/contextnest-engine) |
+| **PromptOwl cloud** | Hosted packs, marketplace, SSO, approvals, role-scoped publishing | [promptowl.ai](https://promptowl.ai) |
+
+Drop the server into any MCP-capable agent — Claude Desktop, Claude Code, Cursor, Gemini CLI, Windsurf — to plug the same vault into your IDE or chat client.
+
 ## Links
 
 - [Context Nest repo](https://github.com/PromptOwl/ContextNest)
 - [Specification](https://github.com/PromptOwl/context-nest-spec)
+- [Whitepaper](https://promptowl.ai/resources/contextnest-whitepaper/)
 - [PromptOwl](https://promptowl.ai)
 - [Discord](https://discord.gg/fxcSQ5gq)
 
 ## License
 
-AGPL-3.0
+AGPL-3.0 — your files, your agent, your vault. No vendor lock-in. Commercial licensing available when you want to embed; contact [PromptOwl](https://promptowl.ai).


### PR DESCRIPTION
## Summary
Align CLI + MCP-server package READMEs into a consistent agent-facing storefront — shared "governed context, not memory" value prop, copy-paste installs, full tool/selector reference, and cross-links across the package family.

## What I changed
**CLI README**
- Add value prop line: **Governed context, not memory** — typed, versioned, hash-chained.
- Add selector grammar one-liner above examples.
- MCP section: add `npx -y` run-without-install + note **19 tools** over stdio.
- Replace "Related Packages" with **Ecosystem** table (CLI ↔ MCP ↔ Engine ↔ PromptOwl cloud).

**MCP-server README**
- Add value prop header + author/links line (matches site + root README).
- Install: add `npx -y @promptowl/contextnest-mcp-server` run-direct form.
- Add **Selector Grammar** one-liner section with example.
- Add **Ecosystem** cross-link table + whitepaper link + expanded license line.

## Impact
- Docs only — no code, no behavior change.
- Consistent positioning across npm, site, READMEs.
- Easier onboarding: copy-paste install, visible tool count, selector grammar at a glance, clear path between CLI / MCP / engine / cloud.
- Risk: none — markdown content only, live on next publish.
