### PR TITLE
fix(cli): render engine errors as one-liners, hide stack traces

### DIFF
--- a/packages/cli/src/__tests__/cli.regression.test.ts
+++ b/packages/cli/src/__tests__/cli.regression.test.ts
@@ -896,7 +896,19 @@ describe("[regression] add/update edge cases", () => {
 
     const res = runCtxResult(tmp, ["update", "nodes/rej", "--body", "sneaky edit"]);
     expect(res.status).not.toBe(0);
-    expect(res.stderr).toMatch(/rejected/i);
+    expect(res.stderr).toMatch(/Error \[REJECTED_DOCUMENT\]/);
+    // No raw stack trace leaks to end users.
+    expect(res.stderr).not.toMatch(/^\s+at\s/m);
+  });
+
+  it("publish on a rejected document fails with a friendly error, no stack trace", () => {
+    runCtx(tmp, ["add", "nodes/rej2", "--title", "Rejected Two", "--body", "x"]);
+    runCtx(tmp, ["update", "nodes/rej2", "--status", "rejected"]);
+
+    const res = runCtxResult(tmp, ["publish", "nodes/rej2"]);
+    expect(res.status).not.toBe(0);
+    expect(res.stderr).toMatch(/Error \[REJECTED_DOCUMENT\]/);
+    expect(res.stderr).not.toMatch(/^\s+at\s/m);
   });
 
   it("update falls back to draft for an unknown status", () => {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -23,6 +23,7 @@ import {
   ContextInjector,
   GraphQueryEngine,
   publishDocument,
+  ContextNestError,
   generateContextYaml,
   generateIndexMd,
   generateAgentConfigs,
@@ -1749,4 +1750,12 @@ drift
   });
 
 // Parse and run
-program.parse();
+program.parseAsync().catch((err: unknown) => {
+  // Engine validation errors render as concise one-liners instead of leaking
+  // stack traces. Unknown errors still throw so genuine bugs stay debuggable.
+  if (err instanceof ContextNestError) {
+    console.error(chalk.red(`Error [${err.code}]: ${err.message}`));
+    process.exit(1);
+  }
+  throw err;
+});


### PR DESCRIPTION
## Summary

CLI commands that hit an engine validation guard (`RejectedDocumentError`, and every other `ContextNestError` subclass) leaked Node.js stack traces to end users. Output looked like an application crash even though exit code was correct. Root cause: `program.parse()` had no top-level rejection handler, so async action errors escaped as unhandled rejections and Node printed the full stack + error properties.

  ## What changed

  - Swapped `program.parse()` for `program.parseAsync().catch(handler)` in the CLI entrypoint.
  - Handler narrows on `ContextNestError` and prints `Error [CODE]: message` in red, then exits 1.
  - Unknown / non-engine errors still re-throw — genuine bugs stay debuggable with a full stack.
  - Regression coverage: locked the contract on both `ctx publish` and `ctx update --body` against a rejected document — stderr must contain `Error [REJECTED_DOCUMENT]` and must not contain stack frames (`^\s+at\s`).

  ## Impact

  - **UX**: end users see one-line validation messages instead of what looks like a crash. Same exit code (1), same audit signal, far less noise.
  - **Coverage**: applies uniformly to every engine error class (`ValidationFailedError`, `DocumentNotFoundError`, `IntegrityError`, `ChainBreakError`,   
  `RejectedDocumentError`, etc.) — single chokepoint, no per-command try/catch churn.
  - **Information hygiene**: stops leaking internal file paths and call frames in normal validation failures.
  - **Debuggability preserved**: unknown errors still surface their full stack — failure of an engine guard is no longer indistinguishable from a real bug.
  - **Scope**: CLI surface only. Engine and MCP server unchanged. No behavior change for happy paths.