### PR TITLE
fix: normalize space-separated --tags input in ctx add and ctx update

### DIFF
--- a/packages/cli/src/__tests__/cli.regression.test.ts
+++ b/packages/cli/src/__tests__/cli.regression.test.ts
@@ -203,6 +203,22 @@ describe("[regression] ctx add", () => {
     expect(onDisk).toMatch(/#api/);
   });
 
+  it("normalizes space-separated tags (--tags '#cmd #analyze') into discrete tags", () => {
+    runCtx(tmp, ["add", "nodes/space-tags", "--tags", "#cmd #analyze"]);
+    const onDisk = readFileSync(join(tmp, "nodes", "space-tags.md"), "utf-8");
+    expect(onDisk).toMatch(/#cmd/);
+    expect(onDisk).toMatch(/#analyze/);
+    expect(onDisk).not.toMatch(/#cmd #analyze/);
+  });
+
+  it("space-separated tags on add are queryable by individual tag", () => {
+    runCtx(tmp, ["add", "nodes/queryable-tags", "--tags", "#alpha #beta"]);
+    const matched = JSON.parse(runCtx(tmp, ["resolve", "#alpha", "--json"])).map(
+      (d: { id: string }) => d.id,
+    );
+    expect(matched).toContain("nodes/queryable-tags");
+  });
+
   it("scaffolds a skill block for --type skill", () => {
     runCtx(tmp, [
       "add",
@@ -359,6 +375,19 @@ describe("[regression] ctx update", () => {
     expect(out).toMatch(/No new version cut/);
     const onDisk = readFileSync(join(tmp, "nodes", "mutable.md"), "utf-8");
     expect(onDisk).toMatch(/status:\s*draft/);
+  });
+
+  it("normalizes space-separated tags on update into discrete queryable tags", () => {
+    runCtx(tmp, ["update", "nodes/mutable", "--tags", "#foo #bar"]);
+    const onDisk = readFileSync(join(tmp, "nodes", "mutable.md"), "utf-8");
+    expect(onDisk).toMatch(/#foo/);
+    expect(onDisk).toMatch(/#bar/);
+    expect(onDisk).not.toMatch(/#foo #bar/);
+
+    const matched = JSON.parse(runCtx(tmp, ["resolve", "#foo", "--json"])).map(
+      (d: { id: string }) => d.id,
+    );
+    expect(matched).toContain("nodes/mutable");
   });
 });
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -634,7 +634,7 @@ program
   .description("Create a new document with frontmatter template")
   .option("-t, --type <type>", "Node type", "document")
   .option("--title <title>", "Document title")
-  .option("--tags <tags>", "Comma-separated tags")
+  .option("--tags <tags>", "Tags (comma- or space-separated)")
   .option("--body <body>", "Markdown body content")
   .option("--trigger <trigger>", "Skill trigger description (for --type skill)")
   .action(async (path, opts) => {
@@ -643,7 +643,7 @@ program
     const title = opts.title || id.split("/").pop()!.replace(/-/g, " ").replace(/\b\w/g, (c: string) => c.toUpperCase());
 
     const tagList = opts.tags
-      ? opts.tags.split(",").map((t: string) => t.trim()).map((t: string) => (t.startsWith("#") ? t : `#${t}`))
+      ? opts.tags.split(/[,\s]+/).filter((t: string) => t.length > 0).map((t: string) => (t.startsWith("#") ? t : `#${t}`))
       : undefined;
     const frontmatter: Frontmatter = {
       title,
@@ -1230,7 +1230,7 @@ program
   .command("update <path>")
   .description("Update a document's frontmatter and/or body, then auto-publish")
   .option("--title <title>", "New title")
-  .option("--tags <tags>", "New tags (comma-separated, replaces existing)")
+  .option("--tags <tags>", "New tags (comma- or space-separated, replaces existing)")
   .option("--status <status>", "New status (draft|pending_review|approved|published|rejected; aliases accepted)")
   .option("--body <body>", "New markdown body content")
   .action(async (path, opts) => {
@@ -1243,7 +1243,7 @@ program
       doc.frontmatter.status = normalizeStatus(opts.status);
     }
     if (opts.tags !== undefined) {
-      doc.frontmatter.tags = opts.tags.split(",").map((t: string) => t.trim()).map((t: string) => (t.startsWith("#") ? t : `#${t}`));
+      doc.frontmatter.tags = opts.tags.split(/[,\s]+/).filter((t: string) => t.length > 0).map((t: string) => (t.startsWith("#") ? t : `#${t}`));
     }
     doc.frontmatter.updated_at = new Date().toISOString();
 


### PR DESCRIPTION
Fixes #32

## Summary

- Split `--tags` input on `/[,\s]+/` instead of `","` in both `ctx add` and `ctx update`, so space-separated tags like `"#cmd #analyze"` are stored as discrete valid tags
- Updated `--tags` help text to say "comma- or space-separated"
- Added 3 regression tests covering space-separated tag storage and queryability for both `add` and `update`

Generated with [Claude Code](https://claude.ai/code)