### PR TITLE
feat(cli): ctx login/logout + browser device-login — stop re-pasting API keys (CU-wdqcpzy2jh)

### DIFF
--- a/packages/cli/src/__tests__/credentials.test.ts
+++ b/packages/cli/src/__tests__/credentials.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from "vitest";
+import {
+  normalizeServerUrl,
+  emptyStore,
+  upsertCredential,
+  removeCredential,
+  resolveToken,
+  parseStore,
+  serializeStore,
+  type CredentialStore,
+} from "../credentials.js";
+
+describe("normalizeServerUrl", () => {
+  it("strips a trailing slash", () => {
+    expect(normalizeServerUrl("https://nest.acme.com/")).toBe(
+      "https://nest.acme.com",
+    );
+  });
+  it("lowercases scheme + host but preserves path/port casing", () => {
+    expect(normalizeServerUrl("HTTPS://Nest.ACME.com:3737")).toBe(
+      "https://nest.acme.com:3737",
+    );
+  });
+  it("throws on a non-http(s) URL", () => {
+    expect(() => normalizeServerUrl("ftp://x")).toThrow();
+    expect(() => normalizeServerUrl("not a url")).toThrow();
+  });
+});
+
+describe("upsert / remove", () => {
+  it("adds a server credential keyed by normalized url", () => {
+    const s = upsertCredential(emptyStore(), "https://a.com/", {
+      token: "cnst_a",
+    });
+    expect(s.servers["https://a.com"].token).toBe("cnst_a");
+  });
+  it("replaces the credential for the same normalized url", () => {
+    let s = upsertCredential(emptyStore(), "https://a.com", { token: "cnst_1" });
+    s = upsertCredential(s, "https://a.com/", { token: "cnst_2" });
+    expect(Object.keys(s.servers)).toEqual(["https://a.com"]);
+    expect(s.servers["https://a.com"].token).toBe("cnst_2");
+  });
+  it("first server added becomes the default", () => {
+    const s = upsertCredential(emptyStore(), "https://a.com", { token: "t" });
+    expect(s.default).toBe("https://a.com");
+  });
+  it("removing the default promotes another server, or clears it when none left", () => {
+    let s = upsertCredential(emptyStore(), "https://a.com", { token: "t1" });
+    s = upsertCredential(s, "https://b.com", { token: "t2" });
+    expect(s.default).toBe("https://a.com");
+    s = removeCredential(s, "https://a.com");
+    expect(s.default).toBe("https://b.com"); // promoted
+    s = removeCredential(s, "https://b.com");
+    expect(s.default).toBeUndefined();
+    expect(s.servers).toEqual({});
+  });
+});
+
+describe("resolveToken", () => {
+  const store: CredentialStore = {
+    version: 1,
+    default: "https://a.com",
+    servers: {
+      "https://a.com": { token: "cnst_a" },
+      "https://b.com": { token: "cnst_b" },
+    },
+  };
+  it("resolves the token for an explicit url (normalized)", () => {
+    expect(resolveToken(store, "https://b.com/")).toBe("cnst_b");
+  });
+  it("falls back to the default server when no url is given", () => {
+    expect(resolveToken(store)).toBe("cnst_a");
+  });
+  it("returns null for an unknown server", () => {
+    expect(resolveToken(store, "https://ghost.com")).toBeNull();
+  });
+  it("returns null when no url and no default", () => {
+    expect(resolveToken({ version: 1, servers: {} })).toBeNull();
+  });
+});
+
+describe("parse / serialize", () => {
+  it("round-trips a store", () => {
+    const s = upsertCredential(emptyStore(), "https://a.com", {
+      token: "cnst_a",
+      label: "me@x.com",
+    });
+    expect(parseStore(serializeStore(s))).toEqual(s);
+  });
+  it("defensively returns an empty store for junk / null", () => {
+    expect(parseStore(null)).toEqual(emptyStore());
+    expect(parseStore("{not json")).toEqual(emptyStore());
+    expect(parseStore(JSON.stringify({ servers: "nope" }))).toEqual(emptyStore());
+  });
+  it("drops malformed server entries (missing token)", () => {
+    const json = JSON.stringify({
+      version: 1,
+      servers: { "https://a.com": { nope: 1 }, "https://b.com": { token: "ok" } },
+    });
+    const parsed = parseStore(json);
+    expect(Object.keys(parsed.servers)).toEqual(["https://b.com"]);
+  });
+});

