### PR TITLE
feat: ctx forget (tombstones + audit trail) + strict governance envelope scaffold

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -23,6 +23,9 @@ import {
   ContextInjector,
   GraphQueryEngine,
   publishDocument,
+  forgetDocument,
+  forgetLog,
+  computeGovernanceEnvelope,
   ContextNestError,
   generateContextYaml,
   generateIndexMd,
@@ -1139,6 +1142,37 @@ program
     }
   });
 
+// ─── ctx forget-log ──────────────────────────────────────────────────────────
+
+program
+  .command("forget-log [path]")
+  .description("Show forget / unforget audit events (optionally scoped to a document)")
+  .option("--json", "Output as JSON")
+  .action(async (path, opts) => {
+    const storage = getStorage();
+    const id = path ? normalizeDocumentId(path) : undefined;
+    const events = await forgetLog(storage, id);
+
+    if (opts.json) {
+      console.log(JSON.stringify(events, null, 2));
+      return;
+    }
+
+    if (events.length === 0) {
+      console.log(chalk.yellow("No forget events recorded."));
+      return;
+    }
+
+    console.log(chalk.bold(`${events.length} forget event(s):\n`));
+    for (const e of events) {
+      const meta = (e.action_metadata ?? {}) as Record<string, unknown>;
+      console.log(`  ${chalk.cyan(e.document_id ?? "(unknown)")} — ${e.event_type}`);
+      console.log(`    By: ${e.actor} at ${e.timestamp}`);
+      if (meta.reason) console.log(`    Reason: ${String(meta.reason)}`);
+      if (meta.requested_by) console.log(`    Requested by: ${String(meta.requested_by)}`);
+    }
+  });
+
 // ─── ctx reconstruct ───────────────────────────────────────────────────────────
 
 program
@@ -1373,10 +1407,54 @@ program
   .option("--hops <n>", "Graph traversal depth (default: 2)", parseInt)
   .option("--full", "Force full-load mode (load all documents)")
   .option("--include-drafts", "Include draft documents (default: published only)", false)
+  .option(
+    "--strict",
+    "Return a sealed governance envelope (records + directive + provenance) for --actor",
+  )
+  .option("--actor <principal>", "Principal the strict envelope is computed for")
   .action(async (selector, opts) => {
     // Cloud pack: @org/pack-name routes to PromptOwl API
     if (selector.startsWith("@")) {
       await queryFromCloud(selector, opts);
+      return;
+    }
+
+    // Strict governed retrieval — SCAFFOLD (ctx-forget-strict-pr-spec §2).
+    // Returns a closed-world envelope instead of raw candidates. The actor's
+    // per-principal eligibility model is NOT yet implemented; the CLI applies
+    // only zone-RBAC (via a permissive hook) + tombstone exclusion. See
+    // engine/governance-envelope.ts for the porting TODO.
+    if (opts.strict) {
+      const storage = getStorage();
+      const envelope = await computeGovernanceEnvelope(
+        storage,
+        selector,
+        opts.actor ?? "anonymous",
+        { hops: opts.hops ?? 2, full: opts.full ?? false, rbac: permissiveRbac },
+      );
+
+      if (opts.json) {
+        console.log(JSON.stringify(envelope, null, 2));
+      } else {
+        console.log(chalk.bold("Governance envelope (strict mode):"));
+        console.log(chalk.dim(`  directive: ${envelope.directive}`));
+        console.log(chalk.dim(`  actor: ${opts.actor ?? "anonymous"}`));
+        console.log(chalk.bold(`\n${envelope.records.length} record(s):`));
+        for (const rec of envelope.records) {
+          const prov = envelope.provenance.find((p) => p.id === rec.id);
+          console.log(`  ${chalk.cyan(rec.id)}: ${rec.title}`);
+          console.log(
+            chalk.dim(
+              `    v${prov?.version ?? "?"} | ${prov?.eligibility_reason ?? "n/a"}`,
+            ),
+          );
+        }
+        console.log(
+          chalk.yellow(
+            "\n  NOTE: scaffold — per-principal eligibility (owner/assignment/consent/delegation) not yet implemented.",
+          ),
+        );
+      }
       return;
     }
 
@@ -1566,6 +1644,78 @@ program
   });
 
 // ─── ctx delete ───────────────────────────────────────────────────────────────
