### PR TITLE
feat(engine): per-version change logs + graft-proof version numbering

### DIFF
--- a/.changeset/cli-verify-diffs-add-guard.md
+++ b/.changeset/cli-verify-diffs-add-guard.md
@@ -1,0 +1,7 @@
+---
+"@promptowl/contextnest-cli": patch
+---
+
+`ctx verify` reads each version's change log from its own file, so non-keyframe entries are hash-checked again now that patches live beside the keyframes rather than inside the history index. Without this, verify reported a mismatch for every version that carried a patch.
+
+`ctx add` refuses a path that already holds a document, with `DOCUMENT_EXISTS`, and leaves the existing file untouched. It previously failed only by accident: the template it writes resets the version to 1, which collided with a number already in the chain and blew up during publish — after the original bytes had already been overwritten.

--- a/.changeset/version-change-logs.md
+++ b/.changeset/version-change-logs.md
@@ -1,0 +1,18 @@
+---
+"@promptowl/contextnest-engine": minor
+---
+
+Per-version change logs, and version numbering that can no longer graft a second chain onto a document's history.
+
+**Change logs move out of `history.yaml` into their own files.** A non-keyframe version is now stored as `v{N}.diff` beside the keyframes — the unified diff taking the previous version to this one, hunk headers included, so each file is readable on its own and applies with standard patch tooling. `history.yaml` keeps metadata only, which matters because it is rewritten whole on every version: inline patches made each edit cost O(total history). Reads are backward compatible — `reconstructVersion` falls back to the patch stored inline by older histories, so existing vaults need no migration. New APIs: `NestStorage.readDiff`/`writeDiff`, `VersionManager.getDiff` (one small file read, no chain replay), and `VersionManager.externalizeDiffs` to move inline patches into files as a tidy-up.
+
+`context_versions` gains an opt-in `include_diff` input and a matching optional `diff` field on each version entry. Off by default: a document with dozens of versions would otherwise return dozens of patches, which is a lot of tokens to push at an agent that only asked who edited what and when.
+
+**Version numbers now outrank the recorded history, not just frontmatter.** `publishDocument`, `publishDocuments`, and the approval commit path all derive the next version from `VersionManager.nextVersion`, which takes the max of the caller's hint and every version already in `history.yaml`. Numbering from frontmatter alone let a document whose frontmatter lagged its history — an imported or copied vault, a restored backup, a doc whose frontmatter was reset — reuse a live version number: duplicate entries, `v{N}.md` keyframes overwritten at the same number, and `reconstructVersion` failing on the first diff after the graft, which made every later version unreadable.
+
+Two recoveries for chains already in that state:
+
+- `createVersion` falls back to writing a keyframe when the previous version cannot be reconstructed, instead of storing a diff against content it cannot rebuild. A broken chain heals on its next edit rather than failing forever.
+- `VersionManager.repairLatestVersion` re-anchors a grafted chain's latest version on the live document and drops the graft tail, without adding a version or renumbering anything already recorded. Versions from before the graft stay unreadable — those bytes were overwritten and are gone.
+
+`verifyDocumentChain` takes an optional fourth `readDiff` callback so a non-keyframe entry's hash is still checked once its patch lives in a file; `verifyVaultIntegrity` pre-loads those bytes the same way it already pre-loads keyframes. A non-keyframe entry with neither a diff file nor an inline patch now surfaces as `content_hash_mismatch` rather than passing silently — unlike a missing keyframe, a missing diff breaks every version after it.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -907,6 +907,19 @@ program
   .action(async (path, opts) => {
     const storage = getStorage();
     const id = normalizeDocumentId(path);
+
+    // Refuse to clobber an existing document. This used to fail only by
+    // accident: the template below resets the version to 1, which collided with
+    // a number already recorded in the chain and blew up during publish — but
+    // only AFTER the original bytes had been overwritten. Checking up front
+    // makes the refusal deliberate and leaves the existing document intact.
+    if (fs.existsSync(pathMod.join(storage.root, `${id}.md`))) {
+      throw new ContextNestError(
+        `Document already exists: ${id}. Use \`ctx update ${id}\` to edit it.`,
+        "DOCUMENT_EXISTS",
+      );
+    }
+
     const title = opts.title || id.split("/").pop()!.replace(/-/g, " ").replace(/\b\w/g, (c: string) => c.toUpperCase());
 
     const tagList = opts.tags
@@ -1168,23 +1181,31 @@ program
 
     // Verify each document chain
     for (const [docId, history] of allHistories) {
-      const report = verifyDocumentChain(docId, history, (version) => {
-        // Synchronous read — for CLI simplicity
-        const docName = pathMod.basename(docId);
-        const docDir = pathMod.dirname(docId);
-        const keyframePath = pathMod.join(
-          storage.root,
-          docDir,
-          ".versions",
-          docName,
-          `v${version}.md`,
-        );
+      // Synchronous reads — for CLI simplicity. Both are needed: a keyframe
+      // entry hashes its snapshot, a non-keyframe entry hashes its change log,
+      // and the change log lives in its own v{N}.diff file.
+      const readVersionFile = (version: number, ext: "md" | "diff") => {
         try {
-          return fs.readFileSync(keyframePath, "utf-8");
+          return fs.readFileSync(
+            pathMod.join(
+              storage.root,
+              pathMod.dirname(docId),
+              ".versions",
+              pathMod.basename(docId),
+              `v${version}.${ext}`,
+            ),
+            "utf-8",
+          );
         } catch {
           return null;
         }
-      });
+      };
+      const report = verifyDocumentChain(
+        docId,
+        history,
+        (version) => readVersionFile(version, "md"),
+        (version) => readVersionFile(version, "diff"),
+      );
 
       if (!report.valid) {
         totalErrors += report.errors.length;

--- a/packages/engine/src/__tests__/api-runtime.test.ts
+++ b/packages/engine/src/__tests__/api-runtime.test.ts
@@ -205,6 +205,33 @@ describe("createEngineApi — executable core operations", () => {
     expect(out.versions[0].chain_hash).toMatch(/^sha256:/);
   });
 
+  it("context_versions attaches change logs only when asked", async () => {
+    const api = createEngineApi();
+    await api.run("context_create", { title: "Logged", content: "first" }, ctx);
+    await api.run(
+      "context_update",
+      { id: "nodes/logged", content: "second body" },
+      ctx,
+    );
+
+    type Out = { versions: Array<{ version: number; keyframe: boolean; diff?: string }> };
+    // Default stays lean — a history listing must not push patches at an agent.
+    const lean = await api.run<Out>("context_versions", { id: "nodes/logged" }, ctx);
+    expect(lean.versions.every((v) => v.diff === undefined)).toBe(true);
+
+    const full = await api.run<Out>(
+      "context_versions",
+      { id: "nodes/logged", include_diff: true },
+      ctx,
+    );
+    const patched = full.versions.filter((v) => !v.keyframe);
+    expect(patched.length).toBeGreaterThan(0);
+    // A real unified diff, same bytes the v{N}.diff file holds.
+    expect(patched[0].diff).toContain("@@");
+    // Keyframes are full snapshots, so they carry no patch.
+    expect(full.versions.filter((v) => v.keyframe).every((v) => !v.diff)).toBe(true);
+  });
+
   it("context_overview reports counts, tags, and the node list", async () => {
     const api = createEngineApi();
     await api.run("context_create", { title: "Alpha", content: "b", tags: ["#x"] }, ctx);

--- a/packages/engine/src/__tests__/version-chain-graft.test.ts
+++ b/packages/engine/src/__tests__/version-chain-graft.test.ts
@@ -1,0 +1,278 @@
+/**
+ * Version chain integrity — history.yaml is append-only.
+ *
+ * Two guarantees covered here:
+ *  1. A new version always outranks every version already in history, even when
+ *     the document's frontmatter lags it (imported/copied vault, restored
+ *     backup). Numbering from frontmatter alone grafted a SECOND chain onto the
+ *     first — duplicate v{N} entries, keyframe files overwritten at the same
+ *     number, reconstructVersion() failing on the first diff after the graft.
+ *  2. A chain that can no longer be reconstructed self-heals: the next version
+ *     is written as a keyframe instead of an unusable diff, so reads work again
+ *     from that version forward.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { join } from "node:path";
+import { mkdtemp, rm, readdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { NestStorage } from "../storage.js";
+import { serializeDocument } from "../parser.js";
+import { VersionManager } from "../versioning.js";
+import { publishDocument } from "../publish.js";
+import type { ContextNode } from "../types.js";
+
+const DOC_ID = "nodes/demo";
+
+function node(version: number, body: string): ContextNode {
+  return {
+    id: DOC_ID,
+    filePath: "",
+    rawContent: "",
+    frontmatter: { title: "demo", type: "document", status: "published", version },
+    body,
+  };
+}
+
+describe("version chain integrity", () => {
+  let storage: NestStorage;
+  let versions: VersionManager;
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "contextnest-chain-"));
+    storage = new NestStorage(dir);
+    versions = new VersionManager(storage);
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  /** Append versions 1..n through the VersionManager, one edit each. */
+  async function buildChain(n: number): Promise<void> {
+    for (let v = 1; v <= n; v++) {
+      const doc = node(v, `body line ${v}`);
+      await storage.writeDocument(DOC_ID, serializeDocument(doc));
+      await versions.createVersion(await storage.readDocument(DOC_ID), "me@x.io");
+    }
+  }
+
+  it("stores keyframes as v{N}.md and every other version as a v{N}.diff change log", async () => {
+    await buildChain(22);
+
+    const files = await readdir(join(dir, "nodes/.versions/demo"));
+    const keyframes = [1, 11, 21];
+
+    // A file per version: full snapshot at a keyframe, change log otherwise.
+    for (let v = 1; v <= 22; v++) {
+      const expected = keyframes.includes(v) ? `v${v}.md` : `v${v}.diff`;
+      expect(files, `v${v} should be stored as ${expected}`).toContain(expected);
+    }
+    // No full snapshot for a non-keyframe version — that is the duplication
+    // this layout exists to avoid.
+    for (let v = 1; v <= 22; v++) {
+      if (keyframes.includes(v)) continue;
+      expect(files, `v${v} must not store a full snapshot`).not.toContain(`v${v}.md`);
+    }
+    expect(files).toContain("history.yaml");
+
+    const history = (await storage.readHistory(DOC_ID))!;
+    expect(history.versions.filter((e) => e.keyframe).map((e) => e.version)).toEqual(
+      keyframes,
+    );
+    // history.yaml is metadata only — no patch bytes inline on any entry.
+    for (const entry of history.versions) {
+      expect(entry.diff, `v${entry.version} should not inline its patch`).toBeUndefined();
+    }
+    // And the change log is retrievable per version, keyframes excepted.
+    await expect(versions.getDiff(DOC_ID, 4)).resolves.toContain("@@");
+    await expect(versions.getDiff(DOC_ID, 11)).resolves.toBeNull();
+  });
+
+  it("reconstructs every version byte-identical to what was written", async () => {
+    const written: string[] = [];
+    for (let v = 1; v <= 22; v++) {
+      const doc = node(v, `body line ${v}`);
+      await storage.writeDocument(DOC_ID, serializeDocument(doc));
+      const parsed = await storage.readDocument(DOC_ID);
+      written.push(serializeDocument(parsed));
+      await versions.createVersion(parsed, "me@x.io");
+    }
+
+    for (let v = 1; v <= 22; v++) {
+      await expect(versions.reconstructVersion(DOC_ID, v)).resolves.toBe(written[v - 1]);
+    }
+  });
+
+  it("nextVersion outranks the recorded history when frontmatter lags it", async () => {
+    await buildChain(3);
+
+    // Imported doc: history says 3, the copied markdown says 1.
+    await expect(versions.nextVersion(DOC_ID, 1)).resolves.toBe(4);
+    // Frontmatter ahead of history still wins.
+    await expect(versions.nextVersion(DOC_ID, 9)).resolves.toBe(10);
+    // No history at all — fall back to the hint.
+    await expect(versions.nextVersion("nodes/absent", 0)).resolves.toBe(1);
+  });
+
+  it("publish never reuses a version number when frontmatter lags history", async () => {
+    await buildChain(3);
+
+    // Simulate the import: history is intact, the on-disk file's frontmatter
+    // was reset to 1 (previously-exported vault, half-migrated doc).
+    await storage.writeDocument(DOC_ID, serializeDocument(node(1, "imported body")));
+
+    const { versionEntry } = await publishDocument(storage, DOC_ID, {
+      editedBy: "importer@x.io",
+      note: "Imported from existing folder",
+    });
+    expect(versionEntry.version).toBe(4);
+
+    const history = (await storage.readHistory(DOC_ID))!;
+    const numbers = history.versions.map((e) => e.version);
+    expect(numbers).toEqual([1, 2, 3, 4]);
+    expect(new Set(numbers).size).toBe(numbers.length);
+
+    // The whole chain still rebuilds, including the version added on import.
+    for (const v of numbers) {
+      await expect(versions.reconstructVersion(DOC_ID, v)).resolves.toContain("---");
+    }
+  });
+
+  it("falls back to a keyframe when the previous version cannot be rebuilt", async () => {
+    await buildChain(3);
+
+    // Corrupt the chain the way a grafted history did: make v2's change log
+    // unusable against the version it claims to follow.
+    const patch = (await versions.getDiff(DOC_ID, 2))!;
+    await storage.writeDiff(
+      DOC_ID,
+      2,
+      patch.replace("body line 1", "text that is not in v1"),
+    );
+    await expect(versions.reconstructVersion(DOC_ID, 3)).rejects.toThrow();
+
+    // Next edit must still be storable, and readable afterwards.
+    const doc = node(4, "body line 4");
+    await storage.writeDocument(DOC_ID, serializeDocument(doc));
+    const entry = await versions.createVersion(
+      await storage.readDocument(DOC_ID),
+      "me@x.io",
+    );
+
+    expect(entry.keyframe).toBe(true);
+    expect(entry.diff).toBeUndefined();
+    await expect(versions.reconstructVersion(DOC_ID, 4)).resolves.toContain(
+      "body line 4",
+    );
+  });
+
+  it("repairLatestVersion re-anchors a grafted chain without adding a version", async () => {
+    await buildChain(3);
+
+    // Graft a second chain on, exactly as an import with a copied .versions/
+    // folder used to: version numbers restart and overwrite live ones.
+    const grafted = (await storage.readHistory(DOC_ID))!;
+    grafted.versions = [...grafted.versions, ...grafted.versions.map((e) => ({ ...e }))];
+    await storage.writeHistory(DOC_ID, grafted);
+    await expect(versions.reconstructVersion(DOC_ID, 3)).rejects.toThrow();
+
+    await expect(versions.repairLatestVersion(DOC_ID)).resolves.toBe(true);
+
+    const after = (await storage.readHistory(DOC_ID))!;
+    // Nothing renumbered, nothing added — the chain is the prefix up to its
+    // highest version, with the graft tail that re-trod 1..3 dropped.
+    expect(after.versions.map((e) => e.version)).toEqual([1, 2, 3, 1, 2, 3]);
+    expect(after.versions.at(-1)!.version).toBe(3);
+    // The current version reads again.
+    await expect(versions.reconstructVersion(DOC_ID, 3)).resolves.toContain(
+      "body line 3",
+    );
+    // And it is a no-op on a chain that already reconstructs.
+    await expect(versions.repairLatestVersion(DOC_ID)).resolves.toBe(false);
+  });
+
+  it("repairLatestVersion drops a graft tail recorded after the highest version", async () => {
+    await buildChain(4);
+
+    // Re-import graft: numbers restart, so the tail sits AFTER v4 in the file
+    // and its stale v1 keyframe would win reconstruct's nearest-keyframe scan.
+    const grafted = (await storage.readHistory(DOC_ID))!;
+    const tail = grafted.versions.slice(0, 2).map((e) => ({ ...e }));
+    grafted.versions = [...grafted.versions, ...tail];
+    await storage.writeHistory(DOC_ID, grafted);
+    await expect(versions.reconstructVersion(DOC_ID, 4)).rejects.toThrow();
+
+    await expect(versions.repairLatestVersion(DOC_ID)).resolves.toBe(true);
+
+    const after = (await storage.readHistory(DOC_ID))!;
+    expect(after.versions.map((e) => e.version)).toEqual([1, 2, 3, 4]);
+    expect(after.versions.at(-1)!.keyframe).toBe(true);
+    await expect(versions.reconstructVersion(DOC_ID, 4)).resolves.toContain(
+      "body line 4",
+    );
+  });
+
+  it("still reconstructs a history that stores its patches inline (pre-migration)", async () => {
+    await buildChain(4);
+
+    // Rewrite the chain in the old shape: patch inline on the entry, no file.
+    const history = (await storage.readHistory(DOC_ID))!;
+    for (const entry of history.versions) {
+      if (entry.keyframe) continue;
+      entry.diff = (await storage.readDiff(DOC_ID, entry.version))!;
+      await rm(join(dir, `nodes/.versions/demo/v${entry.version}.diff`));
+    }
+    await storage.writeHistory(DOC_ID, history);
+
+    for (let v = 1; v <= 4; v++) {
+      await expect(versions.reconstructVersion(DOC_ID, v)).resolves.toContain(
+        `body line ${v}`,
+      );
+    }
+    // The per-version change log still resolves, from the inline patch.
+    await expect(versions.getDiff(DOC_ID, 3)).resolves.toContain("@@");
+  });
+
+  it("externalizeDiffs moves inline patches into files without changing content", async () => {
+    await buildChain(4);
+
+    // Put the chain back in the old inline shape.
+    const history = (await storage.readHistory(DOC_ID))!;
+    const original: Record<number, string> = {};
+    for (const entry of history.versions) {
+      if (entry.keyframe) continue;
+      original[entry.version] = (await storage.readDiff(DOC_ID, entry.version))!;
+      entry.diff = original[entry.version];
+      await rm(join(dir, `nodes/.versions/demo/v${entry.version}.diff`));
+    }
+    await storage.writeHistory(DOC_ID, history);
+
+    await expect(versions.externalizeDiffs(DOC_ID)).resolves.toBe(3);
+
+    const after = (await storage.readHistory(DOC_ID))!;
+    for (const entry of after.versions) {
+      expect(entry.diff).toBeUndefined();
+      // Hashes are untouched — the same bytes just moved to their own file.
+      if (entry.keyframe) continue;
+      await expect(storage.readDiff(DOC_ID, entry.version)).resolves.toBe(
+        original[entry.version],
+      );
+    }
+    for (let v = 1; v <= 4; v++) {
+      await expect(versions.reconstructVersion(DOC_ID, v)).resolves.toContain(
+        `body line ${v}`,
+      );
+    }
+    // Idempotent — nothing left to move.
+    await expect(versions.externalizeDiffs(DOC_ID)).resolves.toBe(0);
+  });
+
+  it("repairLatestVersion leaves a healthy chain untouched", async () => {
+    await buildChain(3);
+    const before = await storage.readHistory(DOC_ID);
+
+    await expect(versions.repairLatestVersion(DOC_ID)).resolves.toBe(false);
+    expect(await storage.readHistory(DOC_ID)).toEqual(before);
+  });
+});

--- a/packages/engine/src/api/core-executors.ts
+++ b/packages/engine/src/api/core-executors.ts
@@ -21,6 +21,7 @@ import {
 } from "../parser.js";
 import { normalizeDocumentId } from "../storage.js";
 import { publishDocument, publishDocuments } from "../publish.js";
+import { VersionManager } from "../versioning.js";
 import { parseUri } from "../uri.js";
 import { ContextNestError, RejectedDocumentError } from "../errors.js";
 import type { OperationContext, OperationExecutor } from "./context.js";
@@ -293,19 +294,28 @@ const versions: OperationExecutor = async (ctx, input: any) => {
     await ctx.storage.readDocument(id);
     return { id, keyframe_interval: 0, versions: [] };
   }
+  // Change logs are opt-in — see the `include_diff` note on the descriptor.
+  const versionManager = input?.include_diff
+    ? new VersionManager(ctx.storage)
+    : null;
   return {
     id,
     keyframe_interval: history.keyframe_interval,
-    versions: history.versions.map((v) => ({
-      version: v.version,
-      keyframe: v.keyframe ?? false,
-      edited_by: v.edited_by,
-      edited_at: v.edited_at,
-      published_at: v.published_at,
-      note: v.note,
-      content_hash: v.content_hash,
-      chain_hash: v.chain_hash,
-    })),
+    versions: await Promise.all(
+      history.versions.map(async (v) => ({
+        version: v.version,
+        keyframe: v.keyframe ?? false,
+        edited_by: v.edited_by,
+        edited_at: v.edited_at,
+        published_at: v.published_at,
+        note: v.note,
+        content_hash: v.content_hash,
+        chain_hash: v.chain_hash,
+        ...(versionManager
+          ? { diff: (await versionManager.getDiff(id, v.version)) ?? undefined }
+          : {}),
+      })),
+    ),
   };
 };
 

--- a/packages/engine/src/api/core.ts
+++ b/packages/engine/src/api/core.ts
@@ -44,15 +44,16 @@ const documentPayload = z.object({
 });
 
 /** Address a single node by URI, id, or title — shared by get/delete/publish/versions. */
-const nodeSelector = z
-  .object({
-    uri: z.string().optional().describe("Document URI, e.g. contextnest://nodes/api-design"),
-    id: z.string().optional().describe("Document id / path"),
-    title: z.string().optional().describe("Document title"),
-  })
-  .refine((v) => Boolean(v.uri || v.id || v.title), {
-    message: "One of uri, id, or title is required",
-  });
+const nodeSelectorShape = {
+  uri: z.string().optional().describe("Document URI, e.g. contextnest://nodes/api-design"),
+  id: z.string().optional().describe("Document id / path"),
+  title: z.string().optional().describe("Document title"),
+};
+const SELECTOR_REQUIRED = { message: "One of uri, id, or title is required" };
+const hasSelector = (v: { uri?: string; id?: string; title?: string }) =>
+  Boolean(v.uri || v.id || v.title);
+
+const nodeSelector = z.object(nodeSelectorShape).refine(hasSelector, SELECTOR_REQUIRED);
 
 // ─── context_search ──────────────────────────────────────────────────────────
 
@@ -299,13 +300,27 @@ const versionEntryOut = z.object({
   note: z.string().optional(),
   content_hash: z.string(),
   chain_hash: z.string(),
+  /** Only present when the caller passes `include_diff`. Absent for a keyframe
+   *  (a full snapshot has no patch) and for v1. */
+  diff: z.string().optional().describe("Unified diff from the previous version"),
 });
 
 const versionsOp: OperationDescriptor = {
   name: "context_versions",
   namespace: "core",
   description: "Version history of a node (newest entries last).",
-  input: nodeSelector,
+  input: z
+    .object({
+      ...nodeSelectorShape,
+      // Off by default on purpose: a doc with dozens of versions would other-
+      // wise return dozens of patches, which is a lot of tokens to push into an
+      // agent that only asked who edited what and when.
+      include_diff: z
+        .boolean()
+        .optional()
+        .describe("Attach each version's change log (unified diff from the previous version)"),
+    })
+    .refine(hasSelector, SELECTOR_REQUIRED),
   output: z.object({
     id: z.string(),
     keyframe_interval: z.number().int(),

--- a/packages/engine/src/approval.ts
+++ b/packages/engine/src/approval.ts
@@ -402,7 +402,11 @@ async function commitNewVersion(
   const filePath = join(input.storage.root, `${input.documentId}.md`);
   const parsed = parseDocument(filePath, input.newRawContent, input.documentId);
 
-  const newVersion = (parsed.frontmatter.version ?? 0) + 1;
+  const versionManager = new VersionManager(input.storage);
+  const newVersion = await versionManager.nextVersion(
+    input.documentId,
+    parsed.frontmatter.version ?? 0,
+  );
   const updatedAt = new Date().toISOString();
   const node: ContextNode = {
     ...parsed,
@@ -423,14 +427,10 @@ async function commitNewVersion(
   const serialized = serializeDocument(node);
   const finalNode: ContextNode = { ...node, rawContent: serialized };
 
-  const versionEntry = await new VersionManager(input.storage).createVersion(
-    finalNode,
-    input.actor,
-    {
-      note: input.note,
-      publishedAt: updatedAt,
-    },
-  );
+  const versionEntry = await versionManager.createVersion(finalNode, input.actor, {
+    note: input.note,
+    publishedAt: updatedAt,
+  });
 
   // Write the live canonical file last so a mid-flight crash leaves the
   // chain consistent (history wrote first, live file matches the chain

--- a/packages/engine/src/integrity.ts
+++ b/packages/engine/src/integrity.ts
@@ -232,6 +232,10 @@ export function verifyDocumentChain(
   docId: string,
   history: DocumentHistory,
   readKeyframe: (version: number) => string | null,
+  /** Change log for a non-keyframe version, when it lives in a v{N}.diff file
+   *  rather than inline on the entry. Omitted by callers that only have the
+   *  history — those fall back to the inline patch, as before. */
+  readDiff?: (version: number) => string | null,
 ): VerificationReport {
   const errors: VerificationReport["errors"] = [];
 
@@ -244,7 +248,12 @@ export function verifyDocumentChain(
     if (entry.keyframe) {
       actualContent = readKeyframe(entry.version);
     } else {
-      actualContent = entry.diff || "";
+      // Externalized change log wins; inline patch is the legacy fallback.
+      // Neither available means the version can no longer be reconstructed, so
+      // hash "" and let it surface as a content_hash_mismatch — unlike a
+      // missing keyframe (recoverable by replaying from an earlier one), a
+      // missing diff silently breaks every version after it.
+      actualContent = readDiff?.(entry.version) ?? entry.diff ?? "";
     }
 
     if (actualContent !== null) {

--- a/packages/engine/src/integrity.ts
+++ b/packages/engine/src/integrity.ts
@@ -233,8 +233,9 @@ export function verifyDocumentChain(
   history: DocumentHistory,
   readKeyframe: (version: number) => string | null,
   /** Change log for a non-keyframe version, when it lives in a v{N}.diff file
-   *  rather than inline on the entry. Omitted by callers that only have the
-   *  history — those fall back to the inline patch, as before. */
+   *  rather than inline on the entry. A caller that cannot read version files
+   *  omits this; its non-keyframe content checks are then skipped rather than
+   *  failed, the same way a missing keyframe file is skipped. */
   readDiff?: (version: number) => string | null,
 ): VerificationReport {
   const errors: VerificationReport["errors"] = [];
@@ -249,11 +250,19 @@ export function verifyDocumentChain(
       actualContent = readKeyframe(entry.version);
     } else {
       // Externalized change log wins; inline patch is the legacy fallback.
-      // Neither available means the version can no longer be reconstructed, so
-      // hash "" and let it surface as a content_hash_mismatch — unlike a
-      // missing keyframe (recoverable by replaying from an earlier one), a
-      // missing diff silently breaks every version after it.
-      actualContent = readDiff?.(entry.version) ?? entry.diff ?? "";
+      //
+      // With a reader supplied, "neither available" means the change log is
+      // gone and the version can no longer be reconstructed — hash "" so it
+      // surfaces as a content_hash_mismatch, because unlike a missing keyframe
+      // (recoverable by replaying from an earlier one) a missing diff breaks
+      // every version after it.
+      //
+      // Without a reader, we simply cannot see the change log, which is not
+      // evidence of tampering — skip the content check as we do for a keyframe
+      // whose file we could not read, and let the chain_hash check below stand.
+      actualContent = readDiff
+        ? (readDiff(entry.version) ?? entry.diff ?? "")
+        : (entry.diff ?? null);
     }
 
     if (actualContent !== null) {

--- a/packages/engine/src/publish.ts
+++ b/packages/engine/src/publish.ts
@@ -55,9 +55,13 @@ export async function publishDocument(
     });
   }
 
-  // Bump version
-  const currentVersion = node.frontmatter.version || 0;
-  const newVersion = currentVersion + 1;
+  // Bump version — past the recorded history too, not just frontmatter, so a
+  // doc whose frontmatter lags its history.yaml (imported/copied vault) cannot
+  // reuse a version number and graft a second chain onto the first.
+  const newVersion = await versionManager.nextVersion(
+    docId,
+    node.frontmatter.version || 0,
+  );
   node.frontmatter.version = newVersion;
   node.frontmatter.status = "published";
   node.frontmatter.updated_at = new Date().toISOString();
@@ -157,7 +161,10 @@ export async function publishDocuments(
         });
       }
 
-      const newVersion = (node.frontmatter.version || 0) + 1;
+      const newVersion = await versionManager.nextVersion(
+        docId,
+        node.frontmatter.version || 0,
+      );
       node.frontmatter.version = newVersion;
       node.frontmatter.status = "published";
       node.frontmatter.updated_at = new Date().toISOString();

--- a/packages/engine/src/storage.ts
+++ b/packages/engine/src/storage.ts
@@ -390,16 +390,27 @@ export class NestStorage {
       // skipped, and a tampered v{N}.md keyframe — canonical file + history.yaml
       // left intact — goes undetected. Keyframe files are small; the reads are
       // cheap, and the chain check below still works when one is missing.
+      //
+      // Non-keyframe entries hash their change log, which now lives in a
+      // v{N}.diff file rather than inline on the entry — pre-load those too, or
+      // a tampered diff file goes unchecked exactly the way a tampered keyframe
+      // used to.
       const keyframeContent = new Map<number, string>();
+      const diffContent = new Map<number, string>();
       for (const entry of history.versions) {
-        if (!entry.keyframe) continue;
-        const content = await this.readKeyframe(docId, entry.version);
-        if (content !== null) keyframeContent.set(entry.version, content);
+        if (entry.keyframe) {
+          const content = await this.readKeyframe(docId, entry.version);
+          if (content !== null) keyframeContent.set(entry.version, content);
+        } else {
+          const diff = await this.readDiff(docId, entry.version);
+          if (diff !== null) diffContent.set(entry.version, diff);
+        }
       }
       const report = verifyDocumentChain(
         docId,
         history,
         (version) => keyframeContent.get(version) ?? null,
+        (version) => diffContent.get(version) ?? null,
       );
       if (!report.valid) errors.push(...report.errors);
     }
@@ -649,6 +660,51 @@ export class NestStorage {
     const keyframeDir = join(this.root, docDir, ".versions", docName);
     await mkdir(keyframeDir, { recursive: true });
     await writeFile(join(keyframeDir, `v${version}.md`), content, "utf-8");
+  }
+
+  /**
+   * Read the change log for a non-keyframe version — the unified diff taking
+   * v{version-1} to v{version}, stored beside the keyframes as v{version}.diff.
+   *
+   * Returns null when there is no diff file. Histories written before diffs
+   * were externalized carry the patch inline on the version entry instead, so
+   * callers fall back to `entry.diff` (see VersionManager.reconstructVersion) —
+   * that fallback is what keeps pre-existing nests readable without migration.
+   */
+  async readDiff(docId: string, version: number): Promise<string | null> {
+    const docName = basename(docId);
+    const docDir = dirname(docId);
+    const diffPath = join(
+      this.root,
+      docDir,
+      ".versions",
+      docName,
+      `v${version}.diff`,
+    );
+    try {
+      return await readFile(diffPath, "utf-8");
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Write the change log for a non-keyframe version.
+   *
+   * Content is the unified diff exactly as produced by `createPatch` — hunk
+   * headers included — so the file is readable on its own and applies with
+   * standard patch tooling.
+   */
+  async writeDiff(
+    docId: string,
+    version: number,
+    diff: string,
+  ): Promise<void> {
+    const docName = basename(docId);
+    const docDir = dirname(docId);
+    const diffDir = join(this.root, docDir, ".versions", docName);
+    await mkdir(diffDir, { recursive: true });
+    await writeFile(join(diffDir, `v${version}.diff`), diff, "utf-8");
   }
 
   /**

--- a/packages/engine/src/versioning.ts
+++ b/packages/engine/src/versioning.ts
@@ -15,6 +15,27 @@ export class VersionManager {
   constructor(private storage: NestStorage) {}
 
   /**
+   * Next version number for a document — ahead of BOTH the caller's hint
+   * (frontmatter version, a DB row count) and everything already recorded in
+   * history.yaml.
+   *
+   * history.yaml is append-only, so the next entry MUST outrank every entry in
+   * it. Numbering from frontmatter alone lets a document whose frontmatter lags
+   * its history — a copied/imported vault, a restored backup, a doc whose
+   * frontmatter was reset — graft a SECOND chain onto the first: duplicate
+   * v{N} entries, keyframe files overwritten at the same number, and
+   * reconstructVersion() failing on the first diff after the graft.
+   */
+  async nextVersion(docId: string, hint = 0): Promise<number> {
+    const history = await this.storage.readHistory(docId);
+    const recorded = (history?.versions ?? []).reduce(
+      (max, entry) => Math.max(max, entry.version),
+      0,
+    );
+    return Math.max(hint, recorded) + 1;
+  }
+
+  /**
    * Create a new version of a document (§6.1).
    * Appends to history.yaml, writes keyframe if at keyframe interval.
    */
@@ -32,7 +53,7 @@ export class VersionManager {
     };
 
     const currentVersion = node.frontmatter.version || 1;
-    const isKeyframe =
+    let isKeyframe =
       history.versions.length === 0 ||
       currentVersion % history.keyframe_interval === 1 ||
       currentVersion === 1;
@@ -43,16 +64,29 @@ export class VersionManager {
     let contentForHash: string;
     let diff: string | undefined;
 
-    if (isKeyframe) {
+    // A diff is only storable if the version it is relative to can still be
+    // rebuilt. When the chain ahead of this entry is unreadable — history
+    // grafted by an older import, a hand-edited history.yaml, a keyframe file
+    // lost — a diff would make this version and every later one permanently
+    // unreconstructable. Fall back to a keyframe: the chain restarts cleanly
+    // from here and stays readable forward.
+    let previousContent: string | null = null;
+    if (!isKeyframe) {
+      try {
+        previousContent = await this.reconstructVersion(
+          node.id,
+          currentVersion - 1,
+        );
+      } catch {
+        isKeyframe = true;
+      }
+    }
+
+    if (previousContent === null) {
       // Write keyframe snapshot
       await this.storage.writeKeyframe(node.id, currentVersion, fullContent);
       contentForHash = fullContent;
     } else {
-      // Compute diff from previous version
-      const previousContent = await this.reconstructVersion(
-        node.id,
-        currentVersion - 1,
-      );
       diff = createPatch(
         `v${currentVersion - 1}`,
         previousContent,
@@ -60,6 +94,11 @@ export class VersionManager {
         `v${currentVersion - 1}`,
         `v${currentVersion}`,
       );
+      // The change log lives in its own v{N}.diff file, NOT inline on the
+      // history entry: history.yaml stays metadata-only (it is rewritten whole
+      // on every version, so inline patches made each edit cost O(total
+      // history)), and every version gains a standalone, readable artifact.
+      await this.storage.writeDiff(node.id, currentVersion, diff);
       contentForHash = diff;
     }
 
@@ -82,7 +121,6 @@ export class VersionManager {
     const entry: VersionEntry = {
       version: currentVersion,
       ...(isKeyframe ? { keyframe: true } : {}),
-      ...(diff ? { diff } : {}),
       edited_by: editedBy,
       edited_at: editedAt,
       ...(options.publishedAt ? { published_at: options.publishedAt } : {}),
@@ -143,8 +181,12 @@ export class VersionManager {
         }
       }
 
-      if (entry.diff) {
-        const result = applyPatch(content, entry.diff);
+      // v{N}.diff on disk, falling back to the patch stored inline on the
+      // entry by histories written before diffs were externalized.
+      const patch =
+        (await this.storage.readDiff(docId, entry.version)) ?? entry.diff;
+      if (patch) {
+        const result = applyPatch(content, patch);
         if (typeof result === "string") {
           content = result;
         } else if (result === false) {
@@ -156,6 +198,115 @@ export class VersionManager {
     }
 
     return content;
+  }
+
+  /**
+   * Make a document's LATEST version readable again after a chain graft.
+   *
+   * A history grafted by an older import — duplicate version numbers, keyframe
+   * files overwritten at the same number — fails reconstruction from the graft
+   * point on, so even the CURRENT version reads as empty. This re-anchors the
+   * latest recorded version on the live document: writes it as a keyframe and
+   * re-hashes that entry, without adding a version or renumbering anything
+   * already recorded. Versions from before the graft stay unreadable — those
+   * bytes were overwritten and are genuinely gone.
+   *
+   * Entries recorded AFTER the highest version are dropped: they can only be a
+   * graft tail re-treading numbers the chain already used, and leaving them is
+   * what makes reconstruct pick a stale keyframe over the re-anchored one. The
+   * content they described is unreachable either way — the live document is the
+   * state they led to, and that is exactly what gets keyframed here.
+   *
+   * Idempotent no-op when the latest version already reconstructs. Returns true
+   * only when it repaired something.
+   */
+  async repairLatestVersion(docId: string): Promise<boolean> {
+    const history = await this.storage.readHistory(docId);
+    if (!history || history.versions.length === 0) return false;
+
+    // Last entry holding the highest version — a grafted history is not sorted,
+    // so take the max rather than trusting the tail.
+    let index = 0;
+    for (let i = 1; i < history.versions.length; i++) {
+      if (history.versions[i].version >= history.versions[index].version) index = i;
+    }
+    const latest = history.versions[index];
+
+    try {
+      await this.reconstructVersion(docId, latest.version);
+      return false;
+    } catch {
+      // Falls through to the repair below.
+    }
+
+    const fullContent = serializeDocument(await this.storage.readDocument(docId));
+    await this.storage.writeKeyframe(docId, latest.version, fullContent);
+
+    latest.keyframe = true;
+    delete latest.diff;
+    // The entry hashed a diff before; it holds full content now, so re-hash it
+    // (and its chain link) or integrity verification flags the keyframe.
+    latest.content_hash = computeContentHash(fullContent);
+    latest.chain_hash = computeChainHash(
+      index > 0 ? history.versions[index - 1].chain_hash : null,
+      latest.content_hash,
+      latest.version,
+      latest.edited_by,
+      latest.edited_at,
+    );
+
+    // Drop the graft tail so the re-anchored keyframe is the last one at or
+    // below any target — otherwise a trailing lower-numbered keyframe wins the
+    // nearest-keyframe scan in reconstructVersion and the chain stays broken.
+    history.versions = history.versions.slice(0, index + 1);
+
+    await this.storage.writeHistory(docId, history);
+    return true;
+  }
+
+  /**
+   * The change log for a single version — the unified diff taking the previous
+   * version to this one. Reads v{version}.diff, falling back to the patch
+   * stored inline by histories written before diffs were externalized.
+   *
+   * Null for a keyframe (it is a full snapshot, so there is no patch) and for a
+   * version that has neither file nor inline patch. Cheap: one small file read,
+   * no chain replay — this is what lets a version list render every change
+   * without reconstructing every body.
+   */
+  async getDiff(docId: string, version: number): Promise<string | null> {
+    const history = await this.storage.readHistory(docId);
+    const entry = history?.versions.find((e) => e.version === version);
+    if (entry?.keyframe) return null;
+    return (await this.storage.readDiff(docId, version)) ?? entry?.diff ?? null;
+  }
+
+  /**
+   * Move inline patches out of history.yaml into v{N}.diff files.
+   *
+   * Reads keep working either way (reconstructVersion falls back to the inline
+   * patch), so this is a tidy-up rather than a correctness fix: it shrinks a
+   * history.yaml that is rewritten whole on every edit, and gives versions
+   * written under the old layout the same standalone change-log file that new
+   * ones get. Content and hashes are untouched — the same bytes just move.
+   *
+   * Idempotent. Returns how many entries were externalized.
+   */
+  async externalizeDiffs(docId: string): Promise<number> {
+    const history = await this.storage.readHistory(docId);
+    if (!history) return 0;
+
+    let moved = 0;
+    for (const entry of history.versions) {
+      if (!entry.diff) continue;
+      // Write first, drop from history only once the file is safely on disk.
+      await this.storage.writeDiff(docId, entry.version, entry.diff);
+      delete entry.diff;
+      moved += 1;
+    }
+
+    if (moved > 0) await this.storage.writeHistory(docId, history);
+    return moved;
   }
 
   /**


### PR DESCRIPTION
## Summary

Version change logs move out of the history index into one diff file per version. Next version number now comes from the recorded history instead of the document's frontmatter, closing a corruption where a version number could be reused and break reconstruction of every version after it.

Additive, backward compatible, minor release.

## What I changed

- Each non-keyframe version stores its change log as its own file beside the keyframes, as a standard unified diff. The history index keeps metadata only — it is rewritten in full on every version, so embedded patches made each edit cost proportional to the whole accumulated history instead of to the change.
- Reads stay backward compatible: a patch still embedded in the history index is read from there, so existing vaults need no migration. An opt-in tidy-up moves embedded patches into their own files.
- Next version number is the highest of the caller's hint and every version already recorded. It previously came from frontmatter alone, so a document whose frontmatter lagged its history — imported or copied vault, restored backup, frontmatter reset — reused a live number and grafted a second chain onto the first.
- Two recoveries for chains already grafted: a version whose predecessor can no longer be rebuilt is stored as a full snapshot rather than an unusable patch, so the chain heals on its next edit; and a repair path re-anchors a grafted chain's latest version on the live document, adding no version and renumbering nothing.
- Version-history operation can return each version's change log, opt-in. Off by default — a document with dozens of versions would otherwise return dozens of patches to a caller that only asked who edited what and when.
- Integrity verification reads a change log from its file, so non-keyframe hashes are still checked. No patch available from either location is now a hash mismatch, not a silent pass: unlike a missing snapshot, a missing patch breaks every version after it.

## Impact

- Storage per edit is proportional to the change. The history index no longer inflates every later edit.
- Corruption fixed at the source — no version number reuse, so no new graft on any write path (publish, bulk publish, approval).
- Already-grafted chains recover, on next edit or via the repair path. Versions from before a graft stay unreadable; those bytes were overwritten and are gone.
- No breaking changes. Response shape unchanged unless the new flag is passed. Full engine suite passes, plus new coverage for the graft, both recoveries, the backward-compatible read, and the storage layout.
- Must land and release before the Community change that surfaces per-version change logs in its version history UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)