--- a/packages/cli/src/credentials.ts
+++ b/packages/cli/src/credentials.ts
@@ -1,0 +1,167 @@
+/**
+ * CLI credential store — caches a per-server API token so `ctx login` is a
+ * one-time thing and commands like `ctx push` stop re-asking for `--key`.
+ *
+ * Pure data-model here (framework-free, unit-tested in credentials.test.ts);
+ * the small filesystem I/O (read/write `~/.contextnest/credentials.json`,
+ * owner-only) lives at the bottom and is the only impure part. Keyed by
+ * normalized server URL so one machine can hold creds for several nest
+ * servers at once (cloud + self-hosted + a client's), like AWS named profiles.
+ */
+import { homedir } from "node:os";
+import { join } from "node:path";
+import {
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+  existsSync,
+  chmodSync,
+} from "node:fs";
+
+export interface ServerCredential {
+  /** Bearer token (a `cnst_…` API key) for this server. */
+  token: string;
+  /** Optional human label — typically the signed-in account email. */
+  label?: string;
+  /** ISO timestamp the credential was stored/refreshed. */
+  updatedAt?: string;
+}
+
+export interface CredentialStore {
+  version: number;
+  /** Normalized URL of the default server (used when a command omits --server). */
+  default?: string;
+  /** Credentials keyed by normalized server URL. */
+  servers: Record<string, ServerCredential>;
+}
+
+/**
+ * Canonical form of a server URL: scheme + host lowercased (via WHATWG URL),
+ * no trailing slash, no fragment. Throws for anything that isn't http(s) so a
+ * typo can't silently key a credential under a garbage string.
+ */
+export function normalizeServerUrl(raw: string): string {
+  let u: URL;
+  try {
+    u = new URL(raw);
+  } catch {
+    throw new Error(`Invalid server URL: "${raw}"`);
+  }
+  if (u.protocol !== "http:" && u.protocol !== "https:") {
+    throw new Error(`Server URL must be http(s): "${raw}"`);
+  }
+  u.hash = "";
+  return u.toString().replace(/\/$/, "");
+}
+
+export function emptyStore(): CredentialStore {
+  return { version: 1, servers: {} };
+}
+
+/** Add or replace the credential for `url`. The first server added becomes the default. */
+export function upsertCredential(
+  store: CredentialStore,
+  url: string,
+  cred: ServerCredential,
+): CredentialStore {
+  const key = normalizeServerUrl(url);
+  const servers = { ...store.servers, [key]: cred };
+  return {
+    version: store.version || 1,
+    default: store.default ?? key,
+    servers,
+  };
+}
+
+/** Remove `url`. If it was the default, promote the next remaining server (or clear). */
+export function removeCredential(
+  store: CredentialStore,
+  url: string,
+): CredentialStore {
+  const key = normalizeServerUrl(url);
+  const servers = { ...store.servers };
+  delete servers[key];
+  let def = store.default;
+  if (def === key) def = Object.keys(servers)[0];
+  const next: CredentialStore = { version: store.version || 1, servers };
+  if (def) next.default = def;
+  return next;
+}
+
+/** Token for `url` (normalized), or the default server when `url` is omitted. Null if none. */
+export function resolveToken(
+  store: CredentialStore,
+  url?: string,
+): string | null {
+  const key = url ? normalizeServerUrl(url) : store.default;
+  if (!key) return null;
+  return store.servers[key]?.token ?? null;
+}
+
+/** Defensive parse: anything malformed collapses to an empty store; junk entries are dropped. */
+export function parseStore(json: string | null): CredentialStore {
+  if (!json) return emptyStore();
+  let data: unknown;
+  try {
+    data = JSON.parse(json);
+  } catch {
+    return emptyStore();
+  }
+  if (!data || typeof data !== "object") return emptyStore();
+  const obj = data as Record<string, unknown>;
+  const rawServers =
+    obj.servers && typeof obj.servers === "object"
+      ? (obj.servers as Record<string, unknown>)
+      : {};
+  const servers: Record<string, ServerCredential> = {};
+  for (const [url, v] of Object.entries(rawServers)) {
+    if (v && typeof v === "object" && typeof (v as any).token === "string") {
+      const e = v as Record<string, unknown>;
+      const cred: ServerCredential = { token: e.token as string };
+      if (typeof e.label === "string") cred.label = e.label;
+      if (typeof e.updatedAt === "string") cred.updatedAt = e.updatedAt;
+      servers[url] = cred;
+    }
+  }
+  const out: CredentialStore = {
+    version: typeof obj.version === "number" ? obj.version : 1,
+    servers,
+  };
+  if (typeof obj.default === "string" && servers[obj.default]) {
+    out.default = obj.default;
+  }
+  return out;
+}
+
+export function serializeStore(store: CredentialStore): string {
+  return JSON.stringify(store, null, 2);
+}
+
+// ─── Filesystem I/O (the only impure part) ──────────────────────────────────
+
+export function getCredentialsPath(): string {
+  return join(homedir(), ".contextnest", "credentials.json");
+}
+
+export function readCredentialStore(): CredentialStore {
+  const path = getCredentialsPath();
+  try {
+    return parseStore(readFileSync(path, "utf-8"));
+  } catch {
+    return emptyStore();
+  }
+}
+
+export function writeCredentialStore(store: CredentialStore): void {
+  const dir = join(homedir(), ".contextnest");
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 });
+  const path = getCredentialsPath();
+  writeFileSync(path, serializeStore(store), { mode: 0o600 });
+  // Tighten perms even if the file pre-existed with looser bits — it holds
+  // bearer tokens, so keep it owner-only.
+  try {
+    chmodSync(path, 0o600);
+  } catch {
+    /* best-effort on platforms without chmod semantics */
+  }
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -12,6 +12,14 @@ import { Command, Help } from "commander";
 const pkg = createRequire(import.meta.url)("../package.json") as { version: string };
 import chalk from "chalk";
 import {
+  readCredentialStore,
+  writeCredentialStore,
+  upsertCredential,
+  removeCredential,
+  resolveToken,
+  normalizeServerUrl,
+} from "./credentials.js";
+import {
   NestStorage,
   validateDocument,
   parseSelector,
@@ -1784,6 +1792,80 @@ program
     }
   });
 