+
+// ─── ctx forget ────────────────────────────────────────────────────────────────
+
+program
+  .command("forget <pathOrSelector>")
+  .description(
+    "Tombstone document(s): exclude from all retrieval, retain history for audit (ctx-forget-strict-pr-spec §1)",
+  )
+  .option("--reason <r>", "Why the node is being forgotten (recorded in audit)")
+  .option("--requested-by <who>", "Principal who requested the forget")
+  .option("--at <iso>", "ISO-8601 timestamp the forget took effect (default: now)")
+  .option("-a, --author <email>", "Actor recorded in version + chain", "cli@contextnest.local")
+  .option("--json", "Output as JSON")
+  .action(async (pathOrSelector, opts) => {
+    const storage = getStorage();
+
+    // Resolve targets: a literal path forgets one doc; otherwise treat the arg
+    // as a selector (parity with `ctx resolve`) and forget every match.
+    let ids: string[];
+    const looksLikeSelector = /[#:|+]/.test(pathOrSelector);
+    if (looksLikeSelector) {
+      const docs = await storage.discoverDocuments();
+      const packs = await storage.readPacks();
+      const resolver = new Resolver({ documents: docs });
+      const packLoader = new PackLoader(packs);
+      const ast = parseSelector(pathOrSelector);
+      const results = await evaluate(ast, {
+        resolver,
+        packLoader: (id) => packLoader.get(id),
+      });
+      ids = results.map((d) => d.id);
+    } else {
+      ids = [normalizeDocumentId(pathOrSelector)];
+    }
+
+    if (ids.length === 0) {
+      console.log(chalk.yellow("No documents matched — nothing forgotten."));
+      return;
+    }
+
+    const forgotten: Array<{ id: string; version: number; chainHash?: string }> = [];
+    for (const id of ids) {
+      const result = await forgetDocument(storage, id, {
+        reason: opts.reason,
+        requestedBy: opts.requestedBy,
+        at: opts.at,
+        editedBy: opts.author,
+      });
+      forgotten.push({
+        id,
+        version: result.node.frontmatter.version ?? 0,
+        chainHash: result.versionEntry.chain_hash,
+      });
+    }
+
+    await regenerateIndex(storage);
+
+    if (opts.json) {
+      console.log(JSON.stringify({ forgotten }, null, 2));
+    } else {
+      console.log(chalk.green(`Forgot ${forgotten.length} document(s):`));
+      for (const f of forgotten) {
+        console.log(`  ${chalk.cyan(f.id)} → v${f.version}`);
+      }
+      if (opts.reason) console.log(chalk.dim(`  reason: ${opts.reason}`));
+      console.log(
+        chalk.dim("  History retained; excluded from all retrieval. Use `ctx forget-log` to audit."),
+      );
+    }
+  });
+
+// ─── ctx delete ────────────────────────────────────────────────────────────────
 
 program
   .command("delete <path>")

--- a/packages/engine/src/__tests__/forget.test.ts
+++ b/packages/engine/src/__tests__/forget.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, mkdir, writeFile, readFile, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import yaml from "js-yaml";
+import { NestStorage } from "../storage.js";
+import { publishDocument } from "../publish.js";
+import { forgetDocument, forgetLog } from "../forget.js";
+import { GraphQueryEngine } from "../graph-query-engine.js";
+import { Resolver } from "../resolver.js";
+import { VersionManager } from "../versioning.js";
+import { verifyDocumentChain } from "../integrity.js";
+import { parseUri } from "../uri.js";
+
+/**
+ * Seed a published document with a clean v1 hash chain by writing a draft to
+ * disk and running the real publish flow. Returns the document id.
+ */
+async function seedPublishedDoc(
+  storage: NestStorage,
+  slug: string,
+  opts: { title: string; tags: string[]; body: string },
+): Promise<string> {
+  const docId = `nodes/${slug}`;
+  const raw =
+    "---\n" +
+    `title: ${opts.title}\n` +
+    "type: document\n" +
+    "status: draft\n" +
+    `tags: [${opts.tags.map((t) => `"${t}"`).join(", ")}]\n` +
+    "---\n" +
+    opts.body;
+  await mkdir(join(storage.root, "nodes"), { recursive: true });
+  await writeFile(join(storage.root, "nodes", `${slug}.md`), raw, "utf-8");
+  await publishDocument(storage, docId, { editedBy: "seed@test" });
+  return docId;
+}
+
+describe("forgetDocument — tombstone (ctx-forget-strict-pr-spec §1)", () => {
+  let root: string;
+  let storage: NestStorage;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "ctxnest-forget-"));
+    storage = new NestStorage(root);
+  });
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("excludes a forgotten doc from GraphQueryEngine query", async () => {
+    const docId = await seedPublishedDoc(storage, "pricing", {
+      title: "Pricing Playbook",
+      tags: ["#pricing"],
+      body: "Tier A is $99/mo.\n",
+    });
+    await storage.regenerateIndex();
+
+    const engine = new GraphQueryEngine(storage);
+    const before = await engine.query("#pricing", { hops: 1 });
+    expect(before.documents.map((d) => d.id)).toContain(docId);
+
+    await forgetDocument(storage, docId, {
+      reason: "GDPR erasure request",
+      requestedBy: "subject:jane",
+      editedBy: "steward@test",
+    });
+    await storage.regenerateIndex();
+
+    const after = await engine.query("#pricing", { hops: 1 });
+    expect(after.documents.map((d) => d.id)).not.toContain(docId);
+  });
+
+  it("excludes a forgotten doc from Resolver resolve + search", async () => {
+    const docId = await seedPublishedDoc(storage, "secret", {
+      title: "Secret Doc",
+      tags: ["#confidential"],
+      body: "classified pineapple content\n",
+    });
+
+    // Present before forget.
+    let docs = await storage.discoverDocuments();
+    let resolver = new Resolver({ documents: docs });
+    expect(
+      (await resolver.resolve(parseUri(`contextnest://${docId}`))).map((d) => d.id),
+    ).toContain(docId);
+
+    await forgetDocument(storage, docId, { editedBy: "steward@test" });
+
+    // Absent after forget — direct resolve, tag, and search all empty.
+    docs = await storage.discoverDocuments();
+    resolver = new Resolver({ documents: docs });
+    expect(
+      await resolver.resolve(parseUri(`contextnest://${docId}`)),
+    ).toHaveLength(0);
+    expect(
+      await resolver.resolve(parseUri("contextnest://tag/confidential")),
+    ).toHaveLength(0);
+    expect(
+      await resolver.resolve(parseUri("contextnest://search/pineapple")),
+    ).toHaveLength(0);
+    expect(resolver.getPublishedDocuments().map((d) => d.id)).not.toContain(docId);
+  });
+
+  it("records a document.forgotten chain event with reason/requested_by/at", async () => {
+    const docId = await seedPublishedDoc(storage, "audit", {
+      title: "Audit Doc",
+      tags: ["#audit"],
+      body: "body\n",
+    });
+
+    const at = "2026-06-29T10:00:00.000Z";
+    await forgetDocument(storage, docId, {
+      reason: "superseded by v2 policy",
+      requestedBy: "steward:bob",
+      at,
+      editedBy: "steward@test",
+    });
+
+    // chain_events.yaml exists and contains the event.
+    const raw = await readFile(
+      join(root, ".versions", "chain_events.yaml"),
+      "utf-8",
+    );
+    const events = yaml.load(raw) as Array<Record<string, any>>;
+    const forgetEvt = events.find(
+      (e) => e.event_type === "document.forgotten" && e.document_id === docId,
+    );
+    expect(forgetEvt).toBeDefined();
+    expect(forgetEvt!.action_metadata).toMatchObject({
+      reason: "superseded by v2 policy",
+      requested_by: "steward:bob",
+      at,
+    });
+
+    // forgetLog surfaces the same event.
+    const log = await forgetLog(storage, docId);
+    expect(log).toHaveLength(1);
+    expect(log[0].event_type).toBe("document.forgotten");
+  });
+
+  it("preserves chain integrity — verifyDocumentChain still passes after forget", async () => {
+    const docId = await seedPublishedDoc(storage, "integrity", {
+      title: "Integrity Doc",
+      tags: ["#x"],
+      body: "original body\n",
+    });
+    await forgetDocument(storage, docId, { editedBy: "steward@test" });
+
+    const vm = new VersionManager(storage);
+    const history = await storage.readHistory(docId);
+    expect(history).not.toBeNull();
+    // v1 keyframe + v2 forget version.
+    expect(history!.versions.at(-1)!.version).toBe(2);
+
+    const kf1 = await storage.readKeyframe(docId, 1);
+    const report = verifyDocumentChain(docId, history!, (v) =>
+      v === 1 ? kf1 : null,
+    );
+    expect(report.valid).toBe(true);
+  });
+
+  it("is distinct from delete — file and history remain on disk", async () => {
+    const docId = await seedPublishedDoc(storage, "retained", {
+      title: "Retained Doc",
+      tags: ["#x"],
+      body: "keep me\n",
+    });
+    await forgetDocument(storage, docId, { editedBy: "steward@test" });
+
+    // Live file still present and flagged forgotten.
+    const live = await readFile(join(root, "nodes", "retained.md"), "utf-8");
+    expect(live).toContain("forgotten: true");
+    expect(live).toContain("keep me");
+
+    // History still readable.
+    const history = await storage.readHistory(docId);
+    expect(history!.versions.length).toBeGreaterThanOrEqual(2);
+
+    // Keyframe file retained.
+    await expect(
+      stat(join(root, "nodes", ".versions", "retained", "v1.md")),
+    ).resolves.toBeDefined();
+  });
+});

