### PR TITLE
fix(cli,engine): ctx query --include-drafts surfaces draft docs

### DIFF
--- a/packages/cli/src/__tests__/cli.regression.test.ts
+++ b/packages/cli/src/__tests__/cli.regression.test.ts
@@ -604,6 +604,39 @@ describe("[regression] ctx query --full", () => {
   });
 });
 
+// ─── query --include-drafts ─────────────────────────────────────────────────
+
+describe("[regression] ctx query --include-drafts", () => {
+  beforeEach(() => {
+    initVault(tmp);
+    // Published baseline.
+    runCtx(tmp, ["add", "nodes/q-pub", "--title", "Published Doc"]);
+    // Plant a raw draft on disk — bypasses the auto-publish that `ctx add` does.
+    writeFileSync(
+      join(tmp, "nodes", "q-draft.md"),
+      `---\ntitle: "Draft Doc"\nstatus: draft\n---\n\nbody\n`,
+      "utf-8",
+    );
+    runCtx(tmp, ["index"]);
+  });
+
+  it("hides drafts by default", () => {
+    const parsed = JSON.parse(runCtx(tmp, ["query", "type:document", "--json"]));
+    const ids = parsed.documents.map((d: { id: string }) => d.id);
+    expect(ids).toContain("nodes/q-pub");
+    expect(ids).not.toContain("nodes/q-draft");
+  });
+
+  it("--include-drafts surfaces draft documents alongside published", () => {
+    const parsed = JSON.parse(
+      runCtx(tmp, ["query", "type:document", "--include-drafts", "--json"]),
+    );
+    const ids = parsed.documents.map((d: { id: string }) => d.id);
+    expect(ids).toContain("nodes/q-pub");
+    expect(ids).toContain("nodes/q-draft");
+  });
+});
+
 // ─── list --status filter ───────────────────────────────────────────────────
 
 describe("[regression] ctx list --status", () => {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1104,6 +1104,7 @@ program
   .option("--json", "Output as JSON")
   .option("--hops <n>", "Graph traversal depth (default: 2)", parseInt)
   .option("--full", "Force full-load mode (load all documents)")
+  .option("--include-drafts", "Include draft documents (default: published only)", false)
   .action(async (selector, opts) => {
     // Cloud pack: @org/pack-name routes to PromptOwl API
     if (selector.startsWith("@")) {
@@ -1117,6 +1118,7 @@ program
     const result = await engine.query(selector, {
       hops: opts.hops ?? 2,
       full: opts.full ?? false,
+      includeDrafts: opts.includeDrafts ?? false,
     });
 
     if (opts.json) {

--- a/packages/engine/src/graph-query-engine.ts
+++ b/packages/engine/src/graph-query-engine.ts
@@ -50,10 +50,13 @@ export class GraphQueryEngine {
     selector: string,
     options: GraphQueryOptions = {},
   ): Promise<GraphQueryResult> {
-    const { hops = 2, full = false } = options;
+    const { hops = 2, full = false, includeDrafts = false } = options;
 
-    // Try graph mode first
-    if (!full) {
+    // Graph mode reads from context.yaml, which is published-only by design
+    // (see `ctx index` and `autoIndex` below). Drafts therefore never appear
+    // as seed candidates and graph mode cannot honor `includeDrafts`. Force
+    // full mode so draft documents actually surface when callers opt in.
+    if (!full && !includeDrafts) {
       let contextYaml = await this.storage.readContextYaml();
 
       // Auto-generate context.yaml if missing


### PR DESCRIPTION
  ## Summary
  
  `ctx query --include-drafts` referenced in QA test plan didn't exist on CLI — Commander rejected as unknown option. Engine accepted `includeDrafts` internally but graph mode reads published-only `context.yaml`, so drafts could never surface even if forwarded.

  ## What changed

  - Added `--include-drafts` flag to `ctx query`, forwards to engine.
  - Engine `query()` short-circuits to full-load mode when `includeDrafts: true` — graph index cannot deliver drafts. Full mode reads from disk and honors the existing draft gate.
  - Regression tests lock the contract: drafts hidden by default, surfaced with flag.

  ## Impact

  - Documented capability now actually works end-to-end.
  - `includeDrafts` honored on every code path — no more silent no-op in graph mode.
  - Default stays published-only; drafts strictly opt-in. No leak to LLM hydration.
  - QA test plan unblocked.