+// ─── ctx login / logout ───────────────────────────────────────────────────────
+
+program
+  .command("login <server>")
+  .description("Save an API token for a hosted ContextNest server so commands stop asking for --key")
+  .option("--key <apiKey>", "Paste an existing API key (cnst_...). Create one in the nest UI → Connect.")
+  .option("--label <text>", "Label for this credential (e.g. your email)")
+  .action(async (server: string, opts: { key?: string; label?: string }) => {
+    let url: string;
+    try {
+      url = normalizeServerUrl(server);
+    } catch (e: any) {
+      console.error(chalk.red(e.message));
+      process.exit(1);
+      return;
+    }
+    if (!opts.key) {
+      // Browser/device login can reuse this server's existing /auth/device flow,
+      // but it needs a live-server verification pass first (session-cookie
+      // capture + the /auth/keys "key already exists" 409 case), so the shipped
+      // path today is pasting a key once.
+      console.error(
+        chalk.red("Browser login isn't wired up yet.") +
+          `\n  Paste a key once instead:\n    ${chalk.cyan(`ctx login ${url} --key cnst_...`)}` +
+          `\n  (create one in the nest UI → Connect, or POST ${url}/auth/keys)`,
+      );
+      process.exit(1);
+      return;
+    }
+    const store = upsertCredential(readCredentialStore(), url, {
+      token: opts.key,
+      label: opts.label,
+      updatedAt: new Date().toISOString(),
+    });
+    writeCredentialStore(store);
+    console.log(
+      chalk.green(`Saved credential for ${url}${opts.label ? ` (${opts.label})` : ""}.`) +
+        (store.default === url ? chalk.dim("  (default)") : ""),
+    );
+    console.log(chalk.dim(`  Now: ctx push --server ${url} --nest <id>   (no --key needed)`));
+  });
+
+program
+  .command("logout [server]")
+  .description("Remove a saved server credential")
+  .option("--all", "Remove every saved credential")
+  .action((server: string | undefined, opts: { all?: boolean }) => {
+    if (opts.all) {
+      writeCredentialStore({ version: 1, servers: {} });
+      console.log(chalk.green("Removed all saved credentials."));
+      return;
+    }
+    if (!server) {
+      console.error(chalk.red("Specify a <server> URL to log out of, or use --all."));
+      process.exit(1);
+      return;
+    }
+    let url: string;
+    try {
+      url = normalizeServerUrl(server);
+    } catch (e: any) {
+      console.error(chalk.red(e.message));
+      process.exit(1);
+      return;
+    }
+    const store = readCredentialStore();
+    if (!store.servers[url]) {
+      console.log(chalk.yellow(`No saved credential for ${url}.`));
+      return;
+    }
+    writeCredentialStore(removeCredential(store, url));
+    console.log(chalk.green(`Logged out of ${url}.`));
+  });
+
 // ─── ctx push ────────────────────────────────────────────────────────────────
 
 program
