### PR TITLE
feat(engine): O(N) bulk document import (publishDocuments + context_import)

### DIFF
--- a/.changeset/bulk-publish.md
+++ b/.changeset/bulk-publish.md
@@ -1,0 +1,7 @@
+---
+"@promptowl/contextnest-engine": minor
+---
+
+Add `publishDocuments()` — bulk publish for folder importers.
+
+Publishing a large nest folder one file at a time via `publishDocument` is O(N²): each call seals its own checkpoint, and every checkpoint re-scans the entire vault (`discoverDocuments` + `findAllHistories` + a rewrite of the growing `context_history.yaml`). `publishDocuments(storage, ids, opts)` does the per-doc version work with bounded concurrency but seals **one** checkpoint for the whole batch and regenerates the index **once** — collapsing N full-vault rescans into a single pass. Failure-isolated: a bad/rejected file is reported in `failed[]` and skipped; the rest still publish. `publishDocument` is unchanged.

--- a/.changeset/bulk-publish.md
+++ b/.changeset/bulk-publish.md
@@ -5,3 +5,5 @@
 Add `publishDocuments()` — bulk publish for folder importers.
 
 Publishing a large nest folder one file at a time via `publishDocument` is O(N²): each call seals its own checkpoint, and every checkpoint re-scans the entire vault (`discoverDocuments` + `findAllHistories` + a rewrite of the growing `context_history.yaml`). `publishDocuments(storage, ids, opts)` does the per-doc version work with bounded concurrency but seals **one** checkpoint for the whole batch and regenerates the index **once** — collapsing N full-vault rescans into a single pass. Failure-isolated: a bad/rejected file is reported in `failed[]` and skipped; the rest still publish. `publishDocument` is unchanged.
+
+Also exposes this over the API catalog as the `context_import` core op — bulk create-and-publish from document payloads `{ documents: [{title, content, type?, tags?, folder?, metadata?}] }` → `{ created[], failed[] }`, composing on `publishDocuments` so every binding (agent/CLI/REST) gets one O(N) bulk-import tool. `core` namespace is now 16 ops.

--- a/packages/engine/src/__tests__/api-runtime.test.ts
+++ b/packages/engine/src/__tests__/api-runtime.test.ts
@@ -292,6 +292,54 @@ describe("createEngineApi — executable core operations", () => {
     expect(Array.isArray(out.packs)).toBe(true);
   });
 