--- a/packages/engine/src/forget.ts
+++ b/packages/engine/src/forget.ts
@@ -1,0 +1,168 @@
+/**
+ * Document forget / tombstone orchestration (ctx-forget-strict-pr-spec §1).
+ *
+ * `ctx forget` is a SUPERSEDING version, not a hard delete. The live file and
+ * its full version history are retained for audit; the node is flagged
+ * `frontmatter.forgotten = true` so every retrieval path (`GraphQueryEngine`,
+ * `Resolver`) excludes it via `isTombstoned`. A `document.forgotten` event is
+ * appended to the hash-chain log so compliance teams can reconstruct what was
+ * forgotten, by whom, and when.
+ *
+ * Modeled on `publish.ts` for version + checkpoint + chain integrity. Never
+ * calls `deleteDocument` — a tombstone preserves history by design.
+ */
+
+import type {
+  ContextNode,
+  HashChainEvent,
+  VersionEntry,
+} from "./types.js";
+import { NestStorage } from "./storage.js";
+import { VersionManager } from "./versioning.js";
+import { CheckpointManager } from "./checkpoint.js";
+import { ChainEventLog } from "./chain-log.js";
+import { serializeDocument, getChecksumContent, isPublished } from "./parser.js";
+import { computeContentHash } from "./integrity.js";
+
+export interface ForgetOptions {
+  /** Why the node was forgotten (e.g. GDPR erasure request, supersession). */
+  reason?: string;
+  /** Principal who requested the forget (data subject, steward, regulator). */
+  requestedBy?: string;
+  /** ISO-8601 timestamp the forget took effect. Defaults to now. */
+  at?: string;
+  /** Opaque actor string recorded in version history + chain event. */
+  editedBy: string;
+}
+
+export interface ForgetResult {
+  node: ContextNode;
+  versionEntry: VersionEntry;
+  checkpointNumber: number;
+  chainEvent: HashChainEvent;
+}
+
+/**
+ * Forget (tombstone) a document: flag it forgotten, record provenance, bump
+ * version, create a version entry + checkpoint, and append a
+ * `document.forgotten` hash-chain event. The node remains on disk and in
+ * history; only retrieval is suppressed.
+ */
+export async function forgetDocument(
+  storage: NestStorage,
+  docId: string,
+  options: ForgetOptions,
+): Promise<ForgetResult> {
+  // Read current document
+  let node = await storage.readDocument(docId);
+
+  const at = options.at ?? new Date().toISOString();
+
+  // Flag as tombstoned and record provenance.
+  node.frontmatter.forgotten = true;
+  node.frontmatter.forget_record = {
+    ...(options.reason !== undefined ? { reason: options.reason } : {}),
+    ...(options.requestedBy !== undefined
+      ? { requested_by: options.requestedBy }
+      : {}),
+    at,
+  };
+
+  // Bump version
+  const currentVersion = node.frontmatter.version || 0;
+  const newVersion = currentVersion + 1;
+  node.frontmatter.version = newVersion;
+  node.frontmatter.updated_at = new Date().toISOString();
+
+  // Compute document body checksum
+  const serialized = serializeDocument(node);
+  node.frontmatter.checksum = computeContentHash(getChecksumContent(serialized));
+
+  // Re-serialize with updated frontmatter
+  const finalContent = serializeDocument(node);
+  node.rawContent = finalContent;
+  node.body = finalContent.slice(
+    finalContent.indexOf("---", finalContent.indexOf("---") + 3) + 3,
+  );
+
+  // Write updated document to disk (file is NOT deleted — tombstone retains it)
+  await storage.writeDocument(docId, finalContent);
+
+  // Re-read to get clean parse
+  node = await storage.readDocument(docId);
+
+  const versionManager = new VersionManager(storage);
+  const forgottenAt = new Date().toISOString();
+
+  // Create version entry — keeps the hash chain continuous (a tombstone is a
+  // superseding version, not a hard delete).
+  const versionEntry = await versionManager.createVersion(node, options.editedBy, {
+    note: options.reason ? `forget: ${options.reason}` : "forget",
+    publishedAt: forgottenAt,
+  });
+
+  // Gather all published documents for checkpoint
+  const allDocs = await storage.discoverDocuments();
+  const publishedDocs = allDocs.filter(isPublished);
+
+  // Gather all document histories
+  const histories = await storage.findAllHistories();
+
+  // Create checkpoint
+  const checkpointManager = new CheckpointManager(storage);
+  const checkpoint = await checkpointManager.createCheckpoint(
+    docId,
+    publishedDocs,
+    histories,
+  );
+
+  // Append a first-class governance event to the hash-chain log.
+  const chainEvent: HashChainEvent = {
+    event_id: makeEventId(docId, "document.forgotten", versionEntry.version),
+    event_type: "document.forgotten",
+    timestamp: versionEntry.edited_at,
+    actor: options.editedBy,
+    document_id: docId,
+    resulting_hash: versionEntry.chain_hash,
+    action_metadata: {
+      ...(options.reason !== undefined ? { reason: options.reason } : {}),
+      ...(options.requestedBy !== undefined
+        ? { requested_by: options.requestedBy }
+        : {}),
+      at,
+    },
+  };
+  await new ChainEventLog(storage).append(chainEvent);
+
+  return {
+    node,
+    versionEntry,
+    checkpointNumber: checkpoint.checkpoint,
+    chainEvent,
+  };
+}
+
+/**
+ * Read the forget audit trail — `document.forgotten` / `document.unforgotten`
+ * events from the hash-chain log. When `path` is given, scope to that document.
+ */
+export async function forgetLog(
+  storage: NestStorage,
+  path?: string,
+): Promise<HashChainEvent[]> {
+  const log = new ChainEventLog(storage);
+  if (path) {
+    const byDoc = await log.readByDocument(path);
+    return byDoc.filter(
+      (e) =>
+        e.event_type === "document.forgotten" ||
+        e.event_type === "document.unforgotten",
+    );
+  }
+  return log.readByType(["document.forgotten", "document.unforgotten"]);
+}
+
+function makeEventId(...parts: Array<string | number>): string {
+  const ts = new Date().toISOString().replace(/[:.]/g, "-");
+  return `evt_${ts}_${parts.join("_")}`;
+}