@@ -1791,9 +1873,20 @@ program
   .description("Push the local vault to a hosted ContextNest server")
   .requiredOption("--server <url>", "Hosted engine URL (e.g. http://localhost:3737)")
   .requiredOption("--nest <id>", "Target nest ID")
-  .requiredOption("--key <apiKey>", "API key (cnst_...)")
+  .option("--key <apiKey>", "API key (cnst_...) — omit to reuse a token saved via `ctx login`")
   .option("--include-drafts", "Include draft documents (default: published only)", false)
   .action(async (opts) => {
+    // Prefer an explicit --key; otherwise fall back to the token saved for this
+    // server by `ctx login` (that's the whole point — stop re-pasting keys).
+    const token = opts.key || resolveToken(readCredentialStore(), opts.server);
+    if (!token) {
+      console.error(
+        chalk.red(`No API key for ${opts.server}.`) +
+          `\n  Run ${chalk.cyan(`ctx login ${opts.server} --key cnst_...`)} once, or pass --key.`,
+      );
+      process.exit(1);
+    }
+
     const storage = getStorage();
     const docs = await storage.discoverDocuments();
 
@@ -1830,7 +1923,7 @@ program
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          Authorization: `Bearer ${opts.key}`,
+          Authorization: `Bearer ${token}`,
         },
         body: JSON.stringify(body),
       });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1794,43 +1794,158 @@ program
 
 // ─── ctx login / logout ───────────────────────────────────────────────────────
 
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * Browser (device) login — reuses the server's existing device-auth flow, the
+ * same one the web UI's "Login with PromptOwl" button drives, then mints a
+ * durable API key from the resulting session so the CLI holds a bearer token:
+ *   POST /auth/device → poll /auth/device/poll → POST /auth/promptowl (session)
+ *   → POST /auth/keys (mint). One key per user, so an existing key 409s unless
+ *   --rotate replaces it (destructive — invalidates the old key everywhere).
+ * NOTE: the happy path needs a real browser approval to exercise end-to-end;
+ * the logic mirrors the shipped web flow and handles the known edge cases.
+ */
+async function deviceLogin(
+  serverUrl: string,
+  opts: { label?: string; rotate?: boolean },
+): Promise<{ token: string; label?: string }> {
+  const startRes = await fetch(`${serverUrl}/auth/device`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: "{}",
+  });
+  if (!startRes.ok) {
+    const e = (await startRes.json().catch(() => ({}))) as { error?: string };
+    throw new Error(
+      `This server doesn't offer browser login (${startRes.status})${e.error ? `: ${e.error}` : ""}. Use --key instead.`,
+    );
+  }
+  const start = (await startRes.json()) as {
+    deviceCode: string;
+    clientSecret: string;
+    verificationUrl: string;
+  };
+  console.log(
+    `\n  Approve the login in your browser:\n    ${chalk.cyan(start.verificationUrl)}\n`,
+  );
+  try {
+    openInBrowser(start.verificationUrl);
+  } catch {
+    /* the URL is printed above */
+  }
+  console.log(chalk.dim("  Waiting for approval..."));
+
+  let poToken: string | null = null;
+  for (let i = 0; i < 180; i++) {
+    await sleep(2000);
+    const pr = await fetch(
+      `${serverUrl}/auth/device/poll?code=${encodeURIComponent(start.deviceCode)}&client_secret=${encodeURIComponent(start.clientSecret)}`,
+    );
+    const pd = (await pr.json().catch(() => ({}))) as {
+      status?: string;
+      token?: string;
+    };
+    if (pd.status === "approved" && pd.token) {
+      poToken = pd.token;
+      break;
+    }
+    if (pd.status === "pending") continue;
+    throw new Error(`Login ${pd.status || "failed"}. Try again.`);
+  }
+  if (!poToken) throw new Error("Login timed out waiting for approval.");
+
+  // Exchange the PromptOwl token for a Community session, capturing the cookie.
+  const exRes = await fetch(`${serverUrl}/auth/promptowl`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ token: poToken }),
+  });
+  if (!exRes.ok) {
+    const e = (await exRes.json().catch(() => ({}))) as { error?: string };
+    throw new Error(
+      `Session exchange failed (${exRes.status})${e.error ? `: ${e.error}` : ""}.`,
+    );
+  }
+  const setCookies: string[] =
+    (exRes.headers as unknown as { getSetCookie?: () => string[] }).getSetCookie?.() ?? [];
+  const cookie = setCookies.map((c) => c.split(";")[0]).join("; ");
+  if (!cookie) throw new Error("Server did not return a session cookie.");
+  const exData = (await exRes.json().catch(() => ({}))) as {
+    user?: { email?: string };
+  };
+  const label = opts.label ?? exData.user?.email;
+
+  // Mint a durable key with the session. One key per user → 409 unless --rotate.
+  const mintRes = await fetch(
+    `${serverUrl}${opts.rotate ? "/auth/keys/rotate" : "/auth/keys"}`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Cookie: cookie },
+      body: JSON.stringify({ label: "ctx CLI" }),
+    },
+  );
+  if (mintRes.status === 409) {
+    throw new Error(
+      `You already have an API key on ${serverUrl} (one per user).\n` +
+        `  • Reuse it:   ctx login ${serverUrl} --key cnst_...\n` +
+        `  • Replace it: re-run with --rotate  (WARNING: invalidates the existing key wherever it's used)`,
+    );
+  }
+  if (!mintRes.ok) {
+    const e = (await mintRes.json().catch(() => ({}))) as { error?: string };
+    throw new Error(
+      `Could not mint an API key (${mintRes.status})${e.error ? `: ${e.error}` : ""}.`,
+    );
+  }
+  const md = (await mintRes.json()) as { api_key?: string };
+  if (!md.api_key) throw new Error("Server did not return an API key.");
+  return { token: md.api_key, label };
+}
+
 program
   .command("login <server>")
   .description("Save an API token for a hosted ContextNest server so commands stop asking for --key")
