### PR TITLE
fix(plugin): allow changing Claude Code plugin settings after enable — /contextnest:config + override files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ fixtures/*
 # Keep the committed test vault tracked (it backs the engine test suite).
 !fixtures/minimal-vault/
 .claude/agent-memory/*
+# Per-checkout Context Nest plugin overrides — personal, never shared.
+.claude/contextnest.local.json
 
 # Test coverage output
 coverage/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,122 +6,99 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Context Nest is a structured second brain for AI agents — a governed, versioned knowledge base that agents can query. It provides typed graph structure, ~100x cheaper queries (~500 tokens vs 50k), and hash-chained audit trails.
 
+Requires Node >= 20 and pnpm >= 9. CI runs the full matrix on ubuntu/windows/macOS × Node 20/22, so **cross-platform correctness matters** — normalize CRLF, avoid POSIX-only path assumptions, and don't shell out to tools Windows lacks (`jq`, etc.).
+
 ## Build and Development Commands
 
 ```bash
-# Install dependencies (uses pnpm workspaces)
 pnpm install
-
-# Build all packages
-pnpm build
-
-# Run all tests
-pnpm test
-
-# Run tests in watch mode
-pnpm test:watch
-
-# Type-check without emitting
-pnpm lint
-
-# Clean all build artifacts
+pnpm build              # tsup, all packages
+pnpm lint               # tsc --noEmit, all packages
+pnpm test               # vitest — unit + structural (regression suites EXCLUDED)
+pnpm test:regression    # builds CLI + MCP server first, then runs *.regression.test.ts
 pnpm clean
 
-# Run a single test file
+# Single file / pattern / package
 pnpm test packages/engine/src/__tests__/engine.test.ts
-
-# Run tests for a specific package
+pnpm test -t "hash chain"
 pnpm --filter @promptowl/contextnest-engine test
+
+# Plugin vendoring (see "Plugins" below) — run after editing plugins/shared/
+pnpm plugins:sync
+pnpm plugins:check      # CI guard; fails on drift
 ```
+
+`pnpm test` and `pnpm test:regression` are separate on purpose: regression suites spawn the *built* `dist/index.js` of the CLI and MCP server against throwaway vaults, so they need a build first and are slow. Editing engine/CLI source and running only `pnpm test` will not exercise them.
 
 ## Architecture
 
-This is a **pnpm monorepo** with three packages:
+pnpm monorepo, two workspaces of interest:
 
 ```
-packages/
-├── engine/      # Core library — parsing, storage, versioning, integrity, selectors
-├── cli/         # Command-line tool (`ctx` / `contextnest`)
-└── mcp-server/  # MCP server exposing vault operations as tools for AI agents
+packages/       # published npm packages (engine ← cli, mcp-server)
+plugins/        # coding-agent plugins that drive the ctx CLI (not published to npm)
 ```
 
-### Package Dependencies
+`packages/governance/` is untracked local build residue — ignore it.
 
-- `cli` → depends on `engine`
-- `mcp-server` → depends on `engine`
-- `engine` → standalone core library
+### Engine (`@promptowl/contextnest-engine`)
 
-### Engine Package (`@promptowl/contextnest-engine`)
-
-The core library implementing the Context Nest specification:
+Standalone core implementing `CONTEXT_NEST_SPEC.md`. Notable modules beyond the obvious CRUD:
 
 | Module | Purpose |
 |--------|---------|
+| `parser.ts` / `schemas.ts` | Markdown + YAML frontmatter; Zod validation rules 1–17 (spec §13) |
 | `storage.ts` | Vault file operations, document CRUD |
-| `parser.ts` | Markdown + YAML frontmatter parsing |
-| `versioning.ts` | Keyframe + diff version history |
-| `checkpoint.ts` | Nest-level atomic snapshots |
-| `integrity.ts` | SHA-256 hash chain verification |
-| `selector/` | Query grammar parser and evaluator |
-| `graph-traverser.ts` | Relationship graph traversal |
-| `resolver.ts` | URI resolution (`contextnest://` scheme) |
-| `schemas.ts` | Zod schemas for frontmatter validation |
+| `versioning.ts` / `checkpoint.ts` | Keyframe+diff history; nest-level atomic snapshots |
+| `integrity.ts` / `chain-log.ts` | SHA-256 hash chains and their audit log |
+| `selector/` | `lexer` → `parser` → `evaluator` (+ `index-evaluator` for the fast path over `context.yaml`) |
+| `graph-traverser.ts` / `graph-query-engine.ts` / `wiki-graph.ts` | Relationship traversal and `[[wikilink]]` graph |
+| `registry.ts` | Central vault registry at `~/.contextnest/config.yaml` — see resolution order below |
+| `source-graph.ts` | Live `source` nodes (MCP/REST/CLI/function transports) |
+| `packs.ts` | Saved selector bundles (`pack:name`) |
+| `suggestions.ts` / `approval.ts` / `rbac.ts` / `stewards.ts` | Drift suggestions, approval workflow, role scoping |
+| `hygienist.ts` / `index-generator.ts` / `index-md-generator.ts` | Vault health checks; `context.yaml` and `INDEX.md` regeneration |
+| `agent-configs.ts` | Generates CLAUDE.md / agent config blocks into a target project |
 
-### CLI Package (`@promptowl/contextnest-cli`)
+**Vault resolution** (`resolveVaultPath()`, highest precedence first) — a frequent source of "wrong vault" bugs:
+`--vault <alias>` → `CONTEXTNEST_VAULT` (alias) → `CONTEXTNEST_VAULT_PATH` (abs path) → positional arg → local `.context/config.yaml` found by walking up cwd → registry `default:` → cwd.
 
-Provides two binary commands: `ctx` and `contextnest`
+### CLI (`@promptowl/contextnest-cli`)
 
-Key commands: `init`, `add`, `update`, `delete`, `read`, `query`, `publish`, `verify`, `history`
+Binaries `ctx` and `contextnest`, both from a single ~2k-line `src/index.ts` (commander). Command groups: document CRUD (`add`/`update`/`delete`/`read`/`publish`), query (`query`/`search`/`resolve`/`list`), integrity (`verify`/`history`/`reconstruct`/`checkpoint`), governance (`drift stage|list|approve|reject`), and multi-vault (`vault add|list|remove|default|which`). `init` scaffolds from `src/starters/` — the starter prompt bodies are the agent-facing onboarding text and have their own tests.
 
-### MCP Server Package (`@promptowl/contextnest-mcp-server`)
+### MCP Server (`@promptowl/contextnest-mcp-server`)
 
-Exposes 19 tools over stdio transport for AI agents:
-- Read tools: `vault_info`, `resolve`, `read_document`, `list_documents`, `search`, `verify_integrity`
-- Mutation tools: `create_document`, `update_document`, `delete_document`, `publish_document`
-- Governance tools: `stage_drift_suggestion`, `list_suggestions`, `approve_suggestion`, `reject_suggestion`
+19 tools over stdio: `vault_info`, `resolve`, `read_document`, `list_documents`, `document_format`, `read_index`, `read_pack`, `search`, `verify_integrity`, `list_checkpoints`, `read_version`, `create_document`, `update_document`, `delete_document`, `publish_document`, `stage_drift_suggestion`, `list_suggestions`, `approve_suggestion`, `reject_suggestion`.
+
+### Plugins (`plugins/`)
+
+Makes coding agents vault-aware (auto-retrieve) and self-maintaining (auto-capture) by shelling out to `ctx`. Only the Claude Code plugin is built; Codex/Gemini are README-only.
+
+**`plugins/shared/` is the single source of truth. Never edit `plugins/claude-code/core/` — it is a vendored byte-identical copy.** Installed Claude plugins can't read files outside their own directory, so `pnpm plugins:sync` copies `shared/core/*` into each agent plugin and fills the `<!-- BEGIN SHARED -->…<!-- END SHARED -->` regions of agent/skill markdown from `shared/prompts/*.md`. `pnpm plugins:check` fails CI on drift.
+
+Each `core/*.js` module exports a **pure** `run({ input, env, exec })` returning the hook-output object (or `null` to do nothing), plus a thin IO shell guarded by `isMain(import.meta.url)`. Tests call `run()` with a fake `exec` — no subprocess. Zero runtime deps, plain Node ESM.
+
+Config comes from env, `CLAUDE_PLUGIN_OPTION_*` with `CONTEXTNEST_*` fallbacks (so non-Claude agents can feed the same values): `RETRIEVAL_MODE` (`off`/`search`/`query`/`agent`, default `search`), `AUTO_CAPTURE` (default true), `VAULT` (pinned alias), `CTX_COMMAND` (default `ctx`).
+
+Hooks: `SessionStart` → vault overview injection, `UserPromptSubmit` → retrieval, `Stop` → loop-safe capture gate.
 
 ## Key Concepts
 
-**Node Types**: `document`, `snippet`, `glossary`, `persona`, `prompt`, `source`, `tool`, `reference`, `skill`
+**Node types**: `document`, `snippet`, `glossary`, `persona`, `prompt`, `source`, `tool`, `reference`, `skill`
 
-**Selector Grammar**: Composable query language for selecting documents
-- Tags: `#engineering`
-- Types: `type:document`
-- Packs: `pack:onboarding.basics`
-- Operators: `+` (AND), `|` (OR), `-` (NOT)
+**Statuses**: `draft`, `pending_review`, `approved`, `published`, `rejected`. Parse-time aliasing normalizes legacy/foreign values (case-insensitive; unknown → `draft`); disk always stores canonical values, re-canonicalized on round-trip through `serializeDocument` or `ctx index`.
 
-**URI Scheme**: `contextnest://path`, `contextnest://path@N` (pinned to checkpoint N), `contextnest://path#section`
+**Selector grammar**: `#tag`, `type:document`, `pack:onboarding.basics`, with `+` (AND), `|` (OR), `-` (NOT).
 
-**Version Model**: Keyframe + diff storage (keyframes every 10 versions by default)
+**URI scheme**: `contextnest://path`, `@N` (pinned to checkpoint N), `#section`.
 
-**Integrity**: SHA-256 hash chains for both document versions and nest checkpoints
+**Version model**: keyframe + diff (keyframe every 10 versions by default), SHA-256 hash-chained for both document versions and nest checkpoints.
 
-## Testing
+## Releasing
 
-Tests use **Vitest** with workspace configuration. Each package has its own `__tests__/` directory.
-
-```bash
-# Run all tests
-pnpm test
-
-# Run specific test file
-pnpm test packages/engine/src/__tests__/engine.test.ts
-
-# Run tests matching pattern
-pnpm test -- --grep "hash chain"
-```
-
-## TypeScript Configuration
-
-- Target: ES2022
-- Module: ESNext with bundler resolution
-- Strict mode enabled
-- Build tool: tsup
+Changesets. `pnpm version-packages` (`changeset version` + lockfile refresh), then `pnpm release`. All three packages are AGPL-3.0 and versioned together.
 
 ## Specification
 
-The full technical specification is in `CONTEXT_NEST_SPEC.md`. Key sections:
-- §1: Document format and frontmatter
-- §2: Selector grammar
-- §4: URI scheme (`contextnest://`)
-- §6-8: Version history and integrity verification
+`CONTEXT_NEST_SPEC.md` is normative — §1 document format, §2 selectors, §3 packs, §4 URI scheme, §5 `context.yaml`, §6–8 versions/checkpoints/integrity, §9 injection & tracing, §10 INDEX.md, §13 validation rules.

--- a/plugins/__tests__/core.unit.test.ts
+++ b/plugins/__tests__/core.unit.test.ts
@@ -13,9 +13,11 @@ import { run as captureGate, isSubstantive } from "../shared/core/capture-gate.j
 import {
   getConfig,
   vaultTargets,
+  isVaultRegistered,
   withVault,
   ctxJson,
   squish,
+  VALID_RETRIEVAL_MODES,
 } from "../shared/core/lib.js";
 
 /** Build a fake exec from a list of [substringMatch, jsonValue]. */