--- a/packages/engine/src/governance-envelope.ts
+++ b/packages/engine/src/governance-envelope.ts
@@ -1,0 +1,130 @@
+/**
+ * Governance envelope — SCAFFOLD for `ctx query --strict --actor`
+ * (ctx-forget-strict-pr-spec §2).
+ *
+ * `--strict` is the "governed retrieval" mode: instead of returning raw
+ * candidates, it returns a sealed envelope of {records, directive, provenance}
+ * that a downstream LLM is meant to treat as a closed world — answer ONLY from
+ * the records, refuse anything outside them.
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * TODO(ctx-forget-strict-pr-spec §2): THIS IS A SCAFFOLD, NOT THE REAL MODEL.
+ *
+ * The per-record PRINCIPAL ELIGIBILITY model — owner / assignment / consent /
+ * delegation, evaluated per (actor, record) — is NOT implemented here. The
+ * current scaffold does ONLY:
+ *   1. tombstone exclusion (reused from Feature 1 — `isTombstoned`), and
+ *   2. zone-level RBAC via the EXISTING injected `RbacHook` (the CLI ships a
+ *      permissive hook, so in the CLI today every zone passes).
+ *
+ * The real eligibility index must be PORTED from the Python reference at:
+ *   /home/misha/Development/contextnest/eval/_gatemem/bench/agents/rag_policy.py
+ * which is a STRUCTURAL, no-LLM policy index (owner/assignment/consent/
+ * delegation lookups — deterministic, not model-judged). Do NOT invent a
+ * principal schema here; port the reference's structure faithfully. Until then
+ * `eligibility_reason` is always "zone-rbac+not-tombstoned" and MUST NOT be
+ * read as a real per-principal authorization decision.
+ * ─────────────────────────────────────────────────────────────────────────
+ */
+
+import type { ContextNode, RbacHook } from "./types.js";
+import { NestStorage } from "./storage.js";
+import { GraphQueryEngine } from "./graph-query-engine.js";
+
+/** Fixed instruction prepended to the envelope for the downstream LLM. */
+export const STRICT_ENVELOPE_DIRECTIVE =
+  "Use ONLY these records; refuse anything outside; never summarize restricted content.";
+
+/** One record in a governance envelope. */
+export interface EnvelopeRecord {
+  id: string;
+  title: string;
+  body: string;
+}
+
+/** Per-record provenance entry — why the record is eligible for this actor. */
+export interface EnvelopeProvenance {
+  id: string;
+  version?: number;
+  /**
+   * SCAFFOLD value only — currently a fixed structural reason, NOT a real
+   * per-principal eligibility decision (see file-level TODO).
+   */
+  eligibility_reason: string;
+}
+
+export interface GovernanceEnvelope {
+  records: EnvelopeRecord[];
+  directive: string;
+  provenance: EnvelopeProvenance[];
+}
+
+export interface GovernanceEnvelopeOptions {
+  /** Graph traversal depth (default: 2). */
+  hops?: number;
+  /** Force full-load mode (default: false). */
+  full?: boolean;
+  /**
+   * Zone-RBAC hook. The engine stays identity-agnostic — the caller supplies
+   * the policy. The CLI ships a permissive hook for the scaffold.
+   */
+  rbac?: RbacHook;
+}
+
+/**
+ * Compute a strict governance envelope for `selector` as seen by `actor`.
+ *
+ * SCAFFOLD: records = normal retrieval candidates (tombstoned already excluded
+ * by `GraphQueryEngine` per Feature 1) filtered through zone-level RBAC only.
+ * See the file-level TODO — per-principal eligibility is not yet implemented.
+ */
+export async function computeGovernanceEnvelope(
+  storage: NestStorage,
+  selector: string,
+  actor: string,
+  options: GovernanceEnvelopeOptions = {},
+): Promise<GovernanceEnvelope> {
+  const engine = new GraphQueryEngine(storage);
+  const result = await engine.query(selector, {
+    hops: options.hops ?? 2,
+    full: options.full ?? false,
+    // Strict mode never surfaces drafts.
+    includeDrafts: false,
+  });
+
+  // Retrieval candidates already exclude tombstoned nodes (Feature 1). Source
+  // nodes participate in the same closed world.
+  const candidates: ContextNode[] = [...result.documents, ...result.sourceNodes];
+
+  const records: EnvelopeRecord[] = [];
+  const provenance: EnvelopeProvenance[] = [];
+
+  for (const doc of candidates) {
+    // Zone-level RBAC. With no zone or no hook, default-allow (the engine is
+    // identity-agnostic; the bridge supplies the real policy). A zone present
+    // with a hook that denies ingest elides the record entirely.
+    const zone = doc.frontmatter.zone;
+    if (zone && options.rbac) {
+      const allowed = await options.rbac.canIngest(actor, zone);
+      if (!allowed) continue;
+    }
+
+    records.push({
+      id: doc.id,
+      title: doc.frontmatter.title,
+      body: doc.body,
+    });
+    provenance.push({
+      id: doc.id,
+      version: doc.frontmatter.version,
+      // SCAFFOLD ONLY — see file-level TODO. Not a per-principal decision.
+      eligibility_reason: "zone-rbac+not-tombstoned",
+    });
+  }
+
+  return {
+    records,
+    directive: STRICT_ENVELOPE_DIRECTIVE,
+    provenance,
+  };
+}