+  it("context_import bulk-creates many nodes under ONE checkpoint", async () => {
+    const api = createEngineApi();
+    const documents = Array.from({ length: 6 }, (_, i) => ({
+      title: `Imported ${i}`,
+      content: `body ${i}`,
+      tags: ["#bulk"],
+    }));
+    const out = await api.run<{
+      created: Array<{ id: string; version: number }>;
+      failed: unknown[];
+    }>("context_import", { documents }, ctx);
+
+    expect(out.created).toHaveLength(6);
+    expect(out.failed).toHaveLength(0);
+    expect(out.created.every((c) => c.version === 1)).toBe(true);
+    // Whole batch sealed one checkpoint, not one-per-doc.
+    const history = await ctx.storage.readCheckpointHistory();
+    expect(history?.checkpoints).toHaveLength(1);
+    // Imported docs are published and retrievable.
+    const got = await api.run<{ frontmatter: { status?: string } }>(
+      "context_get",
+      { id: "nodes/imported-0" },
+      ctx,
+    );
+    expect(got.frontmatter.status).toBe("published");
+  });
+
+  it("context_import reports per-document failures without aborting the batch", async () => {
+    const api = createEngineApi();
+    const out = await api.run<{
+      created: Array<{ id: string }>;
+      failed: Array<{ title: string; error: string }>;
+    }>(
+      "context_import",
+      {
+        documents: [
+          { title: "Fine One", content: "b" },
+          { title: "日本語のみ", content: "b" }, // no slug-able chars → fails
+          { title: "Fine Two", content: "b" },
+        ],
+      },
+      ctx,
+    );
+    expect(out.created).toHaveLength(2);
+    expect(out.failed).toHaveLength(1);
+    expect(out.failed[0].title).toBe("日本語のみ");
+  });
+
   it("normalizes tags to #-prefixed form on create (S7)", async () => {
     const api = createEngineApi();
     await api.run("context_create", { title: "Tagged", content: "b", tags: ["api", "ml"] }, ctx);

--- a/packages/engine/src/__tests__/bulk-publish.test.ts
+++ b/packages/engine/src/__tests__/bulk-publish.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { join } from "node:path";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { NestStorage } from "../storage.js";
+import { serializeDocument } from "../parser.js";
+import { publishDocuments } from "../publish.js";
+import type { ContextNode } from "../types.js";
+
+async function makeStorage(): Promise<{ storage: NestStorage; dir: string }> {
+  const dir = await mkdtemp(join(tmpdir(), "contextnest-bulk-"));
+  return { storage: new NestStorage(dir), dir };
+}
+
+/** Write a draft node to disk at nodes/<slug> and return its id. */
+async function writeDraft(
+  storage: NestStorage,
+  slug: string,
+  extra: Partial<ContextNode["frontmatter"]> = {},
+): Promise<string> {
+  const id = `nodes/${slug}`;
+  const node: ContextNode = {
+    id,
+    filePath: "",
+    rawContent: "",
+    frontmatter: { title: slug, type: "document", status: "draft", ...extra },
+    body: `body of ${slug}`,
+  };
+  await storage.writeDocument(id, serializeDocument(node));
+  return id;
+}
+
+describe("publishDocuments — bulk import", () => {
+  let storage: NestStorage;
+  let dir: string;
+
+  beforeEach(async () => {
+    ({ storage, dir } = await makeStorage());
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("publishes N docs and seals exactly ONE checkpoint for the batch", async () => {
+    const ids = [];
+    for (let i = 0; i < 12; i++) ids.push(await writeDraft(storage, `doc-${i}`));
+
+    const result = await publishDocuments(storage, ids, { editedBy: "importer" });
+
+    expect(result.published).toHaveLength(12);
+    expect(result.failed).toHaveLength(0);
+    expect(result.checkpointNumber).toBe(1);
+    // Every published entry carries a version + chain hash.
+    for (const p of result.published) {
+      expect(p.version).toBe(1);
+      expect(p.chainHash).toMatch(/^sha256:[a-f0-9]{64}$/);
+    }
+
+    // The whole batch produced ONE checkpoint, not one-per-doc.
+    const history = await storage.readCheckpointHistory();
+    expect(history?.checkpoints).toHaveLength(1);
+
+    // All docs are actually published on disk.
+    for (const id of ids) {
+      const doc = await storage.readDocument(id);
+      expect(doc.frontmatter.status).toBe("published");
+      expect(doc.frontmatter.version).toBe(1);
+    }
+  });
+
+  it("keeps the hash chains valid after a bulk publish", async () => {
+    const ids = [];
+    for (let i = 0; i < 8; i++) ids.push(await writeDraft(storage, `n-${i}`));
+    await publishDocuments(storage, ids, { editedBy: "importer" });
+
+    const report = await storage.verifyVaultIntegrity();
+    expect(report.valid).toBe(true);
+  });
+
+  it("isolates failures — a rejected doc lands in failed[], the rest publish", async () => {
+    const good1 = await writeDraft(storage, "good-1");
+    const bad = await writeDraft(storage, "retired", { status: "rejected" });
+    const good2 = await writeDraft(storage, "good-2");
+
+    const result = await publishDocuments(storage, [good1, bad, good2], {
+      editedBy: "importer",
+    });
+
+    expect(result.published.map((p) => p.id).sort()).toEqual([good1, good2].sort());
+    expect(result.failed).toHaveLength(1);
+    expect(result.failed[0].id).toBe(bad);
+    // Checkpoint still sealed over the two good docs.
+    expect(result.checkpointNumber).toBe(1);
+    // The rejected doc was never flipped to published.
+    expect((await storage.readDocument(bad)).frontmatter.status).toBe("rejected");
+  });
+
+  it("returns null checkpoint when nothing publishes", async () => {
+    const bad = await writeDraft(storage, "only-rejected", { status: "rejected" });
+    const result = await publishDocuments(storage, [bad], { editedBy: "importer" });
+
+    expect(result.published).toHaveLength(0);
+    expect(result.failed).toHaveLength(1);
+    expect(result.checkpointNumber).toBeNull();
+  });
+});

--- a/packages/engine/src/api/README.md
+++ b/packages/engine/src/api/README.md
@@ -24,12 +24,12 @@ divergence stops at the root.
 | **Extension framework** | `EngineExtension` lets consumers register new ops (governance/workflow/sync) and wrap every op with `authorize` + `onResult`, without forking the engine. |
 | **Namespace discovery** | `NAMESPACES` advertises the implemented set for MCP `initialize` / REST manifest. |
 
-### `core` operations (15)
+### `core` operations (16)
 
 Read: `context_get` · `context_query` · `context_resolve` · `context_list` ·
 `context_search` · `context_overview` · `context_packs` · `context_init`
 Write/lifecycle: `context_create` · `context_update` · `context_publish` ·
-`context_delete`
+`context_delete` · `context_import` (bulk create+publish, one checkpoint)
 History/audit: `context_versions` · `context_reconstruct` · `context_verify`
 
 These cover the operations all three surfaces (OSS MCP, CLI, Community MCP)

--- a/packages/engine/src/api/core-executors.ts
+++ b/packages/engine/src/api/core-executors.ts
@@ -20,7 +20,7 @@ import {
   isRejected,
 } from "../parser.js";
 import { normalizeDocumentId } from "../storage.js";
-import { publishDocument } from "../publish.js";
+import { publishDocument, publishDocuments } from "../publish.js";
 import { parseUri } from "../uri.js";
 import { ContextNestError, RejectedDocumentError } from "../errors.js";
 import type { OperationContext, OperationExecutor } from "./context.js";
@@ -200,10 +200,21 @@ const list: OperationExecutor = async (ctx, input: any) => {
   return { documents: docs.map((d) => toSummary(d)) };
 };
 
-const create: OperationExecutor = async (ctx, input: any) => {
-  // Slugify each folder segment and always root under nodes/ so the doc is
-  // discoverable (normalizeDocumentId only prepends nodes/ when there is no
-  // slash — a raw "gtm/deals/x" would escape the discoverable tree).
+/**
+ * Build a fresh draft node from create/import input. Slugifies each folder
+ * segment and always roots under nodes/ so the doc is discoverable
+ * (normalizeDocumentId only prepends nodes/ when there is no slash — a raw
+ * "gtm/deals/x" would escape the discoverable tree). Shared by `create` and
+ * the bulk `import` executor so their node shape stays identical.
+ */
+function buildDraftNode(input: {
+  title: string;
+  content: string;
+  type?: string;
+  tags?: unknown[];
+  folder?: string;
+  metadata?: Record<string, unknown>;
+}): ContextNode {
   const folderSegments = String(input.folder ?? "")
     .split("/")
     .map(slugify)
@@ -211,20 +222,24 @@ const create: OperationExecutor = async (ctx, input: any) => {
   const id = normalizeDocumentId(["nodes", ...folderSegments, requireSlug(input.title)].join("/"));
   const frontmatter: Frontmatter = {
     title: input.title,
-    type: input.type ?? "document",
+    type: (input.type as Frontmatter["type"]) ?? "document",
     ...(input.tags ? { tags: normalizeUniqueTags(input.tags) } : {}),
     ...(input.metadata ? { metadata: input.metadata } : {}),
     status: "draft",
     created_at: new Date().toISOString(),
   };
-  const node: ContextNode = { id, filePath: "", rawContent: "", frontmatter, body: input.content };
+  return { id, filePath: "", rawContent: "", frontmatter, body: input.content };
+}
+
+const create: OperationExecutor = async (ctx, input: any) => {
+  const node = buildDraftNode(input);
   assertValid(node);
   // Exclusive write: atomically refuses to clobber an existing doc (mirrors OSS
   // create_document) — no TOCTOU window, and blocks resurrecting a rejected doc
   // the way the pre-check + separate write could race.
-  await ctx.storage.writeDocument(id, serializeDocument(node), { exclusive: true });
-  const result = await publishAndIndex(ctx, id);
-  return { id, version: result.version };
+  await ctx.storage.writeDocument(node.id, serializeDocument(node), { exclusive: true });
+  const result = await publishAndIndex(ctx, node.id);
+  return { id: node.id, version: result.version };
 };
 
 const update: OperationExecutor = async (ctx, input: any) => {
@@ -356,6 +371,40 @@ const packs: OperationExecutor = async (ctx) => {
   };
 };
 
+const importDocs: OperationExecutor = async (ctx, input: any) => {
+  const created: { id: string; version: number }[] = [];
+  const failed: { title: string; error: string }[] = [];
+  const titleById = new Map<string, string>();
+
+  // Stage 1: write every doc as a draft (exclusive → dup/invalid go to failed).
+  const writtenIds: string[] = [];
+  for (const doc of input.documents) {
+    try {
+      const node = buildDraftNode(doc);
+      assertValid(node);
+      await ctx.storage.writeDocument(node.id, serializeDocument(node), { exclusive: true });
+      writtenIds.push(node.id);
+      titleById.set(node.id, doc.title);
+    } catch (err) {
+      failed.push({ title: doc.title, error: err instanceof Error ? err.message : String(err) });
+    }
+  }
+
+  // Stage 2: bulk-publish the drafts — ONE checkpoint + ONE index regen for the
+  // whole batch (the O(N) path), instead of a checkpoint per document.
+  if (writtenIds.length > 0) {
+    const result = await publishDocuments(ctx.storage, writtenIds, {
+      editedBy: ctx.actor ?? "engine",
+    });
+    for (const p of result.published) created.push({ id: p.id, version: p.version });
+    for (const f of result.failed) {
+      failed.push({ title: titleById.get(f.id) ?? f.id, error: f.error });
+    }
+  }
+
+  return { created, failed };
+};
+
 /** name → executor for the built-in `core` namespace. */
 export const CORE_EXECUTORS: Readonly<Record<string, OperationExecutor>> = Object.freeze({
   context_query: query,
@@ -373,4 +422,5 @@ export const CORE_EXECUTORS: Readonly<Record<string, OperationExecutor>> = Objec
   context_verify: verify,
   context_init: init,
   context_packs: packs,
+  context_import: importDocs,
 });

--- a/packages/engine/src/api/core.ts
+++ b/packages/engine/src/api/core.ts
@@ -415,6 +415,31 @@ const packsOp: OperationDescriptor = {
   errors: ["VALIDATION_FAILED"],
 };
 
+// ─── context_import ──────────────────────────────────────────────────────────
+
+/** One node to create in a bulk import — same shape as context_create input. */
+const importDoc = z.object({
+  title: z.string().min(1).max(200).describe("Descriptive title"),
+  content: z.string().describe("Markdown content body"),
+  type: z.enum(NODE_TYPES).optional().describe("Node type (default: document)"),
+  tags: z.array(tag).optional().describe("Tags"),
+  folder: z.string().optional().describe('Folder path under nodes/; segments are slugified'),
+  metadata: z.record(z.unknown()).optional().describe("Extra frontmatter metadata"),
+});
+
+const importOp: OperationDescriptor = {
+  name: "context_import",
+  namespace: "core",
+  description:
+    "Bulk-create and publish many nodes in one pass (folder/batch import). Seals one checkpoint for the batch; failures are reported per-document, never aborting the rest.",
+  input: z.object({ documents: z.array(importDoc).min(1) }),
+  output: z.object({
+    created: z.array(z.object({ id: z.string(), version: z.number().int().min(1) })),
+    failed: z.array(z.object({ title: z.string(), error: z.string() })),
+  }),
+  errors: ["VALIDATION_FAILED"],
+};
+
 /** All `core` namespace operations, in catalog order. */
 export const CORE_OPERATIONS: readonly OperationDescriptor[] = [
   getOp,
@@ -432,4 +457,5 @@ export const CORE_OPERATIONS: readonly OperationDescriptor[] = [
   verifyOp,
   initOp,
   packsOp,
+  importOp,
 ];

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -293,8 +293,13 @@ export type {
 } from "./hygienist.js";
 
 // Publish
-export { publishDocument } from "./publish.js";
-export type { PublishOptions, PublishResult } from "./publish.js";
+export { publishDocument, publishDocuments } from "./publish.js";
+export type {
+  PublishOptions,
+  PublishResult,
+  BulkPublishOptions,
+  BulkPublishResult,
+} from "./publish.js";
 
 // Source graph
 export {

--- a/packages/engine/src/publish.ts
+++ b/packages/engine/src/publish.ts
@@ -100,3 +100,108 @@ export async function publishDocument(
     checkpointNumber: checkpoint.checkpoint,
   };
 }
+
+// ─── Bulk publish (importers) ────────────────────────────────────────────────
+
+export interface BulkPublishOptions extends PublishOptions {
+  /** Max documents published concurrently (default 16). Per-doc work touches
+   * only that doc's own files, so distinct ids are independent. */
+  concurrency?: number;
+  /** Regenerate context.yaml / INDEX.md once after the batch (default true). */
+  regenerateIndex?: boolean;
+}
+
+export interface BulkPublishResult {
+  published: { id: string; version: number; chainHash: string }[];
+  /** Docs that failed (bad frontmatter, rejected, validation) — batch never aborts. */
+  failed: { id: string; error: string }[];
+  /** The single checkpoint sealing every published doc, or null if none published. */
+  checkpointNumber: number | null;
+}
+
+/**
+ * Bulk-publish MANY documents in one pass — for importers ingesting a whole
+ * nest folder (500+ files). Publishing one-by-one via `publishDocument` is
+ * O(N²): each call seals its own checkpoint, and every checkpoint re-scans the
+ * ENTIRE vault (discoverDocuments + findAllHistories + rewrite of the growing
+ * context_history.yaml). This function does the per-doc version work N times
+ * but seals ONE checkpoint for the whole batch and regenerates the index ONCE
+ * — collapsing N full-vault rescans into a single pass (O(N)).
+ *
+ * Failure-isolated: a bad file is recorded in `failed` and skipped; the rest
+ * still publish and the single checkpoint seals the successful ones.
+ *
+ * NOTE: the per-doc body below intentionally mirrors `publishDocument` (minus
+ * the checkpoint) so the existing single-publish path stays untouched. Keep the
+ * two in sync if the publish steps change.
+ */
+export async function publishDocuments(
+  storage: NestStorage,
+  docIds: string[],
+  options: BulkPublishOptions,
+): Promise<BulkPublishResult> {
+  const concurrency = Math.max(1, options.concurrency ?? 16);
+  const published: BulkPublishResult["published"] = [];
+  const failed: BulkPublishResult["failed"] = [];
+
+  const publishOne = async (docId: string): Promise<void> => {
+    try {
+      let node = await storage.readDocument(docId);
+      if (isRejected(node)) throw new RejectedDocumentError(docId);
+
+      const versionManager = new VersionManager(storage);
+      const existingHistory = await storage.readHistory(docId);
+      if (!existingHistory && (node.frontmatter.version || 0) > 1) {
+        await versionManager.createVersion(node, "system:seed", {
+          note: "Pre-publish snapshot (auto-seeded — no prior history)",
+        });
+      }
+
+      const newVersion = (node.frontmatter.version || 0) + 1;
+      node.frontmatter.version = newVersion;
+      node.frontmatter.status = "published";
+      node.frontmatter.updated_at = new Date().toISOString();
+
+      const serialized = serializeDocument(node);
+      node.frontmatter.checksum = computeContentHash(getChecksumContent(serialized));
+      const finalContent = serializeDocument(node);
+      await storage.writeDocument(docId, finalContent);
+
+      node = await storage.readDocument(docId);
+      const versionEntry = await versionManager.createVersion(node, options.editedBy, {
+        note: options.note,
+        publishedAt: new Date().toISOString(),
+      });
+      published.push({
+        id: docId,
+        version: versionEntry.version,
+        chainHash: versionEntry.chain_hash,
+      });
+    } catch (err) {
+      failed.push({ id: docId, error: err instanceof Error ? err.message : String(err) });
+    }
+  };
+
+  // Bounded-concurrency pass — no cross-doc dependency, so a simple sliding
+  // window is enough (avoids pulling in a p-limit dependency).
+  for (let i = 0; i < docIds.length; i += concurrency) {
+    await Promise.all(docIds.slice(i, i + concurrency).map(publishOne));
+  }
+
+  // ONE checkpoint sealing every doc published above (createCheckpointFromVault
+  // snapshots all published docs in the vault under the checkpoint lock).
+  let checkpointNumber: number | null = null;
+  if (published.length > 0) {
+    const checkpoint = await new CheckpointManager(storage).createCheckpointFromVault(
+      `bulk-import (${published.length} docs)`,
+    );
+    checkpointNumber = checkpoint.checkpoint;
+  }
+
+  // ONE index regen for the whole batch (skippable by callers that regen later).
+  if (options.regenerateIndex !== false) {
+    await storage.regenerateIndex();
+  }
+
+  return { published, failed, checkpointNumber };
+}


### PR DESCRIPTION
## Summary

Speeds up multi-document import from **O(N²) to O(N)**. Importing a nest folder published one file at a time, and every publish re-scanned the entire vault to seal its own checkpoint — ~250k file reads at 500 files. This adds a bulk path that seals **one** checkpoint for the whole batch and regenerates the index **once**.

## What I changed

- **`publishDocuments(storage, ids, opts)`** — new engine function. Does the per-document version work with bounded concurrency, then seals a single checkpoint + one index regen for the batch. Failure-isolated: a bad/rejected file is reported in `failed[]`, the rest still publish. `publishDocument` is untouched.
- **`context_import`** — new `core` API catalog op, composing on the above, so every binding (agent/CLI/REST) gets one bulk tool: `context_import({ documents: [...] }) → { created[], failed[] }`. Writes each doc as a draft via an atomic exclusive write (dup/invalid → `failed[]`), then bulk-publishes.

## Impact

- Folder import at 500 files: N full-vault checkpoint rescans collapse to 1.
- **Non-breaking** — purely additive; existing single-publish/create paths unchanged. `core` namespace grows 15 → 16 ops.
- Engine only. Community wiring (`registerImportedDocuments` → `publishDocuments` + a single DB transaction) is a follow-up in the community repo.
- Tests added for both; full engine suite green.