-  .option("--key <apiKey>", "Paste an existing API key (cnst_...). Create one in the nest UI → Connect.")
+  .option("--key <apiKey>", "Paste an existing API key (cnst_...) instead of the browser flow")
   .option("--label <text>", "Label for this credential (e.g. your email)")
-  .action(async (server: string, opts: { key?: string; label?: string }) => {
-    let url: string;
-    try {
-      url = normalizeServerUrl(server);
-    } catch (e: any) {
-      console.error(chalk.red(e.message));
-      process.exit(1);
-      return;
-    }
-    if (!opts.key) {
-      // Browser/device login can reuse this server's existing /auth/device flow,
-      // but it needs a live-server verification pass first (session-cookie
-      // capture + the /auth/keys "key already exists" 409 case), so the shipped
-      // path today is pasting a key once.
-      console.error(
-        chalk.red("Browser login isn't wired up yet.") +
-          `\n  Paste a key once instead:\n    ${chalk.cyan(`ctx login ${url} --key cnst_...`)}` +
-          `\n  (create one in the nest UI → Connect, or POST ${url}/auth/keys)`,
+  .option("--rotate", "During browser login, replace an existing key (invalidates the old one)")
+  .action(
+    async (
+      server: string,
+      opts: { key?: string; label?: string; rotate?: boolean },
+    ) => {
+      let url: string;
+      try {
+        url = normalizeServerUrl(server);
+      } catch (e: any) {
+        console.error(chalk.red(e.message));
+        process.exit(1);
+        return;
+      }
+      let token = opts.key;
+      let label = opts.label;
+      if (!token) {
+        // No key pasted → browser login against the server's device-auth flow.
+        try {
+          const res = await deviceLogin(url, { label, rotate: opts.rotate });
+          token = res.token;
+          label = label ?? res.label;
+        } catch (e: any) {
+          console.error(chalk.red(e.message));
+          process.exit(1);
+          return;
+        }
+      }
+      const store = upsertCredential(readCredentialStore(), url, {
+        token: token!,
+        label,
+        updatedAt: new Date().toISOString(),
+      });
+      writeCredentialStore(store);
+      console.log(
+        chalk.green(`Saved credential for ${url}${label ? ` (${label})` : ""}.`) +
+          (store.default === url ? chalk.dim("  (default)") : ""),
       );
-      process.exit(1);
-      return;
-    }
-    const store = upsertCredential(readCredentialStore(), url, {
-      token: opts.key,
-      label: opts.label,
-      updatedAt: new Date().toISOString(),
-    });
-    writeCredentialStore(store);
-    console.log(
-      chalk.green(`Saved credential for ${url}${opts.label ? ` (${opts.label})` : ""}.`) +
-        (store.default === url ? chalk.dim("  (default)") : ""),
-    );
     console.log(chalk.dim(`  Now: ctx push --server ${url} --nest <id>   (no --key needed)`));
   });
 


### PR DESCRIPTION
## What
`ctx login <server>` so the CLI authenticates **once** instead of re-pasting `--key` on every command.

- **Credential store** (`packages/cli/src/credentials.ts`, pure + unit-tested): caches a token per **normalized server URL** in `~/.contextnest/credentials.json` (owner-only 0o600); first server becomes default.
- **`ctx login <server> --key cnst_…`** — paste-once path (solid).
- **`ctx login <server>`** (no key) — **browser device-login**, reusing the server's existing chain: `POST /auth/device` → poll `/auth/device/poll` → `POST /auth/promptowl` (capture session cookie) → `POST /auth/keys` (mint `cnst_` key). `--rotate` for the one-key-per-user 409.
- **`ctx logout <server>` / `--all`**.
- **`ctx push`** — `--key` now optional; falls back to the saved token for its `--server`.

## No server changes
Consumes existing `/auth/*` endpoints only.

## Testing / review notes
- Credential-store logic verified (14 assertions) via `tsx` — **vitest can't run in this checkout** (root-owned `node_modules` block vite's `.vite-temp`); the unit test (`credentials.test.ts`) is written test-first and will run in a clean env.
- New code adds **0 type errors** (5 pre-existing base `tsc` errors are unrelated history/checkpoint arity drift).
- ⚠️ The **browser happy-path needs a real approval to exercise end-to-end** — logic mirrors the shipped web `Login.tsx` flow and handles the edge cases (non-device server, poll timeout/denied, missing cookie, 409). **@qaish — flagging for your review since you own the auth/device surface.**

Ticket: https://app.clickup.com/t/wdqcpzy2jh

🤖 Generated with [Claude Code](https://claude.com/claude-code)