--- a/packages/engine/src/graph-query-engine.ts
+++ b/packages/engine/src/graph-query-engine.ts
@@ -19,7 +19,7 @@ import { PackLoader } from "./packs.js";
 import { ContextInjector } from "./injection.js";
 import { GraphTraverser } from "./graph-traverser.js";
 import { generateContextYaml } from "./index-generator.js";
-import { isPublished, isRetrievable } from "./parser.js";
+import { isPublished, isRetrievable, isTombstoned } from "./parser.js";
 import { getLatestCheckpoint, getLatestCheckpointNumber } from "./checkpoint.js";
 import { parseSelector } from "./selector/parser.js";
 import { evaluateFromIndex } from "./selector/index-evaluator.js";
@@ -113,6 +113,11 @@ export class GraphQueryEngine {
     const sourceNodes: ContextNode[] = [];
 
     for (const doc of docMap.values()) {
+      // Tombstoned (ctx forget) docs vanish from every retrieval path, even
+      // with includeDrafts (ctx-forget-strict-pr-spec §1).
+      if (isTombstoned(doc)) {
+        continue;
+      }
       // Rejected + approved docs are never returned, even with includeDrafts.
       // Rejected = terminal hide (steward retired). Approved = signed off
       // but not yet live — surfaces only after publish.
@@ -166,7 +171,7 @@ export class GraphQueryEngine {
       const config = await this.storage.readConfig();
       const checkpointHistory = await this.storage.readCheckpointHistory();
       const latestCheckpoint = getLatestCheckpoint(checkpointHistory);
-      const published = docs.filter(isPublished);
+      const published = docs.filter((d) => isPublished(d) && !isTombstoned(d));
 
       const contextYaml = generateContextYaml(published, config, latestCheckpoint);
       await this.storage.writeContextYaml(contextYaml);
@@ -203,11 +208,13 @@ export class GraphQueryEngine {
     // Apply the same retrieval gates as graphQuery so approved/rejected
     // never leak to LLMs, and drafts surface only when explicitly opted in.
     const filteredDocs = result.documents.filter((doc) => {
+      if (isTombstoned(doc)) return false;
       if (!isRetrievable(doc)) return false;
       if (!options.includeDrafts && !isPublished(doc)) return false;
       return true;
     });
     const filteredSources = result.sourceNodes.filter((doc) => {
+      if (isTombstoned(doc)) return false;
       if (!isRetrievable(doc)) return false;
       if (!options.includeDrafts && !isPublished(doc)) return false;
       return true;

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -163,6 +163,7 @@ export {
   isPublished,
   isRejected,
   isRetrievable,
+  isTombstoned,
   /** @deprecated returns false for all post-normalization nodes. Use isRejected. */
   isSuperseded,
 } from "./parser.js";
@@ -277,6 +278,22 @@ export type {
 // Publish
 export { publishDocument } from "./publish.js";
 export type { PublishOptions, PublishResult } from "./publish.js";
+
+// Forget (tombstone) — ctx-forget-strict-pr-spec §1
+export { forgetDocument, forgetLog } from "./forget.js";
+export type { ForgetOptions, ForgetResult } from "./forget.js";
+
+// Governance envelope — SCAFFOLD for `ctx query --strict` (§2)
+export {
+  computeGovernanceEnvelope,
+  STRICT_ENVELOPE_DIRECTIVE,
+} from "./governance-envelope.js";
+export type {
+  GovernanceEnvelope,
+  GovernanceEnvelopeOptions,
+  EnvelopeRecord,
+  EnvelopeProvenance,
+} from "./governance-envelope.js";
 
 // Source graph
 export {

--- a/packages/engine/src/parser.ts
+++ b/packages/engine/src/parser.ts
@@ -75,6 +75,15 @@ export function isApproved(node: ContextNode): boolean {
   return node.frontmatter.status === "approved";
 }
 
+/**
+ * Predicate: document has been tombstoned via `ctx forget`
+ * (ctx-forget-strict-pr-spec §1). Tombstoned nodes are retained in history
+ * for audit but excluded from ALL retrieval paths.
+ */
+export function isTombstoned(node: ContextNode): boolean {
+  return node.frontmatter.forgotten === true;
+}
+
 /** Predicate: document is in `published` status (post-normalization). */
 export function isPublished(node: ContextNode): boolean {
   return node.frontmatter.status === "published";

--- a/packages/engine/src/resolver.ts
+++ b/packages/engine/src/resolver.ts
@@ -5,7 +5,7 @@
 import MiniSearch from "minisearch";
 import type { ContextNode, ContextNestUri, Checkpoint } from "./types.js";
 import { extractSection } from "./inline.js";
-import { stripTagPrefix, isPublished } from "./parser.js";
+import { stripTagPrefix, isPublished, isTombstoned } from "./parser.js";
 import { FederationNotSupportedError } from "./errors.js";
 
 export interface ResolverOptions {
@@ -30,8 +30,11 @@ export class Resolver {
     this.checkpoints = options.checkpoints || [];
     this.reconstructVersion = options.reconstructVersion;
 
-    // Index all documents
+    // Index all documents. Tombstoned (ctx forget) docs are never indexed, so
+    // they cannot surface from resolve / tag / folder / search / getPublished —
+    // even with includeDrafts (ctx-forget-strict-pr-spec §1).
     for (const doc of options.documents) {
+      if (isTombstoned(doc)) continue;
       this.documents.set(doc.id, doc);
 
       // Build tag index
@@ -51,7 +54,7 @@ export class Resolver {
     });
 
     const searchDocs = options.documents
-      .filter(isPublished)
+      .filter((d) => isPublished(d) && !isTombstoned(d))
       .map((d) => ({
         id: d.id,
         title: d.frontmatter.title,

--- a/packages/engine/src/schemas.ts
+++ b/packages/engine/src/schemas.ts
@@ -133,6 +133,8 @@ export const HASH_CHAIN_EVENT_TYPES = [
   "platform_admin.session_opened",
   "platform_admin.session_closed",
   "agent.zone_scope_assigned",
+  "document.forgotten",
+  "document.unforgotten",
 ] as const;
 
 /** Zone ID pattern: lowercase letter start, then alphanumeric / hyphen / underscore */
@@ -198,6 +200,14 @@ export const frontmatterSchema = z
       .regex(ZONE_ID_PATTERN, "Zone ID must match ^[a-z][a-z0-9_-]*$")
       .optional(),
     governance: z.enum(GOVERNANCE_TIERS).optional(),
+    forgotten: z.boolean().optional(),
+    forget_record: z
+      .object({
+        reason: z.string().optional(),
+        requested_by: z.string().optional(),
+        at: z.string(),
+      })
+      .optional(),
   })
   .superRefine((data, ctx) => {
     // Rule 9: source block MUST be present when type is "source"

--- a/packages/engine/src/storage.ts
+++ b/packages/engine/src/storage.ts
@@ -7,7 +7,7 @@ import { readFile, writeFile, mkdir, stat, unlink, rm, rename } from "node:fs/pr
 import { join, dirname, basename } from "node:path";
 import fg from "fast-glob";
 import yaml from "js-yaml";
-import { parseDocument } from "./parser.js";
+import { parseDocument, isTombstoned } from "./parser.js";
 import { parseConfig } from "./config.js";
 import {
   detectDrift,
@@ -289,7 +289,12 @@ export class NestStorage {
     const config = await this.readConfig();
     const checkpointHistory = await this.readCheckpointHistory();
     const latestCheckpoint = checkpointHistory?.checkpoints?.at(-1) ?? null;
-    const published = docs.filter((d) => d.frontmatter.status === "published");
+    // Tombstoned (ctx forget) docs are kept in per-folder INDEX.md for stewards
+    // but excluded from context.yaml so they never seed graph retrieval
+    // (ctx-forget-strict-pr-spec §1).
+    const published = docs.filter(
+      (d) => d.frontmatter.status === "published" && !isTombstoned(d),
+    );
     const packs = await this.readPacks();
 
     const contextYaml = generateContextYaml(published, config, latestCheckpoint);

--- a/packages/engine/src/types.ts
+++ b/packages/engine/src/types.ts
@@ -91,7 +91,9 @@ export type HashChainEventType =
   | "platform_admin.toggle_changed"
   | "platform_admin.session_opened"
   | "platform_admin.session_closed"
-  | "agent.zone_scope_assigned";
+  | "agent.zone_scope_assigned"
+  | "document.forgotten"
+  | "document.unforgotten";
 
 /** Source metadata block — present only on type: source nodes (§1.9.1) */
 export interface SourceMeta {
@@ -145,6 +147,28 @@ export interface Frontmatter {
   zone?: string;
   /** Governance tier (zone-classification-rbac-spec §1) */
   governance?: GovernanceTier;
+  /**
+   * Tombstone flag (ctx-forget-strict-pr-spec §1). When true, the node is
+   * excluded from ALL retrieval (search/resolve/query) but retained in
+   * history for audit. Set by `ctx forget`; distinct from a hard delete.
+   */
+  forgotten?: boolean;
+  /** Provenance for a tombstone — what was forgotten, who requested, when, why. */
+  forget_record?: ForgetRecord;
+}
+
+/**
+ * Right-to-be-forgotten / record-keeping evidence for a tombstoned node
+ * (ctx-forget-strict-pr-spec §1). Persisted in frontmatter and mirrored into
+ * the `document.forgotten` hash-chain event's action_metadata.
+ */
+export interface ForgetRecord {
+  /** Why the node was forgotten (e.g. GDPR erasure request, supersession). */
+  reason?: string;
+  /** Principal who requested the forget (data subject, steward, regulator). */
+  requested_by?: string;
+  /** ISO-8601 timestamp the forget took effect. */
+  at: string;
 }
 
 /** A parsed Context Nest document */


### PR DESCRIPTION
## What

Ships **ctx-forget-strict-pr-spec** §1 (`ctx forget`, full) and §2 (`ctx query --strict`, scaffold) — the engine side of the GateMem governance result, turning the benchmark primitives into the real product.

cc @QaziKilla — taking point on the engine side (Hiren out). Spec node: `ctx-forget-strict-pr-spec`.

## §1 `ctx forget` — first-class tombstone ✅ complete + tested

Right-to-be-forgotten / EU-AI-Act record-keeping primitive.

- `ctx forget <path|selector> [--reason --requested-by --at]` — flags `frontmatter.forgotten` + a `forget_record`, appends a **superseding version** (hash chain stays continuous — **never a hard delete**), and writes a `document.forgotten` event to the chain-event log with `{reason, requested_by, at}`.
- `ctx forget-log [path]` — the forget audit trail.
- Tombstoned nodes are **excluded from every retrieval path**: `GraphQueryEngine` (graph + full), `Resolver` (resolve/tag/folder/search/getPublished), and `context.yaml` index generation. Retained in `.versions/` history + per-folder `INDEX.md` for stewards.
- First production code to persist to `chain_events.yaml` (the log existed but was never wired to a command).

## §2 `ctx query --strict --actor` — governance envelope ⚠️ scaffold only

Returns a sealed `{records, directive, provenance}` envelope. **The scaffold does tombstone-exclusion + zone-RBAC only.** The per-principal eligibility model (owner / assignment / consent / delegation) is **NOT implemented** — there's a prominent TODO to port the structural, no-LLM `rag_policy.py` from the GateMem harness. Code and CLI output are both labelled as a scaffold so it isn't mistaken for the real gate. This is the piece for engine review/extension.

## Integrity note

The GateMem *submitted* agent is an **LLM-gated adapter**, not this structural path. This PR is the structural `forget`; `--strict` is a scaffold toward the structural gate. Keep them distinct in the writeup.

## Tests

`packages/engine/src/__tests__/forget.test.ts` (5, passing): retrieval exclusion (graph + resolver), `document.forgotten` event + `forget-log`, `verifyDocumentChain` still valid after forget (integrity preserved), forget ≠ delete (file + history retained). `tsc --noEmit` clean across engine/cli/mcp-server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)