@@ -135,6 +137,104 @@ describe("getConfig settings override files (CU-wdqcpzw825)", () => {
     expect(c.retrievalMode).toBe("search");
     expect(c.autoCapture).toBe(true);
   });
+
+  // retrieval_mode is the one setting with a fixed value set. A wrong value
+  // (typo, stale, wrong case) must never silently degrade to "search" while
+  // looking set — it is skipped per layer, so resolution falls through.
+  describe("invalid retrieval_mode is rejected, not silently mis-applied", () => {
+    it("a bogus value in the only layer falls back to the search default", () => {
+      const opts = tempSettings({ retrieval_mode: "aggressive" });
+      expect(getConfig({}, opts).retrievalMode).toBe("search");
+    });
+
+    it("a bogus project value is skipped so a valid env value still wins", () => {
+      const opts = tempSettings({ retrieval_mode: "turbo" });
+      // enable-time env is a valid "search"; the junk file must not mask it.
+      expect(getConfig(enableTimeEnv, opts).retrievalMode).toBe("search");
+    });
+
+    it("a bogus project value is skipped so a valid user-file value wins", () => {
+      const opts = tempSettings({ retrieval_mode: "nope" }, { retrieval_mode: "agent" });
+      expect(getConfig({}, opts).retrievalMode).toBe("agent");
+    });
+
+    it("normalizes surrounding whitespace and casing before validating", () => {
+      const opts = tempSettings({ retrieval_mode: "  AGENT  " });
+      expect(getConfig({}, opts).retrievalMode).toBe("agent");
+    });
+
+    it("every accepted mode round-trips through a file override", () => {
+      for (const mode of VALID_RETRIEVAL_MODES) {
+        const opts = tempSettings({ retrieval_mode: mode });
+        expect(getConfig({}, opts).retrievalMode).toBe(mode);
+      }
+    });
+
+    it("a non-string junk value (number) is rejected too", () => {
+      const opts = tempSettings({ retrieval_mode: 42 });
+      expect(getConfig({}, opts).retrievalMode).toBe("search");
+    });
+  });
+
+  describe("auto_capture accepts only boolean spellings", () => {
+    it("recognized truthy/falsy spellings resolve as expected", () => {
+      for (const v of ["true", "1", "yes", "on", "TRUE", " On "]) {
+        expect(getConfig({}, tempSettings({ auto_capture: v })).autoCapture).toBe(true);
+      }
+      for (const v of ["false", "0", "no", "off", "OFF", " No "]) {
+        expect(getConfig({}, tempSettings({ auto_capture: v })).autoCapture).toBe(false);
+      }
+    });
+
+    it("a JSON boolean (not a string) is honoured", () => {
+      expect(getConfig({}, tempSettings({ auto_capture: false })).autoCapture).toBe(false);
+      expect(getConfig({}, tempSettings({ auto_capture: true })).autoCapture).toBe(true);
+    });
+
+    it("a garbage value is skipped → default ON, and cannot mask a valid layer", () => {
+      // Junk in the only layer → default ON.
+      expect(getConfig({}, tempSettings({ auto_capture: "banana" })).autoCapture).toBe(true);
+      // Junk project value must not hide a valid "off" in the user file.
+      const both = tempSettings({ auto_capture: "2" }, { auto_capture: "off" });
+      expect(getConfig({}, both).autoCapture).toBe(false);
+    });
+  });
+
+  describe("vault accepts only the unpin sentinel or a shape-valid alias", () => {
+    it("a shape-valid alias passes through", () => {
+      expect(getConfig({}, tempSettings({ vault: "work-2_v1" })).vault).toBe("work-2_v1");
+    });
+
+    it("a malformed alias is skipped → default unpinned, cannot mask a valid layer", () => {
+      for (const bad of ["my vault", "a/b", "..", "work!"]) {
+        expect(getConfig({}, tempSettings({ vault: bad })).vault).toBe("");
+      }
+      // Junk project value must not hide a valid alias in the user file.
+      const both = tempSettings({ vault: "a/b" }, { vault: "home" });
+      expect(getConfig({}, both).vault).toBe("home");
+    });
+
+    it('an explicit "" still unpins (not treated as malformed)', () => {
+      const env = { CLAUDE_PLUGIN_OPTION_VAULT: "work" };
+      expect(getConfig(env, tempSettings({ vault: "" })).vault).toBe("");
+    });
+  });
+
+  describe("ctx_command is trimmed and must be non-empty", () => {
+    it("surrounding whitespace is trimmed; internal spaces are preserved", () => {
+      expect(getConfig({}, tempSettings({ ctx_command: "  /bin/ctx  " })).ctxCommand).toBe("/bin/ctx");
+      // A path with internal spaces is a legitimate argv[0] for execFileSync.
+      expect(getConfig({}, tempSettings({ ctx_command: "/opt/my ctx/ctx" })).ctxCommand).toBe(
+        "/opt/my ctx/ctx",
+      );
+    });
+
+    it("a blank value is skipped → default 'ctx', cannot mask a valid layer", () => {
+      expect(getConfig({}, tempSettings({ ctx_command: "   " })).ctxCommand).toBe("ctx");
+      const both = tempSettings({ ctx_command: "" }, { ctx_command: "/usr/local/bin/ctx" });
+      expect(getConfig({}, both).ctxCommand).toBe("/usr/local/bin/ctx");
+    });
+  });
 });
 
 describe("lib helpers", () => {
@@ -155,11 +255,28 @@ describe("lib helpers", () => {
     expect(ctxJson(() => ({ status: 0, stdout: "[1,2]" }), ["x"], null)).toEqual([1, 2]);
   });
 
-  it("vaultTargets: pinned beats registry; empty registry → [null]", () => {
+  it("vaultTargets: a registered pin is honoured; unpinned fans out; empty registry → [null]", () => {
     const ex = fakeExec([["vault list", [{ alias: "a", exists: true }, { alias: "b", exists: true }]]]);
-    expect(vaultTargets(getConfig({ CONTEXTNEST_VAULT_ALIAS: "pin" }), ex)).toEqual(["pin"]);
+    expect(vaultTargets(getConfig({ CONTEXTNEST_VAULT_ALIAS: "a" }), ex)).toEqual(["a"]);
     expect(vaultTargets(getConfig({}), ex)).toEqual(["a", "b"]);
     expect(vaultTargets(getConfig({}), fakeExec([["vault list", []]]))).toEqual([null]);
+  });
+
+  it("vaultTargets: a stale pin (not registered) falls back to auto-select, not a bad --vault", () => {
+    const twoVaults = fakeExec([["vault list", [{ alias: "a", exists: true }, { alias: "b", exists: true }]]]);
+    // "pin" isn't in the registry → behave as unpinned (fan out), never ["pin"].
+    expect(vaultTargets(getConfig({ CONTEXTNEST_VAULT_ALIAS: "pin" }), twoVaults)).toEqual(["a", "b"]);
+    // Registered but path missing (exists:false) is also not usable → fall back.
+    const missing = fakeExec([["vault list", [{ alias: "gone", exists: false }]]]);
+    expect(vaultTargets(getConfig({ CONTEXTNEST_VAULT_ALIAS: "gone" }), missing)).toEqual([null]);
+  });
+
+  it("isVaultRegistered: true only for a registered, present alias", () => {
+    const ex = fakeExec([["vault list", [{ alias: "a", exists: true }, { alias: "gone", exists: false }]]]);
+    expect(isVaultRegistered("a", ex)).toBe(true);
+    expect(isVaultRegistered("gone", ex)).toBe(false); // registered but missing on disk
+    expect(isVaultRegistered("nope", ex)).toBe(false); // not registered
+    expect(isVaultRegistered("", ex)).toBe(false); // unpinned
   });
 
   it("squish collapses whitespace and truncates", () => {
@@ -260,6 +377,19 @@ describe("session-start", () => {
     expect(ctx).toContain("`work`");
     expect(ctx).toContain("default");
     expect(ctx).toContain("pinned");
+  });
+
+  it("warns when the pinned vault is not registered (stale pin)", () => {
+    const ex = fakeExec([
+      ["vault list", [{ alias: "work", exists: true }, { alias: "home", exists: true }]],
+    ]);
+    const out = sessionStart({ input: {}, env: { CONTEXTNEST_VAULT_ALIAS: "ghost" }, exec: ex });
+    const ctx = additional(out)!;
+    expect(ctx).toMatch(/not a registered vault/i);
+    expect(ctx).toContain("`ghost`");
+    // Must NOT claim the ghost pin is in effect, and no vault is flagged pinned.
+    expect(ctx).not.toContain("all queries/captures use it");
+    expect(ctx).not.toContain("pinned");
   });
 
   it("notes local resolution when no vaults are registered", () => {

--- a/plugins/__tests__/core.unit.test.ts
+++ b/plugins/__tests__/core.unit.test.ts
@@ -3,6 +3,9 @@
  * fake `exec` returning canned ctx JSON; no subprocess, no real vault.
  */
 import { describe, it, expect } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 import { run as retrieve } from "../shared/core/retrieve.js";
 import { run as sessionStart } from "../shared/core/session-start.js";
@@ -56,6 +59,81 @@ describe("getConfig", () => {
     const c = getConfig({ CONTEXTNEST_RETRIEVAL_MODE: "agent", CONTEXTNEST_VAULT_ALIAS: "p" });
     expect(c.retrievalMode).toBe("agent");
     expect(c.vault).toBe("p");
+  });
+});
+
+describe("getConfig settings override files (CU-wdqcpzw825)", () => {
+  /**
+   * Build throwaway project/user dirs with optional override files.
+   *  - project: <cwd>/.claude/contextnest.local.json
+   *  - user:    <home>/.contextnest/plugin-settings.json
+   */
+  function tempSettings(project?: unknown, user?: unknown) {
+    const cwd = mkdtempSync(join(tmpdir(), "cn-proj-"));
+    const homedir = mkdtempSync(join(tmpdir(), "cn-home-"));
+    if (project !== undefined) {
+      mkdirSync(join(cwd, ".claude"), { recursive: true });
+      writeFileSync(
+        join(cwd, ".claude", "contextnest.local.json"),
+        typeof project === "string" ? project : JSON.stringify(project),
+      );
+    }
+    if (user !== undefined) {
+      mkdirSync(join(homedir, ".contextnest"), { recursive: true });
+      writeFileSync(
+        join(homedir, ".contextnest", "plugin-settings.json"),
+        typeof user === "string" ? user : JSON.stringify(user),
+      );
+    }
+    return { cwd, homedir };
+  }
+
+  // Enable-time answers, frozen into env by Claude Code. The bug: these used
+  // to be the ONLY source, so settings could never be changed after enable.
+  const enableTimeEnv = {
+    CLAUDE_PLUGIN_OPTION_RETRIEVAL_MODE: "search",
+    CLAUDE_PLUGIN_OPTION_AUTO_CAPTURE: "true",
+    CLAUDE_PLUGIN_OPTION_VAULT: "work",
+  };
+
+  it("project override file beats the stale enable-time env value", () => {
+    const opts = tempSettings({ retrieval_mode: "off" });
+    expect(getConfig(enableTimeEnv, opts).retrievalMode).toBe("off");
+  });
+
+  it("auto_capture:false in the project file disables capture despite env true", () => {
+    const opts = tempSettings({ auto_capture: false });
+    expect(getConfig(enableTimeEnv, opts).autoCapture).toBe(false);
+  });
+
+  it("user-level file beats env; project file beats user file", () => {
+    const fromUser = tempSettings(undefined, { retrieval_mode: "agent" });
+    expect(getConfig(enableTimeEnv, fromUser).retrievalMode).toBe("agent");
+
+    const both = tempSettings({ retrieval_mode: "query" }, { retrieval_mode: "agent" });
+    expect(getConfig(enableTimeEnv, both).retrievalMode).toBe("query");
+  });
+
+  it('an explicit vault:"" in the file unpins an enable-time pinned vault', () => {
+    const opts = tempSettings({ vault: "" });
+    expect(getConfig(enableTimeEnv, opts).vault).toBe("");
+  });
+
+  it("keys absent from the file fall through to env, then defaults", () => {
+    const opts = tempSettings({ retrieval_mode: "off" });
+    const c = getConfig(enableTimeEnv, opts);
+    expect(c.vault).toBe("work"); // untouched by file → env wins
+    expect(c.ctxCommand).toBe("ctx"); // nowhere → default
+  });
+
+  it("missing or malformed override files never throw and leave env in charge", () => {
+    const none = tempSettings(); // dirs exist, no files
+    expect(getConfig(enableTimeEnv, none).retrievalMode).toBe("search");
+
+    const broken = tempSettings("{not json", "[1,2,3]");
+    const c = getConfig(enableTimeEnv, broken);
+    expect(c.retrievalMode).toBe("search");
+    expect(c.autoCapture).toBe(true);
   });
 });
 

--- a/plugins/__tests__/core.unit.test.ts
+++ b/plugins/__tests__/core.unit.test.ts
@@ -2,7 +2,7 @@
  * Tier 1 — pure unit tests for the shared core. Each run() is called with a
  * fake `exec` returning canned ctx JSON; no subprocess, no real vault.
  */
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -36,6 +36,24 @@ function fakeExec(routes: [string, unknown][], fallback: unknown = []) {
 function additional(out: any): string | undefined {
   return out?.hookSpecificOutput?.additionalContext;
 }
+
+// getConfig() reads real override files when the caller doesn't inject
+// cwd/homedir (sessionStart never does). Point HOME and the project dir at an
+// empty temp dir so a developer's own ~/.contextnest/plugin-settings.json can't
+// leak into these assertions. Node's os.homedir() honours $HOME on POSIX.
+const realHome = process.env.HOME;
+const realProjectDir = process.env.CLAUDE_PROJECT_DIR;
+beforeAll(() => {
+  const empty = mkdtempSync(join(tmpdir(), "cn-no-settings-"));
+  process.env.HOME = empty;
+  process.env.CLAUDE_PROJECT_DIR = empty;
+});
+afterAll(() => {
+  if (realHome === undefined) delete process.env.HOME;
+  else process.env.HOME = realHome;
+  if (realProjectDir === undefined) delete process.env.CLAUDE_PROJECT_DIR;
+  else process.env.CLAUDE_PROJECT_DIR = realProjectDir;
+});
 
 describe("getConfig", () => {
   it("defaults and Claude userConfig precedence", () => {
@@ -272,11 +290,11 @@ describe("lib helpers", () => {
   });
 
   it("isVaultRegistered: true only for a registered, present alias", () => {
-    const ex = fakeExec([["vault list", [{ alias: "a", exists: true }, { alias: "gone", exists: false }]]]);
-    expect(isVaultRegistered("a", ex)).toBe(true);
-    expect(isVaultRegistered("gone", ex)).toBe(false); // registered but missing on disk
-    expect(isVaultRegistered("nope", ex)).toBe(false); // not registered
-    expect(isVaultRegistered("", ex)).toBe(false); // unpinned
+    const vaults = [{ alias: "a", exists: true }, { alias: "gone", exists: false }];
+    expect(isVaultRegistered("a", vaults)).toBe(true);
+    expect(isVaultRegistered("gone", vaults)).toBe(false); // registered but missing on disk
+    expect(isVaultRegistered("nope", vaults)).toBe(false); // not registered
+    expect(isVaultRegistered("", vaults)).toBe(false); // unpinned
   });
 
   it("squish collapses whitespace and truncates", () => {

--- a/plugins/__tests__/structure.test.ts
+++ b/plugins/__tests__/structure.test.ts
@@ -103,6 +103,24 @@ describe("agent + skill frontmatter", () => {
   });
 });
 
+describe("config command (CU-wdqcpzw825: settings must be changeable after enable)", () => {
+  const commandPath = join(plugin, "commands", "config.md");
+
+  it("ships a /contextnest:config command", () => {
+    expect(existsSync(commandPath)).toBe(true);
+  });
+
+  it("command has description frontmatter and covers all four settings", () => {
+    const text = read(commandPath);
+    const fm = text.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+    expect(fm, "frontmatter present").toBeTruthy();
+    expect(fm![1]).toMatch(/\bdescription:\s*\S+/);
+    for (const key of ["retrieval_mode", "auto_capture", "vault", "ctx_command"]) {
+      expect(text).toContain(key);
+    }
+  });
+});
+
 describe("vendored core sync", () => {
   it("plugins:check passes (vendored core matches plugins/shared)", () => {
     // Throws (non-zero exit) if any vendored copy has drifted.

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "contextnest",
   "displayName": "Context Nest",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Vault-aware context retrieval and automatic knowledge capture, powered by the Context Nest `ctx` CLI.",
   "author": { "name": "PromptOwl" },
   "homepage": "https://github.com/promptowl/contextnest",

--- a/plugins/claude-code/CHANGELOG.md
+++ b/plugins/claude-code/CHANGELOG.md
@@ -5,7 +5,11 @@
 Settings are no longer frozen at enable time (CU-wdqcpzw825).
 
 - New `/contextnest:config` command to view and change `retrieval_mode`,
-  `auto_capture`, `vault`, and `ctx_command` at any time.
+  `auto_capture`, `vault`, and `ctx_command` at any time. Bare invocation
+  drives the change through interactive pickers (setting, value, scope) instead
+  of requiring the user to type an exact value; the pinned-vault choices are
+  populated from the registered vault aliases. A `<setting> <value>` pair still
+  works for scripting.
 - Settings override files, read by every hook and beating the enable-time
   values: project `.claude/contextnest.local.json` > user
   `~/.contextnest/plugin-settings.json` > `CLAUDE_PLUGIN_OPTION_*` >

--- a/plugins/claude-code/CHANGELOG.md
+++ b/plugins/claude-code/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.2.0
+
+Settings are no longer frozen at enable time (CU-wdqcpzw825).
+
+- New `/contextnest:config` command to view and change `retrieval_mode`,
+  `auto_capture`, `vault`, and `ctx_command` at any time.
+- Settings override files, read by every hook and beating the enable-time
+  values: project `.claude/contextnest.local.json` > user
+  `~/.contextnest/plugin-settings.json` > `CLAUDE_PLUGIN_OPTION_*` >
+  `CONTEXTNEST_*` > defaults. An explicit `"vault": ""` unpins.
+- Missing/malformed override files are ignored — hooks never break a session.
+
 ## 0.1.0
 
 Initial release.

--- a/plugins/claude-code/README.md
+++ b/plugins/claude-code/README.md
@@ -44,10 +44,16 @@ Claude Code only prompts for the settings above once, at enable time. To view
 or change them afterwards, use the config command:
 
 ```text
-/contextnest:config                          # show effective settings + sources
+/contextnest:config                          # show settings, then pick what to change
 /contextnest:config retrieval_mode query     # change for this project
 /contextnest:config auto_capture false --global   # change for all projects
 ```
+
+Run bare `/contextnest:config` and it shows the current settings, then walks you
+through a picker — choose the setting, choose the value from its valid options
+(pinned vault is filled from your registered aliases), and choose the scope. No
+need to remember exact values; typing a `<setting> <value>` pair still works for
+scripting.
 
 Changes are written to a settings override file and take effect on the next
 prompt — no restart or re-enable needed. You can also edit the files directly

--- a/plugins/claude-code/README.md
+++ b/plugins/claude-code/README.md
@@ -38,6 +38,30 @@ On enable you'll be prompted for four settings (all optional):
 | **Pinned vault** | _(empty)_ | A registered vault alias. Empty → the agents pick the relevant vault(s) automatically |
 | **ctx binary** | `ctx` | Override the CLI command |
 
+## Changing settings later
+
+Claude Code only prompts for the settings above once, at enable time. To view
+or change them afterwards, use the config command:
+
+```text
+/contextnest:config                          # show effective settings + sources
+/contextnest:config retrieval_mode query     # change for this project
+/contextnest:config auto_capture false --global   # change for all projects
+```
+
+Changes are written to a settings override file and take effect on the next
+prompt — no restart or re-enable needed. You can also edit the files directly
+(keys: `retrieval_mode`, `auto_capture`, `vault`, `ctx_command`):
+
+| Scope | File | Precedence |
+| --- | --- | --- |
+| Project | `.claude/contextnest.local.json` | highest |
+| User | `~/.contextnest/plugin-settings.json` | beats enable-time values |
+
+A key present in an override file always beats the enable-time answer; an
+explicit `"vault": ""` unpins a pinned vault. Remove a key to fall back to the
+enable-time value (then the default).
+
 ## Components
 
 | Type | Name | Role |
@@ -48,6 +72,7 @@ On enable you'll be prompted for four settings (all optional):
 | Agent | `contextnest-retriever` | Selects vault(s), builds a selector, runs `ctx query`, returns a cited digest |
 | Agent | `contextnest-capture` | Dedupes then writes new nodes via `ctx add`/`ctx update` |
 | Skill | `/contextnest:recall <topic>` | Manual deep retrieval |
+| Command | `/contextnest:config` | View/change plugin settings after enable |
 
 ## Local development
 

--- a/plugins/claude-code/agents/contextnest-capture.md
+++ b/plugins/claude-code/agents/contextnest-capture.md
@@ -25,9 +25,12 @@ durable insight). Staying silent is correct in that case — do not force a writ
 
 ## Procedure
 
-1. **Pick the vault.** If a vault is pinned, use it (`--vault <alias>`). Otherwise
-   run `ctx vault list --json` and choose the vault whose `description` fits the
-   material.
+1. **Pick the vault.** Run `ctx vault list --json` first. If a vault is pinned
+   *and its alias appears in that list*, use it (`--vault <alias>`). If a vault
+   is pinned but its alias is **not** in the list, the pin is stale (the vault
+   was removed or renamed) — ignore it, note the stale pin in your summary, and
+   fall back to choosing the vault whose `description` fits the material. If no
+   vault is pinned, likewise choose by `description`.
 
 2. **Dedupe first.** For each candidate fact, run
    `ctx search "<key terms>" --json`. If a node already covers it, extend that node

--- a/plugins/claude-code/agents/contextnest-retriever.md
+++ b/plugins/claude-code/agents/contextnest-retriever.md
@@ -12,13 +12,15 @@ content — only report what `ctx` returns.
 
 ## Procedure
 
-1. **Pick the vault(s).**
+1. **Pick the vault(s).** Run `ctx vault list --json` first to see what's
+   actually registered.
    - If a vault is pinned (the session overview names a pinned vault, or
-     `CONTEXTNEST_VAULT_ALIAS` is set), use only that one — pass `--vault <alias>`
-     to every command.
-   - Otherwise run `ctx vault list --json` and choose the vault(s) whose
-     `description` best matches the user's topic. Prefer one; use two only when the
-     topic clearly spans them.
+     `CONTEXTNEST_VAULT_ALIAS` is set) *and its alias is in that list*, use only
+     that one — pass `--vault <alias>` to every command.
+   - If a pinned alias is **not** in the list, the pin is stale (the vault was
+     removed or renamed) — ignore it and choose by `description` instead.
+   - Otherwise (no pin) choose the vault(s) whose `description` best matches the
+     user's topic. Prefer one; use two only when the topic clearly spans them.
 
 2. **Find seed nodes.** Translate the topic into a selector:
    - Run `ctx search "<topic keywords>" --json` to discover relevant node ids.

--- a/plugins/claude-code/commands/config.md
+++ b/plugins/claude-code/commands/config.md
@@ -28,25 +28,69 @@ Override files (higher wins; both beat enable-time values):
 
 Arguments given: `$ARGUMENTS`
 
-**If no arguments were given** — show current effective settings. Read both
-override files (if present) and the `CLAUDE_PLUGIN_OPTION_RETRIEVAL_MODE`,
-`CLAUDE_PLUGIN_OPTION_AUTO_CAPTURE`, `CLAUDE_PLUGIN_OPTION_VAULT`,
-`CLAUDE_PLUGIN_OPTION_CTX_COMMAND` environment variables, then present a
-small table: each setting, its effective value, and which layer it came from
-(project file / user file / enable-time / default). Mention how to change one:
-`/contextnest:config <setting> <value>`.
+Prefer interactive pickers over asking the user to type. Only `ctx_command`
+takes a free-text value; every other setting has a fixed or enumerable list of
+choices, so present those as a selectable menu (the `AskUserQuestion` tool)
+rather than making the user remember and type an exact string.
 
-**If a setting and value were given** — apply the change:
+### Step 1 — always show current effective settings first
 
-1. Validate: the key must be one of the four above; `retrieval_mode` must be
-   one of `off|search|query|agent`; `auto_capture` must parse as a boolean.
+Read both override files (if present) and the
+`CLAUDE_PLUGIN_OPTION_RETRIEVAL_MODE`, `CLAUDE_PLUGIN_OPTION_AUTO_CAPTURE`,
+`CLAUDE_PLUGIN_OPTION_VAULT`, `CLAUDE_PLUGIN_OPTION_CTX_COMMAND` environment
+variables, then present a small table: each setting, its effective value, and
+which layer it came from (project file / user file / enable-time / default).
+
+### Step 2 — decide how the change is specified
+
+**If a valid `<setting> <value>` pair was given as arguments** — skip the
+pickers and go straight to *Apply the change* below. This keeps the command
+scriptable.
+
+**Otherwise (no arguments, or a setting named without a valid value)** — drive
+the change interactively with `AskUserQuestion`:
+
+1. **Which setting** — if the user didn't already name one, ask which setting
+   to change with one question whose options are `retrieval_mode`,
+   `auto_capture`, `vault`, `ctx_command` (label each with its current value).
+2. **Which value** — ask a follow-up whose options are that setting's choices:
+   - `retrieval_mode` → `off`, `search`, `query`, `agent` (describe each:
+     off = no injection, search = cheap full-text, query = graph, agent = full
+     reasoning).
+   - `auto_capture` → `true`, `false`.
+   - `vault` → enumerate the registered vault aliases by running
+     `<ctx_command> vault list --json` (fall back to `ctx vault list --json`);
+     offer each alias as an option (label it with its description), plus an
+     **Unpin (auto-select)** option that maps to the empty string `""`. Never
+     make the user type an alias.
+   - `ctx_command` → this one is free-form; ask the user to type the command
+     (the picker doesn't apply). The "Other" free-text answer on any question
+     also lets a user supply a value not in the list.
+3. **Which scope** — if `--global` was not passed as an argument, ask whether
+   this applies to **This project only** (`.claude/contextnest.local.json`) or
+   **All projects** (`~/.contextnest/plugin-settings.json`).
+
+### Step 3 — apply the change
+
+1. Validate — the key must be one of the four, and its value must pass:
+   - `retrieval_mode` → one of `off|search|query|agent` (case-insensitive).
+   - `auto_capture` → a boolean spelling: `true|1|yes|on` or `false|0|no|off`.
+   - `vault` → either the empty string `""` (unpin) or a registered alias.
+     Check membership by running `<ctx_command> vault list --json` (fall back
+     to `ctx vault list --json`); reject an alias that isn't registered and
+     show the available aliases. The alias shape is `[A-Za-z0-9_-]+`.
+   - `ctx_command` → a non-empty string.
+
    On invalid input, say what's wrong and stop — do not write anything.
-2. Pick the target file: `.claude/contextnest.local.json` in the project root
-   by default, or `~/.contextnest/plugin-settings.json` when `--global` was
-   passed.
+   (Picker-sourced values are already valid; still validate free-text/`Other`
+   answers.)
+2. Target file: `.claude/contextnest.local.json` in the project root for
+   project scope, or `~/.contextnest/plugin-settings.json` for global scope
+   (`--global` or the "All projects" choice).
 3. Read the existing file if present, merge the new key (preserve other keys),
    and write it back as pretty-printed JSON. Create the parent directory if
-   needed.
+   needed. For **Unpin**, write `"vault": ""` explicitly — the empty string is
+   honoured as a deliberate unpin.
 4. Confirm to the user: the new value, the file written, and that it takes
    effect from the next prompt in any session — no restart or re-enable
    needed. To undo, remove the key from that file.

--- a/plugins/claude-code/commands/config.md
+++ b/plugins/claude-code/commands/config.md
@@ -91,6 +91,11 @@ the change interactively with `AskUserQuestion`:
    and write it back as pretty-printed JSON. Create the parent directory if
    needed. For **Unpin**, write `"vault": ""` explicitly — the empty string is
    honoured as a deliberate unpin.
-4. Confirm to the user: the new value, the file written, and that it takes
+4. For project scope, make sure `.claude/contextnest.local.json` is ignored by
+   git — it is a personal, per-checkout override and must not be committed.
+   If the project is a git repo and the path isn't already ignored (check with
+   `git check-ignore -q .claude/contextnest.local.json`), append it to the
+   repo's `.gitignore`.
+5. Confirm to the user: the new value, the file written, and that it takes
    effect from the next prompt in any session — no restart or re-enable
    needed. To undo, remove the key from that file.

--- a/plugins/claude-code/commands/config.md
+++ b/plugins/claude-code/commands/config.md
@@ -1,0 +1,52 @@
+---
+description: View or change Context Nest plugin settings (retrieval effort, auto-capture, pinned vault, ctx binary) without re-enabling the plugin.
+argument-hint: "[<setting> <value>] [--global]"
+---
+
+# Context Nest plugin settings
+
+Claude Code only prompts for this plugin's settings once, when it is enabled.
+This command lets the user view and change them at any time by writing a
+settings override file that the plugin's hooks read on every invocation
+(overrides beat the frozen enable-time values).
+
+Settings and valid values:
+
+| Key | Values | Meaning |
+|-----|--------|---------|
+| `retrieval_mode` | `off` \| `search` \| `query` \| `agent` | Retrieval effort per prompt |
+| `auto_capture` | `true` \| `false` | Persist new knowledge at end of turn |
+| `vault` | registered vault alias, or `""` to unpin | Pinned vault |
+| `ctx_command` | any command string | Override the `ctx` binary |
+
+Override files (higher wins; both beat enable-time values):
+
+1. Project: `.claude/contextnest.local.json` (in the project root)
+2. User: `~/.contextnest/plugin-settings.json`
+
+## What to do
+
+Arguments given: `$ARGUMENTS`
+
+**If no arguments were given** — show current effective settings. Read both
+override files (if present) and the `CLAUDE_PLUGIN_OPTION_RETRIEVAL_MODE`,
+`CLAUDE_PLUGIN_OPTION_AUTO_CAPTURE`, `CLAUDE_PLUGIN_OPTION_VAULT`,
+`CLAUDE_PLUGIN_OPTION_CTX_COMMAND` environment variables, then present a
+small table: each setting, its effective value, and which layer it came from
+(project file / user file / enable-time / default). Mention how to change one:
+`/contextnest:config <setting> <value>`.
+
+**If a setting and value were given** — apply the change:
+
+1. Validate: the key must be one of the four above; `retrieval_mode` must be
+   one of `off|search|query|agent`; `auto_capture` must parse as a boolean.
+   On invalid input, say what's wrong and stop — do not write anything.
+2. Pick the target file: `.claude/contextnest.local.json` in the project root
+   by default, or `~/.contextnest/plugin-settings.json` when `--global` was
+   passed.
+3. Read the existing file if present, merge the new key (preserve other keys),
+   and write it back as pretty-printed JSON. Create the parent directory if
+   needed.
+4. Confirm to the user: the new value, the file written, and that it takes
+   effect from the next prompt in any session — no restart or re-enable
+   needed. To undo, remove the key from that file.

--- a/plugins/claude-code/core/lib.js
+++ b/plugins/claude-code/core/lib.js
@@ -27,6 +27,29 @@ export const PROJECT_SETTINGS_FILE = join(".claude", "contextnest.local.json");
 export const USER_SETTINGS_FILE = join(".contextnest", "plugin-settings.json");
 
 /**
+ * The only accepted retrieval_mode values. Anything else (a typo, a stale
+ * value, `SEARCH` in the wrong case) is treated as if the key were absent, so
+ * it can never silently degrade to the wrong tier. Shared so the command and
+ * tests validate against the same source of truth.
+ */
+export const VALID_RETRIEVAL_MODES = ["off", "search", "query", "agent"];
+
+/** Recognized truthy / falsy spellings for the boolean auto_capture setting. */
+export const TRUTHY_VALUES = ["true", "1", "yes", "on"];
+export const FALSY_VALUES = ["false", "0", "no", "off"];
+
+/**
+ * Valid shape for a pinned vault alias — mirrors the engine's ALIAS_PATTERN
+ * (packages/engine/src/registry.ts), the single source of truth for what ctx
+ * accepts. Plugins can't import the engine (they run as standalone vendored
+ * JS), so the rule is duplicated here. An empty string is handled separately:
+ * it is the deliberate "unpin" value, not a malformed alias. Note this only
+ * validates *shape*; whether the alias is actually registered is checked by
+ * the /contextnest:config command, which can consult the registry.
+ */
+export const ALIAS_PATTERN = /^[a-zA-Z0-9_-]+$/;
+
+/**
  * Read a settings override file. Missing or malformed files are silently
  * ignored (hooks must never break a session), as is anything that isn't a
  * plain JSON object.
@@ -69,42 +92,85 @@ export function getConfig(env = process.env, opts = {}) {
     readSettingsFile(join(home, USER_SETTINGS_FILE)),
   ];
 
-  const pick = (fileKey, ...envKeys) => {
+  // Resolve one setting across the layers. `envKeys` is scanned after the
+  // files. `opts.normalize` transforms a raw value before it is validated and
+  // returned; `opts.accept` rejects invalid values — a rejected value is
+  // skipped as if that layer never set the key, so resolution falls through to
+  // the next layer (and ultimately the default). File layers honour an empty
+  // string (e.g. vault:"" unpins); env layers treat "" as absent, as before.
+  const pick = (fileKey, envKeys = [], opts = {}) => {
+    const finalize = (raw) => {
+      const v = opts.normalize ? opts.normalize(String(raw)) : String(raw);
+      return opts.accept && !opts.accept(v) ? undefined : v;
+    };
     for (const layer of fileLayers) {
-      const v = layer[fileKey];
-      if (v !== undefined && v !== null) return String(v);
+      const raw = layer[fileKey];
+      if (raw !== undefined && raw !== null) {
+        const v = finalize(raw);
+        if (v !== undefined) return v;
+      }
     }
     for (const k of envKeys) {
-      const v = env[k];
-      if (v !== undefined && v !== "") return v;
+      const raw = env[k];
+      if (raw !== undefined && raw !== "") {
+        const v = finalize(raw);
+        if (v !== undefined) return v;
+      }
     }
     return undefined;
   };
 
+  // Accept only recognized boolean spellings; a garbage value ("banana", "2")
+  // is skipped per layer so it can neither be mistaken for a boolean nor mask
+  // a valid lower-precedence value. JSON booleans arrive as "true"/"false".
   const rawAuto = pick(
     "auto_capture",
-    "CLAUDE_PLUGIN_OPTION_AUTO_CAPTURE",
-    "CONTEXTNEST_AUTO_CAPTURE",
+    ["CLAUDE_PLUGIN_OPTION_AUTO_CAPTURE", "CONTEXTNEST_AUTO_CAPTURE"],
+    {
+      normalize: (s) => s.trim().toLowerCase(),
+      accept: (s) => TRUTHY_VALUES.includes(s) || FALSY_VALUES.includes(s),
+    },
   );
 
+  // Accept the unpin sentinel "" or a shape-valid alias; a malformed alias
+  // ("my vault", "a/b", "..") is skipped so it can't reach ctx as a bad
+  // --vault arg. Registry membership is verified by the config command.
   const rawVault = pick(
     "vault",
-    "CLAUDE_PLUGIN_OPTION_VAULT",
-    "CONTEXTNEST_VAULT_ALIAS",
+    ["CLAUDE_PLUGIN_OPTION_VAULT", "CONTEXTNEST_VAULT_ALIAS"],
+    {
+      normalize: (s) => s.trim(),
+      accept: (s) => s === "" || ALIAS_PATTERN.test(s),
+    },
   );
 
   return {
-    retrievalMode: (
-      pick("retrieval_mode", "CLAUDE_PLUGIN_OPTION_RETRIEVAL_MODE", "CONTEXTNEST_RETRIEVAL_MODE") ||
-      "search"
-    ).toLowerCase(),
-    // Default ON. Only an explicit false/0/no disables it.
-    autoCapture: rawAuto === undefined ? true : !/^(false|0|no|off)$/i.test(rawAuto),
+    // Invalid values are skipped per layer (see pick), so this only ever
+    // yields a known mode or the "search" default — never a bogus string.
+    retrievalMode:
+      pick(
+        "retrieval_mode",
+        ["CLAUDE_PLUGIN_OPTION_RETRIEVAL_MODE", "CONTEXTNEST_RETRIEVAL_MODE"],
+        {
+          normalize: (s) => s.trim().toLowerCase(),
+          accept: (s) => VALID_RETRIEVAL_MODES.includes(s),
+        },
+      ) || "search",
+    // Default ON. Only a recognized falsy value disables it.
+    autoCapture: rawAuto === undefined ? true : TRUTHY_VALUES.includes(rawAuto),
     // Pinned vault alias. Deliberately NOT named CONTEXTNEST_VAULT so it never
     // collides with the env var the ctx CLI itself consumes for resolution.
     vault: rawVault === undefined ? "" : rawVault,
+    // Command used to invoke ctx. Trimmed; a blank value is skipped so it
+    // falls back to the "ctx" default (which itself npx-falls-back on ENOENT).
+    // Internal whitespace is allowed — execFileSync runs the whole string as
+    // argv[0], so a path containing spaces is legitimate.
     ctxCommand:
-      pick("ctx_command", "CLAUDE_PLUGIN_OPTION_CTX_COMMAND", "CONTEXTNEST_CTX_COMMAND") || "ctx",
+      pick(
+        "ctx_command",
+        ["CLAUDE_PLUGIN_OPTION_CTX_COMMAND", "CONTEXTNEST_CTX_COMMAND"],
+        { normalize: (s) => s.trim(), accept: (s) => s.length > 0 },
+      ) || "ctx",
   };
 }
 
@@ -191,9 +257,25 @@ export function listVaults(exec) {
 }
 
 /**
+ * True when `alias` names a vault that is registered AND present on disk.
+ * `getConfig` only checks the alias *shape*; this is the registry check that
+ * needs the live `ctx` registry, so it lives with the exec-taking helpers.
+ *
+ * @param {string} alias
+ * @param {(args:string[]) => any} exec
+ */
+export function isVaultRegistered(alias, exec) {
+  if (!alias) return false;
+  return listVaults(exec).some((v) => v.alias === alias && v.exists !== false);
+}
+
+/**
  * Decide which vault aliases the cheap (non-agent) tiers should search.
  *
- *  - Pinned alias set        → just that alias.
+ *  - Pinned alias, registered → just that alias.
+ *  - Pinned alias, NOT registered (stale/removed pin) → ignore the pin and
+ *    behave as unpinned, rather than passing ctx a bad --vault that resolves to
+ *    nothing. session-start surfaces a warning so this isn't silent.
  *  - Unpinned + registry     → fan out across registered vaults (capped).
  *  - Unpinned + empty registry → a single null target, i.e. let ctx resolve the
  *                                 local/default vault with no --vault flag.
@@ -203,8 +285,10 @@ export function listVaults(exec) {
  * @returns {(string|null)[]} list of alias targets (null = ctx default resolution)
  */
 export function vaultTargets(config, exec) {
-  if (config.vault) return [config.vault];
   const vaults = listVaults(exec).filter((v) => v.exists !== false);
+  if (config.vault && vaults.some((v) => v.alias === config.vault)) {
+    return [config.vault];
+  }
   if (vaults.length === 0) return [null];
   return vaults.slice(0, MAX_FANOUT_VAULTS).map((v) => v.alias);
 }

--- a/plugins/claude-code/core/lib.js
+++ b/plugins/claude-code/core/lib.js
@@ -12,24 +12,69 @@
  */
 
 import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { homedir as osHomedir } from "node:os";
+import { join } from "node:path";
 
 /** Default cap on how many registered vaults the cheap tiers fan out across. */
 export const MAX_FANOUT_VAULTS = 5;
 /** Default cap on how many retrieval hits we inject. */
 export const MAX_HITS = 6;
 
+/** Project-level settings override, relative to the project root. */
+export const PROJECT_SETTINGS_FILE = join(".claude", "contextnest.local.json");
+/** User-level settings override, relative to the home directory. */
+export const USER_SETTINGS_FILE = join(".contextnest", "plugin-settings.json");
+
 /**
- * Read plugin configuration from the environment.
+ * Read a settings override file. Missing or malformed files are silently
+ * ignored (hooks must never break a session), as is anything that isn't a
+ * plain JSON object.
+ */
+function readSettingsFile(path) {
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf-8"));
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Read plugin configuration.
  *
- * Claude Code exports userConfig values as CLAUDE_PLUGIN_OPTION_<KEY>. Other
- * agents (Codex/Gemini) that lack a userConfig mechanism can feed the same
- * values via the generic CONTEXTNEST_* fallbacks.
+ * Claude Code collects userConfig answers once at enable time and exports
+ * them as CLAUDE_PLUGIN_OPTION_<KEY> — they cannot be changed afterwards from
+ * within a session. Settings override files exist so users CAN change them
+ * later (via /contextnest:config or by editing the file); a key present in a
+ * file therefore beats the frozen env value. Precedence, highest first:
+ *
+ *   1. <project>/.claude/contextnest.local.json
+ *   2. ~/.contextnest/plugin-settings.json
+ *   3. CLAUDE_PLUGIN_OPTION_* env (enable-time answers)
+ *   4. CONTEXTNEST_* env (generic fallbacks for Codex/Gemini adapters)
+ *   5. defaults
+ *
+ * File keys mirror the manifest: retrieval_mode, auto_capture, vault,
+ * ctx_command. An explicit "" in a file is honoured (e.g. vault:"" unpins).
  *
  * @param {Record<string, string | undefined>} env
+ * @param {{ cwd?: string, homedir?: string }} [opts] injection points for tests
  */
-export function getConfig(env = process.env) {
-  const pick = (...keys) => {
-    for (const k of keys) {
+export function getConfig(env = process.env, opts = {}) {
+  const cwd = opts.cwd || env.CLAUDE_PROJECT_DIR || process.cwd();
+  const home = opts.homedir || osHomedir();
+  const fileLayers = [
+    readSettingsFile(join(cwd, PROJECT_SETTINGS_FILE)),
+    readSettingsFile(join(home, USER_SETTINGS_FILE)),
+  ];
+
+  const pick = (fileKey, ...envKeys) => {
+    for (const layer of fileLayers) {
+      const v = layer[fileKey];
+      if (v !== undefined && v !== null) return String(v);
+    }
+    for (const k of envKeys) {
       const v = env[k];
       if (v !== undefined && v !== "") return v;
     }
@@ -37,22 +82,29 @@ export function getConfig(env = process.env) {
   };
 
   const rawAuto = pick(
+    "auto_capture",
     "CLAUDE_PLUGIN_OPTION_AUTO_CAPTURE",
     "CONTEXTNEST_AUTO_CAPTURE",
   );
 
+  const rawVault = pick(
+    "vault",
+    "CLAUDE_PLUGIN_OPTION_VAULT",
+    "CONTEXTNEST_VAULT_ALIAS",
+  );
+
   return {
     retrievalMode: (
-      pick("CLAUDE_PLUGIN_OPTION_RETRIEVAL_MODE", "CONTEXTNEST_RETRIEVAL_MODE") ||
+      pick("retrieval_mode", "CLAUDE_PLUGIN_OPTION_RETRIEVAL_MODE", "CONTEXTNEST_RETRIEVAL_MODE") ||
       "search"
     ).toLowerCase(),
     // Default ON. Only an explicit false/0/no disables it.
     autoCapture: rawAuto === undefined ? true : !/^(false|0|no|off)$/i.test(rawAuto),
     // Pinned vault alias. Deliberately NOT named CONTEXTNEST_VAULT so it never
     // collides with the env var the ctx CLI itself consumes for resolution.
-    vault: pick("CLAUDE_PLUGIN_OPTION_VAULT", "CONTEXTNEST_VAULT_ALIAS") || "",
+    vault: rawVault === undefined ? "" : rawVault,
     ctxCommand:
-      pick("CLAUDE_PLUGIN_OPTION_CTX_COMMAND", "CONTEXTNEST_CTX_COMMAND") || "ctx",
+      pick("ctx_command", "CLAUDE_PLUGIN_OPTION_CTX_COMMAND", "CONTEXTNEST_CTX_COMMAND") || "ctx",
   };
 }
 

--- a/plugins/claude-code/core/lib.js
+++ b/plugins/claude-code/core/lib.js
@@ -258,15 +258,17 @@ export function listVaults(exec) {
 
 /**
  * True when `alias` names a vault that is registered AND present on disk.
- * `getConfig` only checks the alias *shape*; this is the registry check that
- * needs the live `ctx` registry, so it lives with the exec-taking helpers.
+ * `getConfig` only checks the alias *shape*; this is the registry check.
+ * Takes the already-fetched `listVaults` result so callers that need the list
+ * anyway (vaultTargets, session-start) share this predicate instead of each
+ * re-running `vault list` — and instead of each inlining the same `.some(...)`.
  *
  * @param {string} alias
- * @param {(args:string[]) => any} exec
+ * @param {{alias: string, exists?: boolean}[]} vaults from listVaults()
  */
-export function isVaultRegistered(alias, exec) {
+export function isVaultRegistered(alias, vaults) {
   if (!alias) return false;
-  return listVaults(exec).some((v) => v.alias === alias && v.exists !== false);
+  return vaults.some((v) => v.alias === alias && v.exists !== false);
 }
 
 /**
@@ -286,9 +288,7 @@ export function isVaultRegistered(alias, exec) {
  */
 export function vaultTargets(config, exec) {
   const vaults = listVaults(exec).filter((v) => v.exists !== false);
-  if (config.vault && vaults.some((v) => v.alias === config.vault)) {
-    return [config.vault];
-  }
+  if (isVaultRegistered(config.vault, vaults)) return [config.vault];
   if (vaults.length === 0) return [null];
   return vaults.slice(0, MAX_FANOUT_VAULTS).map((v) => v.alias);
 }

--- a/plugins/claude-code/core/session-start.js
+++ b/plugins/claude-code/core/session-start.js
@@ -10,6 +10,7 @@
 import {
   getConfig,
   ctxJson,
+  isVaultRegistered,
   squish,
   runAsHook,
   isMain,
@@ -42,8 +43,7 @@ export function run({ env, exec }) {
   // A pin is only honoured if it still resolves to a registered vault; it may
   // have been removed or renamed since it was set. Warn loudly on a stale pin —
   // retrieval falls back to automatic selection (see vaultTargets).
-  const pinnedIsRegistered =
-    config.vault && vaults.some((v) => v.alias === config.vault && v.exists !== false);
+  const pinnedIsRegistered = isVaultRegistered(config.vault, vaults);
 
   if (config.vault && !pinnedIsRegistered) {
     lines.push(

--- a/plugins/claude-code/core/session-start.js
+++ b/plugins/claude-code/core/session-start.js
@@ -39,7 +39,19 @@ export function run({ env, exec }) {
 
   const lines = ["Context Nest is active for this session."];
 
-  if (config.vault) {
+  // A pin is only honoured if it still resolves to a registered vault; it may
+  // have been removed or renamed since it was set. Warn loudly on a stale pin —
+  // retrieval falls back to automatic selection (see vaultTargets).
+  const pinnedIsRegistered =
+    config.vault && vaults.some((v) => v.alias === config.vault && v.exists !== false);
+
+  if (config.vault && !pinnedIsRegistered) {
+    lines.push(
+      `⚠ Pinned vault \`${config.vault}\` is not a registered vault (removed, renamed, or ` +
+        `misspelled). Retrieval and capture fall back to automatic vault selection. Fix it with ` +
+        `\`/contextnest:config vault <alias>\` (or re-register the vault with \`ctx vault add\`).`,
+    );
+  } else if (config.vault) {
     lines.push(`Pinned vault: \`${config.vault}\` (all queries/captures use it).`);
   }
 

--- a/plugins/claude-code/package.json
+++ b/plugins/claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@promptowl/contextnest-claude-plugin",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "description": "Claude Code plugin for Context Nest — vault-aware retrieval + automatic capture via the ctx CLI",

--- a/plugins/claude-code/skills/recall/SKILL.md
+++ b/plugins/claude-code/skills/recall/SKILL.md
@@ -12,9 +12,11 @@ Deeply retrieve context from the **Context Nest** vault for the topic in
 
 ## Steps
 
-1. **Choose the vault.** If a vault is pinned, use it (`--vault <alias>`).
-   Otherwise `ctx vault list --json` and pick the vault(s) whose `description`
-   matches `$ARGUMENTS`.
+1. **Choose the vault.** Run `ctx vault list --json` first. If a vault is pinned
+   *and its alias is in that list*, use it (`--vault <alias>`). If a pinned alias
+   is **not** listed, the pin is stale — ignore it and pick the vault(s) whose
+   `description` matches `$ARGUMENTS`. If no vault is pinned, likewise pick by
+   `description`.
 
 2. **Build a selector.** Run `ctx search "$ARGUMENTS" --json` for seed node ids,
    map ids → tags via `ctx list --json`, and form a tag selector

--- a/plugins/shared/core/lib.js
+++ b/plugins/shared/core/lib.js
@@ -27,6 +27,29 @@ export const PROJECT_SETTINGS_FILE = join(".claude", "contextnest.local.json");
 export const USER_SETTINGS_FILE = join(".contextnest", "plugin-settings.json");
 
 /**
+ * The only accepted retrieval_mode values. Anything else (a typo, a stale
+ * value, `SEARCH` in the wrong case) is treated as if the key were absent, so
+ * it can never silently degrade to the wrong tier. Shared so the command and
+ * tests validate against the same source of truth.
+ */
+export const VALID_RETRIEVAL_MODES = ["off", "search", "query", "agent"];
+
+/** Recognized truthy / falsy spellings for the boolean auto_capture setting. */
+export const TRUTHY_VALUES = ["true", "1", "yes", "on"];
+export const FALSY_VALUES = ["false", "0", "no", "off"];
+
+/**
+ * Valid shape for a pinned vault alias — mirrors the engine's ALIAS_PATTERN
+ * (packages/engine/src/registry.ts), the single source of truth for what ctx
+ * accepts. Plugins can't import the engine (they run as standalone vendored
+ * JS), so the rule is duplicated here. An empty string is handled separately:
+ * it is the deliberate "unpin" value, not a malformed alias. Note this only
+ * validates *shape*; whether the alias is actually registered is checked by
+ * the /contextnest:config command, which can consult the registry.
+ */
+export const ALIAS_PATTERN = /^[a-zA-Z0-9_-]+$/;
+
+/**
  * Read a settings override file. Missing or malformed files are silently
  * ignored (hooks must never break a session), as is anything that isn't a
  * plain JSON object.
@@ -69,42 +92,85 @@ export function getConfig(env = process.env, opts = {}) {
     readSettingsFile(join(home, USER_SETTINGS_FILE)),
   ];
 
-  const pick = (fileKey, ...envKeys) => {
+  // Resolve one setting across the layers. `envKeys` is scanned after the
+  // files. `opts.normalize` transforms a raw value before it is validated and
+  // returned; `opts.accept` rejects invalid values — a rejected value is
+  // skipped as if that layer never set the key, so resolution falls through to
+  // the next layer (and ultimately the default). File layers honour an empty
+  // string (e.g. vault:"" unpins); env layers treat "" as absent, as before.
+  const pick = (fileKey, envKeys = [], opts = {}) => {
+    const finalize = (raw) => {
+      const v = opts.normalize ? opts.normalize(String(raw)) : String(raw);
+      return opts.accept && !opts.accept(v) ? undefined : v;
+    };
     for (const layer of fileLayers) {
-      const v = layer[fileKey];
-      if (v !== undefined && v !== null) return String(v);
+      const raw = layer[fileKey];
+      if (raw !== undefined && raw !== null) {
+        const v = finalize(raw);
+        if (v !== undefined) return v;
+      }
     }
     for (const k of envKeys) {
-      const v = env[k];
-      if (v !== undefined && v !== "") return v;
+      const raw = env[k];
+      if (raw !== undefined && raw !== "") {
+        const v = finalize(raw);
+        if (v !== undefined) return v;
+      }
     }
     return undefined;
   };
 
+  // Accept only recognized boolean spellings; a garbage value ("banana", "2")
+  // is skipped per layer so it can neither be mistaken for a boolean nor mask
+  // a valid lower-precedence value. JSON booleans arrive as "true"/"false".
   const rawAuto = pick(
     "auto_capture",
-    "CLAUDE_PLUGIN_OPTION_AUTO_CAPTURE",
-    "CONTEXTNEST_AUTO_CAPTURE",
+    ["CLAUDE_PLUGIN_OPTION_AUTO_CAPTURE", "CONTEXTNEST_AUTO_CAPTURE"],
+    {
+      normalize: (s) => s.trim().toLowerCase(),
+      accept: (s) => TRUTHY_VALUES.includes(s) || FALSY_VALUES.includes(s),
+    },
   );
 
+  // Accept the unpin sentinel "" or a shape-valid alias; a malformed alias
+  // ("my vault", "a/b", "..") is skipped so it can't reach ctx as a bad
+  // --vault arg. Registry membership is verified by the config command.
   const rawVault = pick(
     "vault",
-    "CLAUDE_PLUGIN_OPTION_VAULT",
-    "CONTEXTNEST_VAULT_ALIAS",
+    ["CLAUDE_PLUGIN_OPTION_VAULT", "CONTEXTNEST_VAULT_ALIAS"],
+    {
+      normalize: (s) => s.trim(),
+      accept: (s) => s === "" || ALIAS_PATTERN.test(s),
+    },
   );
 
   return {
-    retrievalMode: (
-      pick("retrieval_mode", "CLAUDE_PLUGIN_OPTION_RETRIEVAL_MODE", "CONTEXTNEST_RETRIEVAL_MODE") ||
-      "search"
-    ).toLowerCase(),
-    // Default ON. Only an explicit false/0/no disables it.
-    autoCapture: rawAuto === undefined ? true : !/^(false|0|no|off)$/i.test(rawAuto),
+    // Invalid values are skipped per layer (see pick), so this only ever
+    // yields a known mode or the "search" default — never a bogus string.
+    retrievalMode:
+      pick(
+        "retrieval_mode",
+        ["CLAUDE_PLUGIN_OPTION_RETRIEVAL_MODE", "CONTEXTNEST_RETRIEVAL_MODE"],
+        {
+          normalize: (s) => s.trim().toLowerCase(),
+          accept: (s) => VALID_RETRIEVAL_MODES.includes(s),
+        },
+      ) || "search",
+    // Default ON. Only a recognized falsy value disables it.
+    autoCapture: rawAuto === undefined ? true : TRUTHY_VALUES.includes(rawAuto),
     // Pinned vault alias. Deliberately NOT named CONTEXTNEST_VAULT so it never
     // collides with the env var the ctx CLI itself consumes for resolution.
     vault: rawVault === undefined ? "" : rawVault,
+    // Command used to invoke ctx. Trimmed; a blank value is skipped so it
+    // falls back to the "ctx" default (which itself npx-falls-back on ENOENT).
+    // Internal whitespace is allowed — execFileSync runs the whole string as
+    // argv[0], so a path containing spaces is legitimate.
     ctxCommand:
-      pick("ctx_command", "CLAUDE_PLUGIN_OPTION_CTX_COMMAND", "CONTEXTNEST_CTX_COMMAND") || "ctx",
+      pick(
+        "ctx_command",
+        ["CLAUDE_PLUGIN_OPTION_CTX_COMMAND", "CONTEXTNEST_CTX_COMMAND"],
+        { normalize: (s) => s.trim(), accept: (s) => s.length > 0 },
+      ) || "ctx",
   };
 }
 
@@ -191,9 +257,25 @@ export function listVaults(exec) {
 }
 
 /**
+ * True when `alias` names a vault that is registered AND present on disk.
+ * `getConfig` only checks the alias *shape*; this is the registry check that
+ * needs the live `ctx` registry, so it lives with the exec-taking helpers.
+ *
+ * @param {string} alias
+ * @param {(args:string[]) => any} exec
+ */
+export function isVaultRegistered(alias, exec) {
+  if (!alias) return false;
+  return listVaults(exec).some((v) => v.alias === alias && v.exists !== false);
+}
+
+/**
  * Decide which vault aliases the cheap (non-agent) tiers should search.
  *
- *  - Pinned alias set        → just that alias.
+ *  - Pinned alias, registered → just that alias.
+ *  - Pinned alias, NOT registered (stale/removed pin) → ignore the pin and
+ *    behave as unpinned, rather than passing ctx a bad --vault that resolves to
+ *    nothing. session-start surfaces a warning so this isn't silent.
  *  - Unpinned + registry     → fan out across registered vaults (capped).
  *  - Unpinned + empty registry → a single null target, i.e. let ctx resolve the
  *                                 local/default vault with no --vault flag.
@@ -203,8 +285,10 @@ export function listVaults(exec) {
  * @returns {(string|null)[]} list of alias targets (null = ctx default resolution)
  */
 export function vaultTargets(config, exec) {
-  if (config.vault) return [config.vault];
   const vaults = listVaults(exec).filter((v) => v.exists !== false);
+  if (config.vault && vaults.some((v) => v.alias === config.vault)) {
+    return [config.vault];
+  }
   if (vaults.length === 0) return [null];
   return vaults.slice(0, MAX_FANOUT_VAULTS).map((v) => v.alias);
 }

--- a/plugins/shared/core/lib.js
+++ b/plugins/shared/core/lib.js
@@ -12,24 +12,69 @@
  */
 
 import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { homedir as osHomedir } from "node:os";
+import { join } from "node:path";
 
 /** Default cap on how many registered vaults the cheap tiers fan out across. */
 export const MAX_FANOUT_VAULTS = 5;
 /** Default cap on how many retrieval hits we inject. */
 export const MAX_HITS = 6;
 
+/** Project-level settings override, relative to the project root. */
+export const PROJECT_SETTINGS_FILE = join(".claude", "contextnest.local.json");
+/** User-level settings override, relative to the home directory. */
+export const USER_SETTINGS_FILE = join(".contextnest", "plugin-settings.json");
+
 /**
- * Read plugin configuration from the environment.
+ * Read a settings override file. Missing or malformed files are silently
+ * ignored (hooks must never break a session), as is anything that isn't a
+ * plain JSON object.
+ */
+function readSettingsFile(path) {
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf-8"));
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Read plugin configuration.
  *
- * Claude Code exports userConfig values as CLAUDE_PLUGIN_OPTION_<KEY>. Other
- * agents (Codex/Gemini) that lack a userConfig mechanism can feed the same
- * values via the generic CONTEXTNEST_* fallbacks.
+ * Claude Code collects userConfig answers once at enable time and exports
+ * them as CLAUDE_PLUGIN_OPTION_<KEY> — they cannot be changed afterwards from
+ * within a session. Settings override files exist so users CAN change them
+ * later (via /contextnest:config or by editing the file); a key present in a
+ * file therefore beats the frozen env value. Precedence, highest first:
+ *
+ *   1. <project>/.claude/contextnest.local.json
+ *   2. ~/.contextnest/plugin-settings.json
+ *   3. CLAUDE_PLUGIN_OPTION_* env (enable-time answers)
+ *   4. CONTEXTNEST_* env (generic fallbacks for Codex/Gemini adapters)
+ *   5. defaults
+ *
+ * File keys mirror the manifest: retrieval_mode, auto_capture, vault,
+ * ctx_command. An explicit "" in a file is honoured (e.g. vault:"" unpins).
  *
  * @param {Record<string, string | undefined>} env
+ * @param {{ cwd?: string, homedir?: string }} [opts] injection points for tests
  */
-export function getConfig(env = process.env) {
-  const pick = (...keys) => {
-    for (const k of keys) {
+export function getConfig(env = process.env, opts = {}) {
+  const cwd = opts.cwd || env.CLAUDE_PROJECT_DIR || process.cwd();
+  const home = opts.homedir || osHomedir();
+  const fileLayers = [
+    readSettingsFile(join(cwd, PROJECT_SETTINGS_FILE)),
+    readSettingsFile(join(home, USER_SETTINGS_FILE)),
+  ];
+
+  const pick = (fileKey, ...envKeys) => {
+    for (const layer of fileLayers) {
+      const v = layer[fileKey];
+      if (v !== undefined && v !== null) return String(v);
+    }
+    for (const k of envKeys) {
       const v = env[k];
       if (v !== undefined && v !== "") return v;
     }
@@ -37,22 +82,29 @@ export function getConfig(env = process.env) {
   };
 
   const rawAuto = pick(
+    "auto_capture",
     "CLAUDE_PLUGIN_OPTION_AUTO_CAPTURE",
     "CONTEXTNEST_AUTO_CAPTURE",
   );
 
+  const rawVault = pick(
+    "vault",
+    "CLAUDE_PLUGIN_OPTION_VAULT",
+    "CONTEXTNEST_VAULT_ALIAS",
+  );
+
   return {
     retrievalMode: (
-      pick("CLAUDE_PLUGIN_OPTION_RETRIEVAL_MODE", "CONTEXTNEST_RETRIEVAL_MODE") ||
+      pick("retrieval_mode", "CLAUDE_PLUGIN_OPTION_RETRIEVAL_MODE", "CONTEXTNEST_RETRIEVAL_MODE") ||
       "search"
     ).toLowerCase(),
     // Default ON. Only an explicit false/0/no disables it.
     autoCapture: rawAuto === undefined ? true : !/^(false|0|no|off)$/i.test(rawAuto),
     // Pinned vault alias. Deliberately NOT named CONTEXTNEST_VAULT so it never
     // collides with the env var the ctx CLI itself consumes for resolution.
-    vault: pick("CLAUDE_PLUGIN_OPTION_VAULT", "CONTEXTNEST_VAULT_ALIAS") || "",
+    vault: rawVault === undefined ? "" : rawVault,
     ctxCommand:
-      pick("CLAUDE_PLUGIN_OPTION_CTX_COMMAND", "CONTEXTNEST_CTX_COMMAND") || "ctx",
+      pick("ctx_command", "CLAUDE_PLUGIN_OPTION_CTX_COMMAND", "CONTEXTNEST_CTX_COMMAND") || "ctx",
   };
 }
 

--- a/plugins/shared/core/lib.js
+++ b/plugins/shared/core/lib.js
@@ -258,15 +258,17 @@ export function listVaults(exec) {
 
 /**
  * True when `alias` names a vault that is registered AND present on disk.
- * `getConfig` only checks the alias *shape*; this is the registry check that
- * needs the live `ctx` registry, so it lives with the exec-taking helpers.
+ * `getConfig` only checks the alias *shape*; this is the registry check.
+ * Takes the already-fetched `listVaults` result so callers that need the list
+ * anyway (vaultTargets, session-start) share this predicate instead of each
+ * re-running `vault list` — and instead of each inlining the same `.some(...)`.
  *
  * @param {string} alias
- * @param {(args:string[]) => any} exec
+ * @param {{alias: string, exists?: boolean}[]} vaults from listVaults()
  */
-export function isVaultRegistered(alias, exec) {
+export function isVaultRegistered(alias, vaults) {
   if (!alias) return false;
-  return listVaults(exec).some((v) => v.alias === alias && v.exists !== false);
+  return vaults.some((v) => v.alias === alias && v.exists !== false);
 }
 
 /**
@@ -286,9 +288,7 @@ export function isVaultRegistered(alias, exec) {
  */
 export function vaultTargets(config, exec) {
   const vaults = listVaults(exec).filter((v) => v.exists !== false);
-  if (config.vault && vaults.some((v) => v.alias === config.vault)) {
-    return [config.vault];
-  }
+  if (isVaultRegistered(config.vault, vaults)) return [config.vault];
   if (vaults.length === 0) return [null];
   return vaults.slice(0, MAX_FANOUT_VAULTS).map((v) => v.alias);
 }

--- a/plugins/shared/core/session-start.js
+++ b/plugins/shared/core/session-start.js
@@ -10,6 +10,7 @@
 import {
   getConfig,
   ctxJson,
+  isVaultRegistered,
   squish,
   runAsHook,
   isMain,
@@ -42,8 +43,7 @@ export function run({ env, exec }) {
   // A pin is only honoured if it still resolves to a registered vault; it may
   // have been removed or renamed since it was set. Warn loudly on a stale pin —
   // retrieval falls back to automatic selection (see vaultTargets).
-  const pinnedIsRegistered =
-    config.vault && vaults.some((v) => v.alias === config.vault && v.exists !== false);
+  const pinnedIsRegistered = isVaultRegistered(config.vault, vaults);
 
   if (config.vault && !pinnedIsRegistered) {
     lines.push(

--- a/plugins/shared/core/session-start.js
+++ b/plugins/shared/core/session-start.js
@@ -39,7 +39,19 @@ export function run({ env, exec }) {
 
   const lines = ["Context Nest is active for this session."];
 
-  if (config.vault) {
+  // A pin is only honoured if it still resolves to a registered vault; it may
+  // have been removed or renamed since it was set. Warn loudly on a stale pin —
+  // retrieval falls back to automatic selection (see vaultTargets).
+  const pinnedIsRegistered =
+    config.vault && vaults.some((v) => v.alias === config.vault && v.exists !== false);
+
+  if (config.vault && !pinnedIsRegistered) {
+    lines.push(
+      `⚠ Pinned vault \`${config.vault}\` is not a registered vault (removed, renamed, or ` +
+        `misspelled). Retrieval and capture fall back to automatic vault selection. Fix it with ` +
+        `\`/contextnest:config vault <alias>\` (or re-register the vault with \`ctx vault add\`).`,
+    );
+  } else if (config.vault) {
     lines.push(`Pinned vault: \`${config.vault}\` (all queries/captures use it).`);
   }
 

--- a/plugins/shared/prompts/capture.md
+++ b/plugins/shared/prompts/capture.md
@@ -17,9 +17,12 @@ durable insight). Staying silent is correct in that case — do not force a writ
 
 ## Procedure
 
-1. **Pick the vault.** If a vault is pinned, use it (`--vault <alias>`). Otherwise
-   run `ctx vault list --json` and choose the vault whose `description` fits the
-   material.
+1. **Pick the vault.** Run `ctx vault list --json` first. If a vault is pinned
+   *and its alias appears in that list*, use it (`--vault <alias>`). If a vault
+   is pinned but its alias is **not** in the list, the pin is stale (the vault
+   was removed or renamed) — ignore it, note the stale pin in your summary, and
+   fall back to choosing the vault whose `description` fits the material. If no
+   vault is pinned, likewise choose by `description`.
 
 2. **Dedupe first.** For each candidate fact, run
    `ctx search "<key terms>" --json`. If a node already covers it, extend that node

--- a/plugins/shared/prompts/recall.md
+++ b/plugins/shared/prompts/recall.md
@@ -3,9 +3,11 @@ Deeply retrieve context from the **Context Nest** vault for the topic in
 
 ## Steps
 
-1. **Choose the vault.** If a vault is pinned, use it (`--vault <alias>`).
-   Otherwise `ctx vault list --json` and pick the vault(s) whose `description`
-   matches `$ARGUMENTS`.
+1. **Choose the vault.** Run `ctx vault list --json` first. If a vault is pinned
+   *and its alias is in that list*, use it (`--vault <alias>`). If a pinned alias
+   is **not** listed, the pin is stale — ignore it and pick the vault(s) whose
+   `description` matches `$ARGUMENTS`. If no vault is pinned, likewise pick by
+   `description`.
 
 2. **Build a selector.** Run `ctx search "$ARGUMENTS" --json` for seed node ids,
    map ids → tags via `ctx list --json`, and form a tag selector

--- a/plugins/shared/prompts/retriever.md
+++ b/plugins/shared/prompts/retriever.md
@@ -4,13 +4,15 @@ content — only report what `ctx` returns.
 
 ## Procedure
 
-1. **Pick the vault(s).**
+1. **Pick the vault(s).** Run `ctx vault list --json` first to see what's
+   actually registered.
    - If a vault is pinned (the session overview names a pinned vault, or
-     `CONTEXTNEST_VAULT_ALIAS` is set), use only that one — pass `--vault <alias>`
-     to every command.
-   - Otherwise run `ctx vault list --json` and choose the vault(s) whose
-     `description` best matches the user's topic. Prefer one; use two only when the
-     topic clearly spans them.
+     `CONTEXTNEST_VAULT_ALIAS` is set) *and its alias is in that list*, use only
+     that one — pass `--vault <alias>` to every command.
+   - If a pinned alias is **not** in the list, the pin is stale (the vault was
+     removed or renamed) — ignore it and choose by `description` instead.
+   - Otherwise (no pin) choose the vault(s) whose `description` best matches the
+     user's topic. Prefer one; use two only when the topic clearly spans them.
 
 2. **Find seed nodes.** Translate the topic into a selector:
    - Run `ctx search "<topic keywords>" --json` to discover relevant node ids.


### PR DESCRIPTION
## Problem

ClickUp [CU-wdqcpzw825](https://app.clickup.com/t/wdqcpzw825) — *"claude plugin doesn't let me change its settings"*.

Claude Code prompts for the plugin's four `userConfig` settings (`retrieval_mode`, `auto_capture`, `vault`, `ctx_command`) **once at enable time** and exports them to hooks as frozen `CLAUDE_PLUGIN_OPTION_*` env vars. `getConfig()` read only those env vars, so there was no command, re-prompt, or documented path to ever change a setting afterwards.

## Fix (test-first)

1. **Reproduction commit** adds RED tests encoding the desired behavior (override sources must beat the frozen env; a config entry point must exist) — 6 failing on the old code.
2. **Fix commit** makes them green:
   - `getConfig()` (shared core, vendored via `pnpm plugins:sync`) now layers JSON settings override files above the env. Precedence, highest first: project `.claude/contextnest.local.json` → user `~/.contextnest/plugin-settings.json` → `CLAUDE_PLUGIN_OPTION_*` → `CONTEXTNEST_*` → defaults. A key present in a file wins even when empty (`"vault": ""` unpins); missing/malformed files are silently ignored so hooks never break a session.
   - New **`/contextnest:config`** command: no args shows effective settings + which layer each came from; `<setting> <value>` validates and writes the project file (`--global` for the user file). Changes apply from the next prompt — no restart/re-enable.
   - README "Changing settings later" section, CHANGELOG, version 0.1.0 → 0.2.0.

## Verification

- `plugins` vitest suite: 45/45 green (was 39 passed / 6 RED before the fix); includes the `plugins:check` vendored-sync guard.
- Live hook run: with `CLAUDE_PLUGIN_OPTION_RETRIEVAL_MODE=off` and a project override `{"retrieval_mode":"agent"}`, `core/retrieve.js` emits the retriever directive (file wins); without the file it stays silent (env wins) — the exact change-after-enable journey from the ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
