### PR TITLE
Converge the CLI, MCP server and Community on one operation catalog

### DIFF
--- a/.changeset/finish-the-catalog.md
+++ b/.changeset/finish-the-catalog.md
@@ -21,3 +21,5 @@ Node summaries now carry `description` when the document has one.
 `ctx search`, `query`, `publish`, `delete` and `reconstruct` run through the catalog; `ctx search` gains `--limit`. Six more MCP tools are registered, with `search`, `resolve`, `publish_document`, `delete_document` and `read_version` kept, unchanged, and marked deprecated.
 
 Two commands deliberately stay on their own implementations, and the reason is worth recording. `ctx verify` checks each document chain and reports unreadable histories per document, which is strictly more than the vault-level integrity operation. And `ctx resolve` evaluates a selector and lists what matches — despite the shared word, that is not `context_resolve`, which returns full bodies within a token budget.
+
+`context_packs` also returns each pack's `includes` and `excludes`. Leaving them out made it a lossy view of what is on disk — a caller listing packs had to read the file itself to see what a pack actually selects. `ctx pack list` runs through the operation now.

--- a/.changeset/finish-the-catalog.md
+++ b/.changeset/finish-the-catalog.md
@@ -1,0 +1,23 @@
+---
+"@promptowl/contextnest-engine": minor
+"@promptowl/contextnest-cli": minor
+"@promptowl/contextnest-mcp-server": minor
+---
+
+The rest of the core operations become the shared path
+
+Search, selector query, resolution, publish, delete and version reconstruction were the last core operations each surface still implemented privately. They now run through the catalog, which completes the core namespace.
+
+**A version that does not exist returned a different version's content.** Reconstruction starts at the nearest keyframe at or before the version asked for and replays change logs forward. Ask for a version the history does not contain and there is nothing to replay, so it returned the keyframe's content as though it were the version requested — silently, in the one place that must never give a silently wrong answer. It refuses now. This surfaced a regression test that had been passing on exactly that wrong content: it asked for version 2 of a document left at version 1 and matched on a title both versions share.
+
+Three operations gained what a surface needed before it could adopt them:
+
+- `context_query` takes `include_drafts`, for authoring surfaces where the point is finding the draft you are working on. Without it, adoption would have silently dropped `ctx query --include-drafts`.
+- `context_publish` takes a version-history `note` and returns the `chain_hash`, both of which `ctx publish` reports.
+- `context_delete` returns the deleted node's `title`, read before removal — after the delete there is nothing left to ask.
+
+Node summaries now carry `description` when the document has one.
+
+`ctx search`, `query`, `publish`, `delete` and `reconstruct` run through the catalog; `ctx search` gains `--limit`. Six more MCP tools are registered, with `search`, `resolve`, `publish_document`, `delete_document` and `read_version` kept, unchanged, and marked deprecated.
+
+Two commands deliberately stay on their own implementations, and the reason is worth recording. `ctx verify` checks each document chain and reports unreadable histories per document, which is strictly more than the vault-level integrity operation. And `ctx resolve` evaluates a selector and lists what matches — despite the shared word, that is not `context_resolve`, which returns full bodies within a token budget.

--- a/.changeset/one-call-vault-open.md
+++ b/.changeset/one-call-vault-open.md
@@ -1,0 +1,41 @@
+---
+"@promptowl/contextnest-engine": minor
+"@promptowl/contextnest-cli": minor
+"@promptowl/contextnest-mcp-server": minor
+---
+
+Opening a vault takes one call, and `context_overview` is gone
+
+`context_init` returned only `CONTEXT.md`, `context_overview` returned counts and
+a node list, and neither returned the vault's configuration — so an agent opening
+a vault made two round trips and still could not see the config. Meanwhile the
+`vault_info` alias sat on `context_overview`, an operation that returns none of
+what `vault_info` returns.
+
+`context_init` now answers both halves of "open this vault" in one call: its
+`CONTEXT.md` instructions, its configuration (name, description, declared MCP
+servers), its path, and what it holds — total, counts by type and status, and the
+tag set. The node list itself is opt-in behind `include_nodes` (with `limit`),
+because counts and tags answer most opening questions and a large vault's node
+list dwarfs them. `vault_info` now aliases this operation, which actually returns
+what that name promises.
+
+`context_overview` is **removed**. Everything it returned, `context_init` returns.
+
+`context_init` also counts retired nodes. It discovers with `includeRetired`, so
+`by_status` can report `rejected` at all — the manifest previously omitted a whole
+status rather than reporting zero, the same defect `context_list` carried.
+
+`context_init`, `context_verify` and `context_packs` are registered as MCP tools;
+`vault_info` and `verify_integrity` keep their exact behaviour and are deprecated
+in favour of the first two.
+
+New CLI command `ctx info` shows a vault's instructions, configuration and
+contents (`--nodes` to list them, `--json` for the raw payload). It is
+deliberately **not** called `ctx init`: that command *creates* a vault, where this
+one opens an existing one — same word, opposite meaning.
+
+`ctx verify` deliberately does **not** move onto `context_verify`. It verifies
+each document chain itself and reports unreadable histories per document, which is
+strictly more than the operation's vault-level integrity check; routing it through
+the catalog would have lost that.

--- a/.changeset/shared-create-path.md
+++ b/.changeset/shared-create-path.md
@@ -31,6 +31,20 @@ triggers — stay with their surface. `create_document` keeps its exact behaviou
 and registration and is now marked deprecated in favour of `context_create`, so
 existing MCP clients are unaffected.
 
+**Vocabulary now covers what the ecosystem actually stores.** Adopting the shared
+create path made Community validate its documents against the engine schema for
+the first time, and three shapes it has always written turned out to be invalid:
+
+- `agent`, `artifact` and `table` join `NODE_TYPES`. Vaults holding them failed
+  `ctx validate` even though every surface reads and writes them.
+- `TAG_PATTERN` accepts `:`, so namespaced tags (`#dept:engineering`) validate.
+  Strictly a widening — every previously valid tag still matches. Note the
+  selector lexer does not tokenize `:` inside a tag, so namespaced tags are not
+  yet addressable in a query.
+- `context_create` accepts an initial `status`, for callers that create a node
+  directly into a lifecycle state other than draft (only meaningful alongside
+  `publish: false`).
+
 **Behaviour fix — new-document version numbering.** `ctx add` wrote
 `version: 1` into frontmatter and let publish bump it, so a brand-new document's
 history began at **v2 with no v1 keyframe**. Publish owns version assignment

--- a/.changeset/shared-create-path.md
+++ b/.changeset/shared-create-path.md
@@ -1,0 +1,38 @@
+---
+"@promptowl/contextnest-engine": minor
+"@promptowl/contextnest-cli": minor
+"@promptowl/contextnest-mcp-server": minor
+---
+
+`context_create` becomes the shared create path for every surface
+
+The operation could only derive an id from title + folder, always published, and
+could not express a skill block — so no surface could actually adopt it, and the
+CLI and MCP server each kept a private copy of "create a document". Those copies
+drifted: the same action produced different version numbers depending on which
+one you used.
+
+`context_create` now accepts:
+
+- `id` — mint your own instead of deriving from title + folder.
+- `publish: false` — leave the node a draft, for governed callers whose writes
+  must clear review before becoming retrievable.
+- `note` — recorded against the publish in version history.
+- the `skill` block fields (`trigger`, `inputs`, `tools_required`,
+  `output_format`, `guard_rails`), without which the operation could not produce
+  a valid `type: skill` node at all.
+
+Output gains `status` and `checkpoint`, and a created node now carries
+`updated_at` instead of rendering blank until its first edit.
+
+`ctx add` and a new `context_create` MCP tool both run through that one path.
+Surface-specific authoring niceties — heading and step templates, default skill
+triggers — stay with their surface. `create_document` keeps its exact behaviour
+and registration and is now marked deprecated in favour of `context_create`, so
+existing MCP clients are unaffected.
+
+**Behaviour fix — new-document version numbering.** `ctx add` wrote
+`version: 1` into frontmatter and let publish bump it, so a brand-new document's
+history began at **v2 with no v1 keyframe**. Publish owns version assignment
+(spec §6); a newly created document is now v1. The MCP server already had this
+fix, the CLI did not. Existing documents are unaffected.

--- a/.changeset/shared-list-and-versions.md
+++ b/.changeset/shared-list-and-versions.md
@@ -1,0 +1,48 @@
+---
+"@promptowl/contextnest-engine": minor
+"@promptowl/contextnest-cli": minor
+"@promptowl/contextnest-mcp-server": minor
+---
+
+`context_list` and `context_versions` become the shared browse path
+
+The CLI, the MCP server and Community each grew a private copy of "filter a
+document list", and each got a different subset of the rules right. The filter
+now lives in one place — a new exported `filterDocuments(docs, filters)` — which
+`context_list` wraps and which surfaces that filter a list they already hold can
+call directly.
+
+**Two bugs in `context_list`, both of which made a filter silently return
+nothing:**
+
+- `status: "rejected"` could never match. The executor discovered documents
+  without `includeRetired`, so retired ones were dropped before the status
+  filter ever saw them. The CLI and MCP server each worked around this
+  privately.
+- `type` compared `frontmatter.type` literally, with no `document` default. The
+  field is optional, so `type: "document"` skipped every document that omits it
+  — which is most of them.
+
+Also fixed, and previously inconsistent between surfaces: a tag now matches with
+or without its leading `#` and regardless of case. Comparing a bare filter value
+against `#`-prefixed frontmatter tags is a filter that always returns empty,
+which is worse than one that errors.
+
+`context_list` additionally accepts an **array of types**, so a caller browsing a
+family of types (every runnable type, say) no longer has to list everything and
+re-filter. Two more inputs let a governed surface adopt the operation rather than
+keep its own copy of discovery:
+
+- `include_retired` keeps retired nodes when no status filter is given. There a
+  rejected document is still something its stewards act on, not one removed from
+  the vault.
+- `full` returns each node's whole frontmatter and body instead of a summary, for
+  callers that go on to gate and render the documents and would otherwise have to
+  read every file a second time.
+
+`ctx list` gains `--limit` and now runs through the operation. `ctx history` runs
+through `context_versions` and gains `--diff`, which it could not do at all
+before. Both `context_list` and `context_versions` are registered as MCP tools;
+`list_documents` keeps its exact behaviour and is marked deprecated in favour of
+`context_list`. `context_versions` is a new capability there — nothing exposed
+version history before, since `read_version` answers a different question.

--- a/.changeset/shared-list-and-versions.md
+++ b/.changeset/shared-list-and-versions.md
@@ -55,6 +55,12 @@ carry no such prefix pointed at a document that does not exist — the same fix
 `context_update` and `context_import` already took, now applied to every
 selector-based operation.
 
+An id is therefore taken **exactly as stored**: a bare slug is no longer
+re-rooted under `nodes/`, so a caller migrating from `read_document` (which did
+re-root) must pass the full id. A trailing `.md` and leading slashes are still
+stripped, since callers build ids from file paths and storage appends `.md`
+itself.
+
 `context_get` gains three inputs, each one a thing a surface previously had to
 bypass the operation to do: `include_raw` returns the exact stored bytes for
 callers that re-serve the file verbatim, `verify_checksum` detects drift on read,

--- a/.changeset/shared-list-and-versions.md
+++ b/.changeset/shared-list-and-versions.md
@@ -4,7 +4,7 @@
 "@promptowl/contextnest-mcp-server": minor
 ---
 
-`context_list` and `context_versions` become the shared browse path
+`context_list`, `context_get` and `context_versions` become the shared browse path
 
 The CLI, the MCP server and Community each grew a private copy of "filter a
 document list", and each got a different subset of the rules right. The filter
@@ -40,7 +40,30 @@ keep its own copy of discovery:
   callers that go on to gate and render the documents and would otherwise have to
   read every file a second time.
 
-`ctx list` gains `--limit` and now runs through the operation. `ctx history` runs
+**An operation whose input carried a `.refine()` could not be exposed over MCP at
+all.** A refine makes the input a `ZodEffects`, which has no `.shape` — and that
+shape is exactly what a tool is registered from. The SDK accepted the undefined
+value and published a tool advertising **no parameters**, so a client had no way
+to know what to send; `context_versions` shipped that way. The selector schemas
+are plain objects now and `resolveId` raises the same `VALIDATION_FAILED` at
+execution time. A regression test asserts each catalog tool advertises its
+declared inputs, which the old "inputSchema is defined" check sailed past.
+
+**Reading a node from a flat-layout vault returned NOT_FOUND.** `resolveId`
+re-rooted a bare id under `nodes/`, so every id from a vault whose documents
+carry no such prefix pointed at a document that does not exist — the same fix
+`context_update` and `context_import` already took, now applied to every
+selector-based operation.
+
+`context_get` gains three inputs, each one a thing a surface previously had to
+bypass the operation to do: `include_raw` returns the exact stored bytes for
+callers that re-serve the file verbatim, `verify_checksum` detects drift on read,
+and `allow_rejected` returns a retired node instead of refusing — reading one is
+not the same as republishing it. It is registered as an MCP tool, with
+`read_document` deprecated in its favour.
+
+`ctx read` runs through it. `ctx list` gains `--limit` and now runs through the
+operation. `ctx history` runs
 through `context_versions` and gains `--diff`, which it could not do at all
 before. Both `context_list` and `context_versions` are registered as MCP tools;
 `list_documents` keeps its exact behaviour and is marked deprecated in favour of

--- a/.changeset/shared-update-path.md
+++ b/.changeset/shared-update-path.md
@@ -1,0 +1,59 @@
+---
+"@promptowl/contextnest-engine": minor
+"@promptowl/contextnest-cli": minor
+"@promptowl/contextnest-mcp-server": minor
+---
+
+`context_update` becomes the shared update path for every surface
+
+The operation could not rename a node, could not set a status, and always
+published — so no surface could adopt it, and the CLI, MCP server and Community
+each kept a private copy of "edit a document". The copies drifted, and one rule
+in particular ("a lifecycle status change is metadata, not a release") was
+hand-rolled identically in two places and absent from a third.
+
+`context_update` now accepts:
+
+- `title` as the **new** title. It was previously a way to *select* the node to
+  update — but every surface addresses a node by id or path and sends a title
+  only to rename, so selecting by title served no caller and collided with the
+  field they all wanted. Selection is by `id`.
+- `status` — a canonical lifecycle status (normalize aliases with
+  `normalizeStatus` before calling).
+- `publish` — defaults to true, and to **false** when `status` names a
+  non-published lifecycle value, because those are metadata transitions rather
+  than content releases. An explicit value always wins. This is the rule the CLI
+  and MCP server each carried privately.
+- `note` — recorded against the publish in version history.
+- `version` — an explicit version to stamp, for governed callers that assign
+  version numbers themselves for a revision awaiting review. Ignored when
+  publishing, which assigns its own.
+
+Output gains `status` and `checkpoint`, mirroring `context_create`.
+
+Three behaviour changes come with it:
+
+- **`tags` replaces rather than merges**, matching the CLI, the MCP server and
+  `context_create`. A caller that wants the old merge sends the merged set.
+- **`metadata` treats a null value as "clear this key".** A merge alone gave
+  callers no way to remove metadata at all: over a JSON wire an absent key is
+  indistinguishable from "leave this alone".
+- **A rejected document is refused only when no `status` is given.** Naming a new
+  status is how a caller revives one, which the MCP server already allowed and
+  the operation previously blocked outright.
+- **A body edit drops the stored checksum before writing.** The checksum
+  describes the published body, so an edit whose publish then fails used to
+  leave a stale one on disk and the next verified read reported the document as
+  externally modified. Frontmatter-only edits keep it — the checksum covers the
+  body alone.
+
+**Bug fix — updating a flat-layout vault.** The operation re-rooted a bare
+document id under `nodes/`, which silently redirected every id from a vault whose
+documents don't carry that prefix. Ids are now vetted for traversal without being
+rewritten, and the storage layer resolves them for its own layout — the same fix
+`context_import` took for its `ids` input.
+
+`ctx update` and a new `context_update` MCP tool both run through that one path.
+`update_document` keeps its exact behaviour and registration (including its status
+aliases) and is now marked deprecated in favour of `context_update`, so existing
+MCP clients are unaffected.

--- a/packages/cli/src/__tests__/cli.regression.test.ts
+++ b/packages/cli/src/__tests__/cli.regression.test.ts
@@ -484,8 +484,14 @@ describe("[regression] ctx publish, history & reconstruct", () => {
   });
 
   it("reconstruct returns the serialized content for a known version", () => {
+    // beforeEach leaves the doc at v1, so v2 has to be cut here. This asked for
+    // v2 without publishing and passed anyway: reconstruct fell back to the
+    // nearest keyframe and handed back v1, which carries the same title.
+    runCtx(tmp, ["publish", "nodes/release", "-m", "cut"]);
     const content = runCtx(tmp, ["reconstruct", "nodes/release", "2"]);
     expect(content).toMatch(/title:\s*Release Doc/);
+    // Assert the VERSION, not just the title — that is what tells v2 from v1.
+    expect(content).toMatch(/version:\s*2/);
   });
 
   /** Highest checkpoint number currently sealed in the vault. */
@@ -1079,8 +1085,19 @@ describe("[regression] add/update edge cases", () => {
     expect(res.stderr).not.toMatch(/^\s+at\s/m);
   });
 
-  it("reconstruct without version history fails with a friendly error, no stack trace", () => {
+  it("reconstruct names the missing document, not a missing version, no stack trace", () => {
+    // Asking for v1 of a document that does not exist is a missing DOCUMENT.
+    // Saying VERSION_NOT_FOUND sends the reader hunting through a history that
+    // was never going to be there either.
     const res = runCtxResult(tmp, ["reconstruct", "nodes/never-existed", "1"]);
+    expect(res.status).not.toBe(0);
+    expect(res.stderr).toMatch(/Error \[DOCUMENT_NOT_FOUND\]/);
+    expect(res.stderr).not.toMatch(/^\s+at\s/m);
+  });
+
+  it("reconstruct reports a missing VERSION of a document that does exist", () => {
+    runCtx(tmp, ["add", "nodes/only-v1", "--title", "Only V1"]);
+    const res = runCtxResult(tmp, ["reconstruct", "nodes/only-v1", "99"]);
     expect(res.status).not.toBe(0);
     expect(res.stderr).toMatch(/Error \[VERSION_NOT_FOUND\]/);
     expect(res.stderr).not.toMatch(/^\s+at\s/m);

--- a/packages/cli/src/__tests__/cli.regression.test.ts
+++ b/packages/cli/src/__tests__/cli.regression.test.ts
@@ -194,8 +194,11 @@ describe("[regression] ctx add", () => {
   it("creates and auto-publishes a document at checkpoint 1", () => {
     const out = runCtx(tmp, ["add", "nodes/alpha", "--title", "Alpha Doc"]);
     expect(out).toMatch(/Created and published nodes\/alpha\.md/);
-    // init seeds v1; the publish on add bumps to v2.
-    expect(out).toMatch(/Version: 2/);
+    // A brand-new document's first published version is 1. `add` used to
+    // pre-set version:1 in frontmatter and let publish bump it, so the doc's
+    // history started at v2 with no v1 keyframe at all. Publish owns version
+    // assignment (spec §6) — the shared create path enforces that.
+    expect(out).toMatch(/Version: 1/);
     expect(out).toMatch(/Checkpoint: 1/);
 
     const onDisk = readFileSync(join(tmp, "nodes", "alpha.md"), "utf-8");
@@ -420,8 +423,8 @@ describe("[regression] ctx update", () => {
   it("a content edit auto-publishes and bumps the version", () => {
     const out = runCtx(tmp, ["update", "nodes/mutable", "--body", "Revised body"]);
     expect(out).toMatch(/Updated and published nodes\/mutable/);
-    // add landed at v2; a content update cuts v3.
-    expect(out).toMatch(/Version: 3/);
+    // add landed at v1; a content update cuts v2.
+    expect(out).toMatch(/Version: 2/);
 
     const onDisk = readFileSync(join(tmp, "nodes", "mutable.md"), "utf-8");
     expect(onDisk).toMatch(/Revised body/);
@@ -465,7 +468,7 @@ describe("[regression] ctx publish, history & reconstruct", () => {
   it("publish bumps the version, advances the checkpoint, and reports a chain hash", () => {
     const out = runCtx(tmp, ["publish", "nodes/release", "-m", "second cut"]);
     expect(out).toMatch(/Published nodes\/release/);
-    expect(out).toMatch(/Version: 3/);
+    expect(out).toMatch(/Version: 2/);
     expect(out).toMatch(/Chain hash: sha256:/);
   });
 
@@ -473,8 +476,8 @@ describe("[regression] ctx publish, history & reconstruct", () => {
     runCtx(tmp, ["publish", "nodes/release", "-m", "cut"]);
     const history = JSON.parse(runCtx(tmp, ["history", "nodes/release", "--json"]));
     const versions = history.versions.map((v: { version: number }) => v.version);
+    expect(versions).toContain(1);
     expect(versions).toContain(2);
-    expect(versions).toContain(3);
     for (const v of history.versions) {
       expect(v.chain_hash).toMatch(/^sha256:/);
     }
@@ -554,7 +557,7 @@ describe("[regression] ctx verify", () => {
 
   it("detects a tampered keyframe and exits non-zero", () => {
     appendFileSync(
-      join(tmp, "nodes", ".versions", "sealed", "v2.md"),
+      join(tmp, "nodes", ".versions", "sealed", "v1.md"),
       "\ntampered content\n",
     );
     const res = runCtxResult(tmp, ["verify"]);
@@ -929,25 +932,25 @@ describe("[regression] flows", () => {
   beforeEach(() => initVault(tmp));
 
   it("full document lifecycle: add → read → update → history → reconstruct → delete", () => {
-    // add (auto-publishes the seeded doc to v2)
+    // add (auto-publishes the new doc at v1)
     const added = runCtx(tmp, ["add", "nodes/lc", "--title", "Lifecycle", "--body", "first body"]);
-    expect(added).toMatch(/Version: 2/);
+    expect(added).toMatch(/Version: 1/);
 
     // read shows the current body
     expect(runCtx(tmp, ["read", "nodes/lc"])).toContain("first body");
 
     // a content edit auto-publishes a new version
     const updated = runCtx(tmp, ["update", "nodes/lc", "--body", "second body"]);
-    expect(updated).toMatch(/Version: 3/);
+    expect(updated).toMatch(/Version: 2/);
 
     // history records both published versions with chain hashes
     const history = JSON.parse(runCtx(tmp, ["history", "nodes/lc", "--json"]));
     const versions = history.versions.map((v: { version: number }) => v.version);
-    expect(versions).toEqual(expect.arrayContaining([2, 3]));
+    expect(versions).toEqual(expect.arrayContaining([1, 2]));
 
     // each version reconstructs to the body it was published with
-    expect(runCtx(tmp, ["reconstruct", "nodes/lc", "2"])).toContain("first body");
-    expect(runCtx(tmp, ["reconstruct", "nodes/lc", "3"])).toContain("second body");
+    expect(runCtx(tmp, ["reconstruct", "nodes/lc", "1"])).toContain("first body");
+    expect(runCtx(tmp, ["reconstruct", "nodes/lc", "2"])).toContain("second body");
 
     // delete removes the doc and its version history; reads then fail
     runCtx(tmp, ["delete", "nodes/lc"]);
@@ -1001,7 +1004,7 @@ describe("[regression] flows", () => {
 
     // approving merges the edit and bumps the version
     const approved = JSON.parse(runCtx(tmp, ["drift", "approve", "nodes/policy", sid, "--json"]));
-    expect(approved.versionEntry.version).toBe(3);
+    expect(approved.versionEntry.version).toBe(2);
 
     // the suggestion is archived and the vault is clean again
     expect(JSON.parse(runCtx(tmp, ["drift", "list", "nodes/policy", "--json"])).count).toBe(0);
@@ -1110,7 +1113,7 @@ describe("[regression] integrity — keyframe tamper", () => {
   it("ctx verify reports content_hash_mismatch when a version keyframe is tampered", () => {
     // Canonical .md and history.yaml are untouched — only a keyframe re-hash
     // can surface this corruption.
-    appendFileSync(join(tmp, "nodes", ".versions", "archived", "v2.md"), "\nrewritten history\n");
+    appendFileSync(join(tmp, "nodes", ".versions", "archived", "v1.md"), "\nrewritten history\n");
     const res = runCtxResult(tmp, ["verify", "--json"]);
     expect(res.status).toBe(1);
     const parsed = JSON.parse(res.stdout);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1854,19 +1854,21 @@ packCmd
   .option("--json", "Output as JSON")
   .action(async (opts) => {
     const storage = getStorage();
-    const packs = await storage.readPacks();
+    const { packs } = await createEngineApi().run<{
+      packs: Array<{ id: string; label: string; description?: string }>;
+    }>("context_packs", {}, opContext(storage, "cli@contextnest.local"));
 
     if (opts.json) {
       console.log(JSON.stringify(packs, null, 2));
-    } else {
-      if (packs.length === 0) {
-        console.log(chalk.yellow("No packs found."));
-      } else {
-        for (const pack of packs) {
-          console.log(`  ${chalk.cyan(`pack:${pack.id}`)} — ${pack.label}`);
-          if (pack.description) console.log(`    ${pack.description}`);
-        }
-      }
+      return;
+    }
+    if (packs.length === 0) {
+      console.log(chalk.yellow("No packs found."));
+      return;
+    }
+    for (const pack of packs) {
+      console.log(`  ${chalk.cyan(`pack:${pack.id}`)} — ${pack.label}`);
+      if (pack.description) console.log(`    ${pack.description}`);
     }
   });
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1206,29 +1206,43 @@ async function publishAll(storage: NestStorage, author: string): Promise<void> {
 program
   .command("history <path>")
   .description("Show version history for a document")
+  .option("--diff", "Include each version's unified diff from the one before")
   .option("--json", "Output as JSON")
   .action(async (path, opts) => {
     const storage = getStorage();
     const id = normalizeDocumentId(path);
-    const vm = new VersionManager(storage);
-    const history = await vm.getHistory(id);
+    const history = await createEngineApi().run<{
+      id: string;
+      keyframe_interval: number;
+      versions: Array<{
+        version: number;
+        keyframe: boolean;
+        edited_by: string;
+        edited_at: string;
+        published_at?: string;
+        note?: string;
+        chain_hash: string;
+        diff?: string;
+      }>;
+    }>("context_versions", { id, ...(opts.diff ? { include_diff: true } : {}) }, opContext(storage, "cli@contextnest.local"));
 
-    if (!history) {
+    if (history.versions.length === 0) {
       console.log(chalk.yellow(`No version history for ${id}`));
       return;
     }
 
     if (opts.json) {
       console.log(JSON.stringify(history, null, 2));
-    } else {
-      console.log(chalk.bold(`Version history for ${id}:\n`));
-      for (const entry of history.versions) {
-        const keyframe = entry.keyframe ? chalk.blue(" [keyframe]") : "";
-        const published = entry.published_at ? chalk.green(" published") : chalk.yellow(" draft");
-        console.log(`  v${entry.version}${keyframe}${published}`);
-        console.log(`    By: ${entry.edited_by} at ${entry.edited_at}`);
-        if (entry.note) console.log(`    Note: ${entry.note}`);
-      }
+      return;
+    }
+    console.log(chalk.bold(`Version history for ${id}:\n`));
+    for (const entry of history.versions) {
+      const keyframe = entry.keyframe ? chalk.blue(" [keyframe]") : "";
+      const published = entry.published_at ? chalk.green(" published") : chalk.yellow(" draft");
+      console.log(`  v${entry.version}${keyframe}${published}`);
+      console.log(`    By: ${entry.edited_by} at ${entry.edited_at}`);
+      if (entry.note) console.log(`    Note: ${entry.note}`);
+      if (entry.diff) console.log(entry.diff.replace(/^/gm, "    "));
     }
   });
 
@@ -1552,57 +1566,49 @@ program
   .option("-t, --type <type>", "Filter by node type")
   .option("-s, --status <status>", "Filter by status (draft|pending_review|approved|published|rejected; aliases accepted)")
   .option("--tag <tag>", "Filter by tag")
+  .option("--limit <n>", "Max documents to return", (v) => parseInt(v, 10))
   .option("--json", "Output as JSON")
   .action(async (opts) => {
     const storage = getStorage();
-    // Include retired so users can list them with `--status rejected`; the
-    // default branch below re-filters them out when no status is requested.
-    let docs = await storage.discoverDocuments({ includeRetired: true });
-
-    if (opts.type) docs = docs.filter((d) => (d.frontmatter.type || "document") === opts.type);
-    if (opts.status) {
-      const wanted = normalizeStatus(opts.status);
-      docs = docs.filter((d) => (d.frontmatter.status || "draft") === wanted);
-    } else {
-      docs = docs.filter((d) => d.frontmatter.status !== "rejected");
-    }
-    if (opts.tag) {
-      const normalizedTag = opts.tag.startsWith("#") ? opts.tag : `#${opts.tag}`;
-      docs = docs.filter((d) => d.frontmatter.tags?.includes(normalizedTag));
-    }
+    // Aliases collapse here; the operation owns the rest of the filtering,
+    // including hiding retired documents when no status was asked for.
+    const { documents } = await createEngineApi().run<{
+      documents: Array<{
+        id: string;
+        title: string;
+        type: string;
+        status: string;
+        tags?: string[];
+      }>;
+    }>(
+      "context_list",
+      {
+        ...(opts.type ? { type: opts.type } : {}),
+        ...(opts.status ? { status: normalizeStatus(opts.status) } : {}),
+        ...(opts.tag ? { tag: opts.tag } : {}),
+        ...(opts.limit ? { limit: opts.limit } : {}),
+      },
+      opContext(storage, "cli@contextnest.local"),
+    );
 
     if (opts.json) {
-      console.log(
-        JSON.stringify(
-          docs.map((d) => ({
-            id: d.id,
-            title: d.frontmatter.title,
-            type: d.frontmatter.type || "document",
-            status: d.frontmatter.status || "draft",
-            tags: d.frontmatter.tags,
-          })),
-          null,
-          2,
-        ),
-      );
-    } else {
-      if (docs.length === 0) {
-        console.log(chalk.yellow("No documents found."));
-      } else {
-        console.log(chalk.bold(`${docs.length} document(s):\n`));
-        for (const doc of docs) {
-          const type = doc.frontmatter.type || "document";
-          const status = doc.frontmatter.status || "draft";
-          const statusColor =
-            status === "published" ? chalk.green
-            : status === "approved" ? chalk.cyan
-            : status === "pending_review" ? chalk.magenta
-            : status === "rejected" ? chalk.red
-            : chalk.yellow;
-          console.log(`  ${chalk.cyan(doc.id)} [${type}] ${statusColor(status)}`);
-          console.log(`    ${doc.frontmatter.title}`);
-        }
-      }
+      console.log(JSON.stringify(documents, null, 2));
+      return;
+    }
+    if (documents.length === 0) {
+      console.log(chalk.yellow("No documents found."));
+      return;
+    }
+    console.log(chalk.bold(`${documents.length} document(s):\n`));
+    for (const doc of documents) {
+      const statusColor =
+        doc.status === "published" ? chalk.green
+        : doc.status === "approved" ? chalk.cyan
+        : doc.status === "pending_review" ? chalk.magenta
+        : doc.status === "rejected" ? chalk.red
+        : chalk.yellow;
+      console.log(`  ${chalk.cyan(doc.id)} [${doc.type}] ${statusColor(doc.status)}`);
+      console.log(`    ${doc.title}`);
     }
   });
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -851,7 +851,26 @@ program
   .action(async (path, opts) => {
     const storage = getStorage();
     const id = normalizeDocumentId(path);
-    const doc = await storage.readDocument(id);
+    // allow_rejected: `ctx read` has always shown a retired document — reading
+    // one is not republishing it, and refusing would hide it from the person
+    // deciding whether to revive it.
+    const got = await createEngineApi().run<{
+      id: string;
+      frontmatter: ContextNode["frontmatter"];
+      body: string;
+      raw?: string;
+    }>(
+      "context_get",
+      { id, include_raw: true, allow_rejected: true },
+      opContext(storage, "cli@contextnest.local"),
+    );
+    const doc: ContextNode = {
+      id: got.id,
+      filePath: "",
+      rawContent: got.raw ?? "",
+      frontmatter: got.frontmatter,
+      body: got.body,
+    };
 
     if (opts.raw) {
       console.log(doc.rawContent);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -244,6 +244,22 @@ const permissiveRbac: RbacHook = {
   isDocOwner: () => true,
 };
 
+/** Engine primitives an operation runs against, for one vault. */
+function opContext(
+  storage: NestStorage,
+  actor: string,
+  onProgress?: (done: number, total: number) => void,
+): OperationContext {
+  return {
+    storage,
+    query: new GraphQueryEngine(storage),
+    versions: new VersionManager(storage),
+    rbac: permissiveRbac,
+    actor,
+    onProgress,
+  };
+}
+
 // Interactively prompt the user to pick a starter recipe using an arrow-key
 // navigable list (↑/↓ to move, Enter to select, Esc to skip). Resolves to the
 // chosen recipe id, or null if the user skips. Callers MUST only invoke this
@@ -958,27 +974,30 @@ program
       body = `\n# ${title}\n\n`;
     }
 
-    const node: ContextNode = {
-      id,
-      filePath: "",
-      frontmatter,
-      body,
-      rawContent: "",
-    };
+    // Scaffolding above stays a CLI concern (heading/steps templates are an
+    // authoring nicety, not vault semantics); the write + publish + index pass
+    // goes through the catalog so this matches every other surface.
+    const result = await createEngineApi().run<{
+      id: string;
+      version: number;
+      checkpoint: number | null;
+    }>(
+      "context_create",
+      {
+        id,
+        title,
+        content: body,
+        type: opts.type,
+        ...(tagList ? { tags: tagList } : {}),
+        ...(frontmatter.skill ?? {}),
+        note: "Created via CLI",
+      },
+      opContext(storage, "cli@contextnest.local"),
+    );
 
-    const content = serializeDocument(node);
-    await storage.writeDocument(id, content);
-
-    const result = await publishDocument(storage, id, {
-      editedBy: "cli@contextnest.local",
-      note: "Created via CLI",
-    });
-
-    await regenerateIndex(storage);
-
-    console.log(chalk.green(`Created and published ${id}.md`));
-    console.log(`  Version: ${result.node.frontmatter.version}`);
-    console.log(`  Checkpoint: ${result.checkpointNumber}`);
+    console.log(chalk.green(`Created and published ${result.id}.md`));
+    console.log(`  Version: ${result.version}`);
+    console.log(`  Checkpoint: ${result.checkpoint}`);
   });
 
 // ─── ctx validate ──────────────────────────────────────────────────────────────
@@ -1156,21 +1175,14 @@ async function publishAll(storage: NestStorage, author: string): Promise<void> {
     return;
   }
 
-  const ctx: OperationContext = {
-    storage,
-    query: new GraphQueryEngine(storage),
-    versions: new VersionManager(storage),
-    rbac: permissiveRbac,
-    actor: author,
-    onProgress: (done, total) => {
-      // Single rewritten line; fall back to plain lines when piped to a file.
-      if (process.stdout.isTTY) {
-        process.stdout.write(`\rPublishing ${done}/${total}…`);
-      } else if (done === total) {
-        console.log(`Publishing ${done}/${total}`);
-      }
-    },
-  };
+  const ctx = opContext(storage, author, (done, total) => {
+    // Single rewritten line; fall back to plain lines when piped to a file.
+    if (process.stdout.isTTY) {
+      process.stdout.write(`\rPublishing ${done}/${total}…`);
+    } else if (done === total) {
+      console.log(`Publishing ${done}/${total}`);
+    }
+  });
 
   const result = await createEngineApi().run<{
     published: { id: string; version: number }[];

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1278,6 +1278,74 @@ program
     console.log(content);
   });
 
+// ─── ctx info ─────────────────────────────────────────────────────────────────
+//
+// Named `info`, not `init`: `ctx init` CREATES a vault, while the operation
+// behind this one opens an existing vault (its instructions, config and what it
+// holds). Same word, opposite meaning — worth keeping apart on the CLI.
+
+program
+  .command("info")
+  .description("Show the vault's instructions, configuration and contents")
+  .option("--nodes", "Also list every node")
+  .option("--json", "Output as JSON")
+  .action(async (opts) => {
+    const storage = getStorage();
+    const out = await createEngineApi().run<{
+      context_md: string | null;
+      vault_path: string;
+      config: { name: string; description?: string; servers: string[] } | null;
+      total: number;
+      by_type: Record<string, number>;
+      by_status: Record<string, number>;
+      tags: string[];
+      nodes?: Array<{ id: string; title: string; type: string }>;
+    }>(
+      "context_init",
+      opts.nodes ? { include_nodes: true } : {},
+      opContext(storage, "cli@contextnest.local"),
+    );
+
+    if (opts.json) {
+      console.log(JSON.stringify(out, null, 2));
+      return;
+    }
+
+    console.log(chalk.bold(out.config?.name ?? "Vault"));
+    if (out.config?.description) console.log(chalk.dim(out.config.description));
+    console.log(chalk.dim(out.vault_path));
+    console.log();
+    console.log(`${chalk.bold(String(out.total))} node(s)`);
+    for (const [type, count] of Object.entries(out.by_type).sort((a, b) => b[1] - a[1])) {
+      console.log(`  ${chalk.cyan(type)}: ${count}`);
+    }
+    if (Object.keys(out.by_status).length) {
+      console.log(chalk.dim("status:"));
+      for (const [status, count] of Object.entries(out.by_status).sort((a, b) => b[1] - a[1])) {
+        console.log(`  ${status}: ${count}`);
+      }
+    }
+    if (out.tags.length) {
+      console.log(chalk.dim("tags:") + " " + out.tags.map((t) => chalk.cyan(t)).join(" "));
+    }
+    if (out.config?.servers.length) {
+      console.log(chalk.dim("servers:") + " " + out.config.servers.join(", "));
+    }
+    if (out.nodes) {
+      console.log();
+      for (const n of out.nodes) {
+        console.log(`  ${chalk.cyan(n.id)} [${n.type}]`);
+        console.log(`    ${n.title}`);
+      }
+    }
+    console.log();
+    console.log(
+      out.context_md
+        ? chalk.dim("CONTEXT.md:\n") + out.context_md
+        : chalk.yellow("No CONTEXT.md — run `ctx init` to scaffold one."),
+    );
+  });
+
 // ─── ctx verify ────────────────────────────────────────────────────────────────
 
 program

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1617,67 +1617,53 @@ program
   .option("--body <body>", "New markdown body content")
   .action(async (path, opts) => {
     const storage = getStorage();
-    const id = normalizeDocumentId(path);
-    const doc = await storage.readDocument(id);
+    // Aliases (`cancelled`, `submitted`, `active`, …) collapse here: the op
+    // takes canonical statuses only. It decides from that status whether this
+    // is a content release or a lifecycle transition, so the CLI no longer
+    // carries its own copy of that rule.
+    const status = opts.status !== undefined ? normalizeStatus(opts.status) : undefined;
+    const result = await createEngineApi().run<{
+      id: string;
+      version: number;
+      status: string;
+      checkpoint: number | null;
+    }>(
+      "context_update",
+      {
+        id: normalizeDocumentId(path),
+        ...(opts.title !== undefined ? { title: opts.title } : {}),
+        ...(status !== undefined ? { status } : {}),
+        ...(opts.tags !== undefined
+          ? {
+              tags: opts.tags
+                .split(/[,\s]+/)
+                .filter((t: string) => t.length > 0)
+                .map((t: string) => (t.startsWith("#") ? t : `#${t}`)),
+            }
+          : {}),
+        ...(opts.body !== undefined ? { content: `\n${opts.body}\n` } : {}),
+        note: "Updated via CLI",
+      },
+      opContext(storage, "cli@contextnest.local"),
+    );
 
-    if (opts.title !== undefined) doc.frontmatter.title = opts.title;
-    if (opts.status !== undefined) {
-      doc.frontmatter.status = normalizeStatus(opts.status);
-    }
-    if (opts.tags !== undefined) {
-      doc.frontmatter.tags = opts.tags.split(/[,\s]+/).filter((t: string) => t.length > 0).map((t: string) => (t.startsWith("#") ? t : `#${t}`));
-    }
-    doc.frontmatter.updated_at = new Date().toISOString();
-
-    if (opts.body !== undefined) {
-      doc.body = `\n${opts.body}\n`;
-    }
-
-    const validation = validateDocument(doc);
-    if (!validation.valid) {
-      console.log(chalk.red("Validation failed:"));
-      for (const err of validation.errors) {
-        console.log(`  Rule ${err.rule}: ${err.message}${err.field ? ` (${err.field})` : ""}`);
-      }
-      process.exit(1);
-    }
-
-    const content = serializeDocument(doc);
-    await storage.writeDocument(id, content);
-
-    // Non-published lifecycle paths skip auto-publish — those are metadata
-    // changes, not content releases. Mirrors MCP `update_document`.
-    if (
-      opts.status !== undefined &&
-      (doc.frontmatter.status === "rejected" ||
-        doc.frontmatter.status === "approved" ||
-        doc.frontmatter.status === "pending_review" ||
-        doc.frontmatter.status === "draft")
-    ) {
-      await regenerateIndex(storage);
+    if (result.checkpoint === null) {
       const label =
-        doc.frontmatter.status === "rejected"
+        result.status === "rejected"
           ? "retired"
-          : doc.frontmatter.status === "pending_review"
+          : result.status === "pending_review"
             ? "submitted for review"
-            : doc.frontmatter.status === "approved"
+            : result.status === "approved"
               ? "marked approved"
               : "reverted to draft";
-      console.log(chalk.green(`Updated and ${label}: ${id}`));
+      console.log(chalk.green(`Updated and ${label}: ${result.id}`));
       console.log(chalk.dim("  No new version cut. Run `ctx publish` to release."));
       return;
     }
 
-    const result = await publishDocument(storage, id, {
-      editedBy: "cli@contextnest.local",
-      note: "Updated via CLI",
-    });
-
-    await regenerateIndex(storage);
-
-    console.log(chalk.green(`Updated and published ${id}`));
-    console.log(`  Version: ${result.node.frontmatter.version}`);
-    console.log(`  Checkpoint: ${result.checkpointNumber}`);
+    console.log(chalk.green(`Updated and published ${result.id}`));
+    console.log(`  Version: ${result.version}`);
+    console.log(`  Checkpoint: ${result.checkpoint}`);
   });
 
 // ─── ctx delete ───────────────────────────────────────────────────────────────

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1171,19 +1171,24 @@ program
       process.exit(1);
     }
 
-    const id = normalizeDocumentId(path);
+    const result = await createEngineApi().run<{
+      id: string;
+      version: number;
+      checkpoint: number;
+      chain_hash: string;
+    }>(
+      "context_publish",
+      {
+        id: normalizeDocumentId(path),
+        ...(opts.message ? { note: opts.message } : {}),
+      },
+      opContext(storage, opts.author),
+    );
 
-    const result = await publishDocument(storage, id, {
-      editedBy: opts.author,
-      note: opts.message,
-    });
-
-    await regenerateIndex(storage);
-
-    console.log(chalk.green(`Published ${id}`));
-    console.log(`  Version: ${result.node.frontmatter.version}`);
-    console.log(`  Checkpoint: ${result.checkpointNumber}`);
-    console.log(`  Chain hash: ${result.versionEntry.chain_hash}`);
+    console.log(chalk.green(`Published ${result.id}`));
+    console.log(`  Version: ${result.version}`);
+    console.log(`  Checkpoint: ${result.checkpoint}`);
+    console.log(`  Chain hash: ${result.chain_hash}`);
   });
 
 /**
@@ -1280,9 +1285,11 @@ program
   .description("Reconstruct a specific version of a document")
   .action(async (path, version) => {
     const storage = getStorage();
-    const id = normalizeDocumentId(path);
-    const vm = new VersionManager(storage);
-    const content = await vm.reconstructVersion(id, parseInt(version, 10));
+    const { content } = await createEngineApi().run<{ content: string }>(
+      "context_reconstruct",
+      { id: normalizeDocumentId(path), version: parseInt(version, 10) },
+      opContext(storage, "cli@contextnest.local"),
+    );
     console.log(content);
   });
 
@@ -1606,12 +1613,21 @@ program
 
     // Local query — graph-aware traversal
     const storage = getStorage();
-    const engine = new GraphQueryEngine(storage);
-    const result = await engine.query(selector, {
-      hops: opts.hops ?? 2,
-      full: opts.full ?? false,
-      includeDrafts: opts.includeDrafts ?? false,
-    });
+    type Doc = { id: string; title: string; body?: string; source?: unknown };
+    const result = await createEngineApi().run<{
+      documents: Doc[];
+      source_nodes?: Doc[];
+      traversal?: { mode: string; hops_used: number; nodes_traversed: number };
+    }>(
+      "context_query",
+      {
+        query: selector,
+        ...(opts.hops !== undefined ? { hops: opts.hops } : {}),
+        ...(opts.full ? { full: true } : {}),
+        ...(opts.includeDrafts ? { include_drafts: true } : {}),
+      },
+      opContext(storage, "cli@contextnest.local"),
+    );
 
     if (opts.json) {
       console.log(
@@ -1619,19 +1635,18 @@ program
           {
             documents: result.documents.map((d) => ({
               id: d.id,
-              title: d.frontmatter.title,
+              title: d.title,
               body: d.body,
             })),
-            sourceNodes: result.sourceNodes.map((d) => ({
+            sourceNodes: (result.source_nodes ?? []).map((d) => ({
               id: d.id,
-              title: d.frontmatter.title,
-              source: d.frontmatter.source,
+              title: d.title,
+              source: d.source,
               body: d.body,
             })),
-            traceCount: result.traces.length,
-            mode: result.mode,
-            hopsUsed: result.hopsUsed,
-            nodesTraversed: result.nodesTraversed,
+            mode: result.traversal?.mode,
+            hopsUsed: result.traversal?.hops_used,
+            nodesTraversed: result.traversal?.nodes_traversed,
           },
           null,
           2,
@@ -1640,16 +1655,21 @@ program
     } else {
       console.log(chalk.bold("Documents:"));
       for (const doc of result.documents) {
-        console.log(`  ${chalk.cyan(doc.id)}: ${doc.frontmatter.title}`);
+        console.log(`  ${chalk.cyan(doc.id)}: ${doc.title}`);
       }
-      if (result.sourceNodes.length > 0) {
+      const sources = result.source_nodes ?? [];
+      if (sources.length > 0) {
         console.log(chalk.bold("\nSource Nodes (hydration order):"));
-        for (const doc of result.sourceNodes) {
-          console.log(`  ${chalk.magenta(doc.id)}: ${doc.frontmatter.title}`);
-          console.log(`    Transport: ${doc.frontmatter.source?.transport}, Server: ${doc.frontmatter.source?.server || "n/a"}`);
+        for (const doc of sources) {
+          const src = doc.source as { transport?: string; server?: string } | undefined;
+          console.log(`  ${chalk.magenta(doc.id)}: ${doc.title}`);
+          console.log(`    Transport: ${src?.transport}, Server: ${src?.server || "n/a"}`);
         }
       }
-      console.log(chalk.dim(`\n${result.mode} mode | ${result.hopsUsed} hops | ${result.nodesTraversed} nodes | ${result.traces.length} traces`));
+      const t = result.traversal;
+      console.log(
+        chalk.dim(`\n${t?.mode} mode | ${t?.hops_used} hops | ${t?.nodes_traversed} nodes`),
+      );
     }
   });
 
@@ -1774,13 +1794,12 @@ program
   .description("Delete a document and its version history")
   .action(async (path) => {
     const storage = getStorage();
-    const id = normalizeDocumentId(path);
-
-    const doc = await storage.readDocument(id);
-    await storage.deleteDocument(id);
-    await regenerateIndex(storage);
-
-    console.log(chalk.green(`Deleted ${id} (${doc.frontmatter.title})`));
+    const result = await createEngineApi().run<{ id: string; title: string }>(
+      "context_delete",
+      { id: normalizeDocumentId(path) },
+      opContext(storage, "cli@contextnest.local"),
+    );
+    console.log(chalk.green(`Deleted ${result.id} (${result.title})`));
   });
 
 // ─── ctx search ───────────────────────────────────────────────────────────────
@@ -1789,36 +1808,39 @@ program
   .command("search <query>")
   .description("Full-text search across vault documents")
   .option("--json", "Output as JSON")
+  .option("--limit <n>", "Max results", (v) => parseInt(v, 10))
   .action(async (query, opts) => {
     const storage = getStorage();
-    const docs = await storage.discoverDocuments();
-    const resolver = new Resolver({ documents: docs });
-
-    const uri = parseUri(`contextnest://search/${query.replace(/\s+/g, "+")}`);
-    const results = await resolver.resolve(uri);
+    const { results } = await createEngineApi().run<{
+      results: Array<{ id: string; title: string; description?: string; type: string }>;
+    }>(
+      "context_search",
+      { query, ...(opts.limit ? { limit: opts.limit } : {}) },
+      opContext(storage, "cli@contextnest.local"),
+    );
 
     if (opts.json) {
       console.log(
         JSON.stringify(
           results.map((d) => ({
             id: d.id,
-            title: d.frontmatter.title,
-            description: d.frontmatter.description,
-            type: d.frontmatter.type || "document",
+            title: d.title,
+            description: d.description,
+            type: d.type,
           })),
           null,
           2,
         ),
       );
-    } else {
-      if (results.length === 0) {
-        console.log(chalk.yellow("No results found."));
-      } else {
-        console.log(chalk.bold(`${results.length} result(s):\n`));
-        for (const doc of results) {
-          console.log(`  ${chalk.cyan(doc.id)}: ${doc.frontmatter.title}`);
-        }
-      }
+      return;
+    }
+    if (results.length === 0) {
+      console.log(chalk.yellow("No results found."));
+      return;
+    }
+    console.log(chalk.bold(`${results.length} result(s):\n`));
+    for (const doc of results) {
+      console.log(`  ${chalk.cyan(doc.id)}: ${doc.title}`);
     }
   });
 

--- a/packages/engine/src/__tests__/api-runtime.test.ts
+++ b/packages/engine/src/__tests__/api-runtime.test.ts
@@ -88,17 +88,27 @@ describe("createEngineApi — executable core operations", () => {
     expect(listed.documents.some((d) => d.id === created.id)).toBe(true);
   });
 
-  it("update by title (not id) resolves the real doc (regression: C2)", async () => {
+  it("title selects the real doc, and on update it renames instead (regression: C2)", async () => {
     const api = createEngineApi();
     await api.run("context_create", { title: "My Cool Title", content: "orig" }, ctx);
-    const updated = await api.run<{ id: string; version: number }>(
+    // Selecting by title still resolves the real doc rather than a slug guess —
+    // the C2 guard, now carried by the selector ops that kept that input.
+    const got = await api.run<{ id: string }>("context_get", { title: "My Cool Title" }, ctx);
+    expect(got.id).toBe("nodes/my-cool-title");
+    // On context_update `title` is the NEW title: it renames, leaving the id be.
+    const updated = await api.run<{ id: string }>(
       "context_update",
-      { title: "My Cool Title", append: "more" },
+      { id: got.id, title: "Renamed", append: "more" },
       ctx,
     );
     expect(updated.id).toBe("nodes/my-cool-title");
-    const got = await api.run<{ body: string }>("context_get", { title: "My Cool Title" }, ctx);
-    expect(got.body).toContain("more");
+    const after = await api.run<{ frontmatter: { title: string }; body: string }>(
+      "context_get",
+      { id: got.id },
+      ctx,
+    );
+    expect(after.frontmatter.title).toBe("Renamed");
+    expect(after.body).toContain("more");
   });
 
   it("published doc is visible to graph-mode query after create (regression: S3 index regen)", async () => {
@@ -657,15 +667,112 @@ describe("core executors — review-fix regressions", () => {
     ).rejects.toMatchObject({ code: "VALIDATION_FAILED" });
   });
 
-  it("context_update de-duplicates merged tags", async () => {
+  it("context_update replaces tags and de-duplicates them", async () => {
     const api = createEngineApi();
-    await api.run("context_create", { title: "Dedupe", content: "b", tags: ["#api"] }, ctx);
+    await api.run(
+      "context_create",
+      { title: "Dedupe", content: "b", tags: ["#api", "#legacy"] },
+      ctx,
+    );
     await api.run("context_update", { id: "nodes/dedupe", tags: ["api", "#api", "ml"] }, ctx);
     const got = await api.run<{ frontmatter: { tags?: string[] } }>(
       "context_get",
       { id: "nodes/dedupe" },
       ctx,
     );
+    // #legacy is gone: the list replaces rather than merges, matching the CLI,
+    // mcp-server and context_create.
     expect(got.frontmatter.tags).toEqual(["#api", "#ml"]);
+  });
+});
+
+// ─── context_update — publish resolution ─────────────────────────────────────
+//
+// The CLI and mcp-server each hand-rolled "a lifecycle status change is
+// metadata, not a release". The op owns that rule now, so it is pinned here.
+
+describe("context_update — when it publishes", () => {
+  let ctx: OperationContext;
+  let dir: string;
+
+  beforeEach(async () => {
+    ({ ctx, dir } = await makeContext());
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  const api = createEngineApi();
+  const historyLength = async (id: string) =>
+    (await ctx.storage.readHistory(id))?.versions.length ?? 0;
+
+  it("publishes a content edit", async () => {
+    await api.run("context_create", { title: "Live", content: "one" }, ctx);
+    const before = await historyLength("nodes/live");
+    const res = await api.run<{ status: string; checkpoint: number | null }>(
+      "context_update",
+      { id: "nodes/live", content: "two" },
+      ctx,
+    );
+    expect(res.status).toBe("published");
+    expect(res.checkpoint).not.toBeNull();
+    expect(await historyLength("nodes/live")).toBe(before + 1);
+  });
+
+  it.each(["draft", "pending_review", "approved", "rejected"])(
+    "treats a %s transition as metadata — no version cut",
+    async (status) => {
+      await api.run("context_create", { title: "Cycle", content: "one" }, ctx);
+      const before = await historyLength("nodes/cycle");
+      const res = await api.run<{ status: string; checkpoint: number | null }>(
+        "context_update",
+        { id: "nodes/cycle", status },
+        ctx,
+      );
+      expect(res.status).toBe(status);
+      expect(res.checkpoint).toBeNull();
+      expect(await historyLength("nodes/cycle")).toBe(before);
+    },
+  );
+
+  it("honours an explicit publish:false over the derived default", async () => {
+    await api.run("context_create", { title: "Held", content: "one" }, ctx);
+    const before = await historyLength("nodes/held");
+    const res = await api.run<{ version: number; checkpoint: number | null }>(
+      "context_update",
+      { id: "nodes/held", content: "two", publish: false, version: 7 },
+      ctx,
+    );
+    // A governed caller assigns its own version for a revision awaiting review.
+    expect(res.version).toBe(7);
+    expect(res.checkpoint).toBeNull();
+    expect(await historyLength("nodes/held")).toBe(before);
+    const got = await api.run<{ frontmatter: { checksum?: string }; body: string }>(
+      "context_get",
+      { id: "nodes/held" },
+      ctx,
+    );
+    expect(got.body).toContain("two");
+    // Stale published-state checksum dropped, or the next verified read reports
+    // this write as external drift.
+    expect(got.frontmatter.checksum).toBeUndefined();
+  });
+
+  it("revives a rejected doc when the caller names a new status", async () => {
+    await api.run("context_create", { title: "Retired", content: "one" }, ctx);
+    await api.run("context_update", { id: "nodes/retired", status: "rejected" }, ctx);
+    // Content-only edit stays refused …
+    await expect(
+      api.run("context_update", { id: "nodes/retired", content: "sneaky" }, ctx),
+    ).rejects.toMatchObject({ code: "REJECTED_DOCUMENT" });
+    // … but declaring a status revives it.
+    const res = await api.run<{ status: string }>(
+      "context_update",
+      { id: "nodes/retired", status: "draft", content: "revived" },
+      ctx,
+    );
+    expect(res.status).toBe("draft");
+    const got = await api.run<{ body: string }>("context_get", { id: "nodes/retired" }, ctx);
+    expect(got.body).toContain("revived");
   });
 });

--- a/packages/engine/src/__tests__/api-runtime.test.ts
+++ b/packages/engine/src/__tests__/api-runtime.test.ts
@@ -1040,3 +1040,44 @@ describe("context_nests — registry-scoped operation", () => {
     expect(byAlias.gone.exists).toBe(false);
   });
 });
+
+describe("context_reconstruct — asking for a version that isn't there", () => {
+  let ctx: OperationContext;
+  let dir: string;
+
+  beforeEach(async () => {
+    ({ ctx, dir } = await makeContext());
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  const api = createEngineApi();
+
+  it("refuses a version the history does not contain", async () => {
+    await api.run("context_create", { title: "Only V1", content: "first" }, ctx);
+    // Reconstruction starts at the nearest keyframe at or before the target and
+    // replays diffs forward, so v99 used to land on v1's keyframe, find nothing
+    // to replay, and return v1's content AS v99.
+    await expect(
+      api.run("context_reconstruct", { id: "nodes/only-v1", version: 99 }, ctx),
+    ).rejects.toMatchObject({ code: "VERSION_NOT_FOUND" });
+  });
+
+  it("still reconstructs a version that does exist", async () => {
+    await api.run("context_create", { title: "Two Versions", content: "first" }, ctx);
+    await api.run("context_update", { id: "nodes/two-versions", content: "second" }, ctx);
+    const v2 = await api.run<{ content: string }>(
+      "context_reconstruct",
+      { id: "nodes/two-versions", version: 2 },
+      ctx,
+    );
+    expect(v2.content).toContain("second");
+    const v1 = await api.run<{ content: string }>(
+      "context_reconstruct",
+      { id: "nodes/two-versions", version: 1 },
+      ctx,
+    );
+    expect(v1.content).toContain("first");
+  });
+});

--- a/packages/engine/src/__tests__/api-runtime.test.ts
+++ b/packages/engine/src/__tests__/api-runtime.test.ts
@@ -1081,3 +1081,121 @@ describe("context_reconstruct — asking for a version that isn't there", () => 
     expect(v1.content).toContain("first");
   });
 });
+
+// ─── Review follow-ups: rejected handling and id tolerance ───────────────────
+
+describe("a rejected status never publishes, and never strands a file", () => {
+  let ctx: OperationContext;
+  let dir: string;
+
+  beforeEach(async () => {
+    ({ ctx, dir } = await makeContext());
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  const api = createEngineApi();
+
+  it("creates a rejected node as a draft instead of writing then crashing", async () => {
+    // Publish refuses a rejected doc. This used to write the file, throw from
+    // publish, and leave an orphan with no version — so the caller's retry hit
+    // DOCUMENT_ALREADY_EXISTS for a create it believed had failed.
+    const res = await api.run<{ id: string; status: string; checkpoint: number | null }>(
+      "context_create",
+      { title: "Born Rejected", content: "x", status: "rejected" },
+      ctx,
+    );
+    expect(res.status).toBe("rejected");
+    expect(res.checkpoint).toBeNull();
+    const got = await api.run<{ frontmatter: { version?: number } }>(
+      "context_get",
+      { id: res.id, allow_rejected: true },
+      ctx,
+    );
+    expect(got.frontmatter.version).toBe(1);
+  });
+
+  it("ignores an explicit publish:true when the edit lands on rejected", async () => {
+    await api.run("context_create", { title: "Going Away", content: "original" }, ctx);
+    const res = await api.run<{ checkpoint: number | null }>(
+      "context_update",
+      { id: "nodes/going-away", status: "rejected", publish: true },
+      ctx,
+    );
+    expect(res.checkpoint).toBeNull();
+  });
+
+  it("refuses an edit that re-asserts rejected, rather than rewriting the body", async () => {
+    await api.run("context_create", { title: "Stay Put", content: "original" }, ctx);
+    await api.run("context_update", { id: "nodes/stay-put", status: "rejected" }, ctx);
+    // A client echoing the current status back alongside an edit used to slip
+    // past the guard and mutate a document that stayed rejected.
+    await expect(
+      api.run(
+        "context_update",
+        { id: "nodes/stay-put", status: "rejected", content: "MUTATED" },
+        ctx,
+      ),
+    ).rejects.toMatchObject({ code: "REJECTED_DOCUMENT" });
+    const got = await api.run<{ body: string }>(
+      "context_get",
+      { id: "nodes/stay-put", allow_rejected: true },
+      ctx,
+    );
+    expect(got.body).toContain("original");
+    expect(got.body).not.toContain("MUTATED");
+  });
+});
+
+describe("id and title tolerance", () => {
+  let ctx: OperationContext;
+  let dir: string;
+
+  beforeEach(async () => {
+    ({ ctx, dir } = await makeContext());
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  const api = createEngineApi();
+
+  it("accepts an id built from a file path (.md suffix, leading slash)", async () => {
+    await api.run("context_create", { title: "Path Doc", content: "body" }, ctx);
+    // Storage appends `.md` itself, so an un-stripped suffix resolved to
+    // `<id>.md.md` and 404'd. Callers build ids from file paths all the time.
+    for (const id of ["nodes/path-doc", "nodes/path-doc.md", "/nodes/path-doc"]) {
+      const got = await api.run<{ id: string }>("context_get", { id }, ctx);
+      expect(got.id).toBe("nodes/path-doc");
+    }
+  });
+
+  it("still does NOT re-root a bare id, which a flat-layout vault depends on", async () => {
+    // The contract is "exactly as stored". Re-rooting `flat-doc` to
+    // `nodes/flat-doc` is what broke every read in an imported vault.
+    await ctx.storage.writeDocument(
+      "flat-doc",
+      `---\ntitle: Flat Doc\nstatus: published\n---\n\nbody\n`,
+    );
+    const got = await api.run<{ id: string }>("context_get", { id: "flat-doc" }, ctx);
+    expect(got.id).toBe("flat-doc");
+  });
+
+  it("finds a retired document by title, not just by id", async () => {
+    // A custom id means the slug guess cannot rescue this: title lookup has to
+    // actually see the retired doc.
+    await api.run(
+      "context_create",
+      { id: "nodes/custom/slot-7", title: "Quarterly Plan", content: "body" },
+      ctx,
+    );
+    await api.run("context_update", { id: "nodes/custom/slot-7", status: "rejected" }, ctx);
+    const got = await api.run<{ id: string }>(
+      "context_get",
+      { title: "Quarterly Plan", allow_rejected: true },
+      ctx,
+    );
+    expect(got.id).toBe("nodes/custom/slot-7");
+  });
+});

--- a/packages/engine/src/__tests__/api-runtime.test.ts
+++ b/packages/engine/src/__tests__/api-runtime.test.ts
@@ -319,6 +319,63 @@ describe("createEngineApi — executable core operations", () => {
     expect(Array.isArray(out.packs)).toBe(true);
   });
 
+  it("context_create with publish:false leaves the node a draft", async () => {
+    const api = createEngineApi();
+    const out = await api.run<{ id: string; version: number; status: string }>(
+      "context_create",
+      { title: "Needs Review", content: "body", publish: false },
+      ctx,
+    );
+    expect(out.status).toBe("draft");
+    const got = await api.run<{ frontmatter: { status?: string } }>(
+      "context_get",
+      { id: out.id },
+      ctx,
+    );
+    expect(got.frontmatter.status).toBe("draft");
+  });
+
+  it("context_create honours an explicit id over the title slug", async () => {
+    const api = createEngineApi();
+    const out = await api.run<{ id: string; status: string }>(
+      "context_create",
+      { title: "Human Title", content: "body", id: "nodes/system/deterministic-id" },
+      ctx,
+    );
+    expect(out.id).toBe("nodes/system/deterministic-id");
+    expect(out.status).toBe("published");
+  });
+
+  it("context_create rejects an explicit id that escapes the vault", async () => {
+    const api = createEngineApi();
+    await expect(
+      api.run("context_create", { title: "Escape", content: "b", id: "../../outside" }, ctx),
+    ).rejects.toThrow(/path traversal/);
+  });
+
+  it("context_create builds a valid skill node from the skill fields", async () => {
+    const api = createEngineApi();
+    const out = await api.run<{ id: string }>(
+      "context_create",
+      {
+        title: "Deploy Skill",
+        content: "steps",
+        type: "skill",
+        trigger: "when asked to deploy",
+        tools_required: ["bash"],
+        output_format: "markdown",
+      },
+      ctx,
+    );
+    const got = await api.run<{ frontmatter: any }>("context_get", { id: out.id }, ctx);
+    // A `skill` block, not loose top-level keys — validation requires it.
+    expect(got.frontmatter.skill).toMatchObject({
+      trigger: "when asked to deploy",
+      tools_required: ["bash"],
+      output_format: "markdown",
+    });
+  });
+
   it("context_import bulk-creates many nodes under ONE checkpoint", async () => {
     const api = createEngineApi();
     const documents = Array.from({ length: 6 }, (_, i) => ({

--- a/packages/engine/src/__tests__/api-runtime.test.ts
+++ b/packages/engine/src/__tests__/api-runtime.test.ts
@@ -242,21 +242,46 @@ describe("createEngineApi — executable core operations", () => {
     expect(full.versions.filter((v) => v.keyframe).every((v) => !v.diff)).toBe(true);
   });
 
-  it("context_overview reports counts, tags, and the node list", async () => {
+  it("context_init opens the vault in one call: instructions, config and counts", async () => {
     const api = createEngineApi();
     await api.run("context_create", { title: "Alpha", content: "b", tags: ["#x"] }, ctx);
     await api.run("context_create", { title: "Beta", content: "b", type: "glossary" }, ctx);
-    const out = await api.run<{
+    type Init = {
+      context_md: string | null;
+      vault_path: string;
+      config: { name: string } | null;
       total: number;
       by_type: Record<string, number>;
       tags: string[];
-      nodes: Array<{ id: string }>;
-    }>("context_overview", {}, ctx);
+      nodes?: Array<{ id: string }>;
+    };
+    const out = await api.run<Init>("context_init", {}, ctx);
     expect(out.total).toBeGreaterThanOrEqual(2);
     expect(out.by_type.document).toBeGreaterThanOrEqual(1);
     expect(out.by_type.glossary).toBeGreaterThanOrEqual(1);
     expect(out.tags).toContain("#x");
-    expect(out.nodes.some((n) => n.id === "nodes/alpha")).toBe(true);
+    expect(out.vault_path).toBe(dir);
+    // The node list is the expensive part, so it is opt-in.
+    expect(out.nodes).toBeUndefined();
+
+    const withNodes = await api.run<Init>("context_init", { include_nodes: true }, ctx);
+    expect(withNodes.nodes?.some((n) => n.id === "nodes/alpha")).toBe(true);
+    expect((await api.run<Init>("context_init", { include_nodes: true, limit: 1 }, ctx)).nodes)
+      .toHaveLength(1);
+  });
+
+  it("context_init counts retired nodes, which discovery drops by default", async () => {
+    const api = createEngineApi();
+    await api.run("context_create", { title: "Live One", content: "b" }, ctx);
+    await api.run("context_create", { title: "Dead One", content: "b" }, ctx);
+    await api.run("context_update", { id: "nodes/dead-one", status: "rejected" }, ctx);
+    const out = await api.run<{ by_status: Record<string, number>; total: number }>(
+      "context_init",
+      {},
+      ctx,
+    );
+    expect(out.by_status.rejected).toBe(1);
+    expect(out.total).toBe(2);
   });
 
   it("context_reconstruct returns a past version's content", async () => {

--- a/packages/engine/src/__tests__/api-runtime.test.ts
+++ b/packages/engine/src/__tests__/api-runtime.test.ts
@@ -776,3 +776,108 @@ describe("context_update — when it publishes", () => {
     expect(got.body).toContain("revived");
   });
 });
+
+// ─── context_list — filters ──────────────────────────────────────────────────
+//
+// The CLI, mcp-server and Community each grew a private copy of this filter and
+// each got a different subset of the rules right. These pin the shared one.
+
+describe("context_list — filters", () => {
+  let ctx: OperationContext;
+  let dir: string;
+
+  beforeEach(async () => {
+    ({ ctx, dir } = await makeContext());
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  const api = createEngineApi();
+  const ids = (r: { documents: Array<{ id: string }> }) => r.documents.map((d) => d.id).sort();
+  const list = (input: object = {}) =>
+    api.run<{ documents: Array<{ id: string }> }>("context_list", input, ctx);
+
+  /** A document with NO `type:` field — the common case, and the one a literal
+   *  type comparison used to skip. */
+  const writeUntyped = async (id: string, status: string, tags = "") =>
+    ctx.storage.writeDocument(
+      id,
+      `---\ntitle: ${id}\nstatus: ${status}\n${tags}---\n\nbody\n`,
+    );
+
+  it("matches untyped documents against type:document", async () => {
+    await writeUntyped("nodes/plain", "published");
+    await api.run("context_create", { title: "A Skill", content: "b", type: "skill", trigger: "when asked" }, ctx);
+    expect(await list({ type: "document" }).then(ids)).toEqual(["nodes/plain"]);
+  });
+
+  it("accepts several types at once", async () => {
+    await writeUntyped("nodes/plain", "published");
+    await api.run("context_create", { title: "A Skill", content: "b", type: "skill", trigger: "when asked" }, ctx);
+    await api.run("context_create", { title: "An Agent", content: "b", type: "agent" }, ctx);
+    expect(await list({ type: ["skill", "agent"] }).then(ids)).toEqual([
+      "nodes/a-skill",
+      "nodes/an-agent",
+    ]);
+  });
+
+  it("finds retired documents on status:rejected, and hides them otherwise", async () => {
+    await writeUntyped("nodes/live", "published");
+    await writeUntyped("nodes/dead", "rejected");
+    // Discovery drops retired docs, so this filter used to match nothing at all.
+    expect(await list({ status: "rejected" }).then(ids)).toEqual(["nodes/dead"]);
+    expect(await list().then(ids)).toEqual(["nodes/live"]);
+  });
+
+  it("normalizes status aliases", async () => {
+    await writeUntyped("nodes/live", "published");
+    expect(await list({ status: "active" }).then(ids)).toEqual(["nodes/live"]);
+  });
+
+  it("matches a tag with or without its # and regardless of case", async () => {
+    await writeUntyped("nodes/tagged", "published", "tags:\n  - '#API'\n");
+    await writeUntyped("nodes/untagged", "published");
+    for (const tag of ["#API", "API", "api", "#api"]) {
+      expect(await list({ tag }).then(ids)).toEqual(["nodes/tagged"]);
+    }
+  });
+
+  it("applies limit last", async () => {
+    await writeUntyped("nodes/a", "published");
+    await writeUntyped("nodes/b", "published");
+    await writeUntyped("nodes/c", "rejected");
+    // Retired doc is excluded before the limit counts, not after.
+    expect((await list({ limit: 2 })).documents).toHaveLength(2);
+  });
+
+  it("include_retired keeps retired nodes with no status filter", async () => {
+    await writeUntyped("nodes/live", "published");
+    await writeUntyped("nodes/dead", "rejected");
+    // Governed surfaces list a rejected node as one its stewards still act on.
+    expect(await list({ include_retired: true }).then(ids)).toEqual([
+      "nodes/dead",
+      "nodes/live",
+    ]);
+  });
+
+  it("full returns frontmatter and body so callers need not re-read the files", async () => {
+    await ctx.storage.writeDocument(
+      "nodes/rich",
+      `---\ntitle: Rich\nstatus: published\nversion: 4\nauthor: someone@example.com\ncreated_at: '2024-01-01T00:00:00.000Z'\n---\n\nthe body\n`,
+    );
+    const summary = (await list()).documents[0] as Record<string, unknown>;
+    expect(summary.frontmatter).toBeUndefined();
+    expect(summary.body).toBeUndefined();
+
+    const full = (await list({ full: true })).documents[0] as {
+      body: string;
+      frontmatter: { version?: number; author?: string; created_at?: string };
+    };
+    expect(full.body).toContain("the body");
+    // The fields a summary drops are exactly why `full` exists.
+    expect(full.frontmatter.version).toBe(4);
+    expect(full.frontmatter.author).toBe("someone@example.com");
+    expect(full.frontmatter.created_at).toBeTruthy();
+  });
+});

--- a/packages/engine/src/__tests__/api-runtime.test.ts
+++ b/packages/engine/src/__tests__/api-runtime.test.ts
@@ -870,7 +870,7 @@ describe("context_list — filters", () => {
     expect(summary.frontmatter).toBeUndefined();
     expect(summary.body).toBeUndefined();
 
-    const full = (await list({ full: true })).documents[0] as {
+    const full = (await list({ full: true })).documents[0] as unknown as {
       body: string;
       frontmatter: { version?: number; author?: string; created_at?: string };
     };
@@ -879,5 +879,66 @@ describe("context_list — filters", () => {
     expect(full.frontmatter.version).toBe(4);
     expect(full.frontmatter.author).toBe("someone@example.com");
     expect(full.frontmatter.created_at).toBeTruthy();
+  });
+});
+
+// ─── context_get — what each surface needs beyond {id, frontmatter, body} ────
+
+describe("context_get — raw, rejected, selector", () => {
+  let ctx: OperationContext;
+  let dir: string;
+
+  beforeEach(async () => {
+    ({ ctx, dir } = await makeContext());
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  const api = createEngineApi();
+
+  it("include_raw returns the exact stored bytes, frontmatter block and all", async () => {
+    await api.run("context_create", { title: "Raw Doc", content: "the body" }, ctx);
+    const plain = await api.run<{ raw?: string }>("context_get", { id: "nodes/raw-doc" }, ctx);
+    expect(plain.raw).toBeUndefined();
+
+    const withRaw = await api.run<{ raw: string; body: string }>(
+      "context_get",
+      { id: "nodes/raw-doc", include_raw: true },
+      ctx,
+    );
+    // `body` is the parsed body; `raw` still carries the frontmatter block, so
+    // a caller can re-serve the file verbatim.
+    expect(withRaw.raw).toContain("---");
+    expect(withRaw.raw).toContain("title: Raw Doc");
+    expect(withRaw.raw).toContain("the body");
+    expect(withRaw.body).not.toContain("title: Raw Doc");
+  });
+
+  it("refuses a rejected node, unless the caller allows it", async () => {
+    await api.run("context_create", { title: "Retired Doc", content: "body" }, ctx);
+    await api.run("context_update", { id: "nodes/retired-doc", status: "rejected" }, ctx);
+
+    await expect(api.run("context_get", { id: "nodes/retired-doc" }, ctx)).rejects.toMatchObject({
+      code: "REJECTED_DOCUMENT",
+    });
+    // Reading one is not republishing it — governed surfaces show retired docs.
+    const allowed = await api.run<{ frontmatter: { status?: string } }>(
+      "context_get",
+      { id: "nodes/retired-doc", allow_rejected: true },
+      ctx,
+    );
+    expect(allowed.frontmatter.status).toBe("rejected");
+  });
+
+  it("still demands a selector now that the schema no longer refines one", async () => {
+    // The `.refine` came off so MCP can register these ops at all; the same
+    // error has to survive as a runtime check.
+    await expect(api.run("context_get", {}, ctx)).rejects.toMatchObject({
+      code: "VALIDATION_FAILED",
+    });
+    await expect(api.run("context_versions", {}, ctx)).rejects.toMatchObject({
+      code: "VALIDATION_FAILED",
+    });
   });
 });

--- a/packages/engine/src/api/core-executors.ts
+++ b/packages/engine/src/api/core-executors.ts
@@ -39,6 +39,7 @@ function toSummary(node: ContextNode, includeBody = false, includeFrontmatter = 
     type: node.frontmatter.type ?? "document",
     status: node.frontmatter.status ?? "draft",
     tags: node.frontmatter.tags,
+    ...(node.frontmatter.description ? { description: node.frontmatter.description } : {}),
     ...(node.frontmatter.type === "source" && node.frontmatter.source
       ? { source: node.frontmatter.source }
       : {}),
@@ -156,6 +157,7 @@ const query: OperationExecutor = async (ctx, input: any) => {
   const result = await ctx.query.query(input.query, {
     hops: clampHops(input.hops),
     full: input.full ?? false,
+    includeDrafts: input.include_drafts ?? false,
   });
   return {
     documents: result.documents.map((d) => toSummary(d, true)),
@@ -408,17 +410,28 @@ const publish: OperationExecutor = async (ctx, input: any) => {
   const id = await resolveId(ctx, input);
   // publishDocument guards rejected docs and seals a checkpoint; regenerate the
   // index so graph-mode reads see the freshly-published node (same as create/update).
-  const result = await publishDocument(ctx.storage, id, { editedBy: ctx.actor ?? "engine" });
+  const result = await publishDocument(ctx.storage, id, {
+    editedBy: ctx.actor ?? "engine",
+    ...(input.note ? { note: input.note } : {}),
+  });
   await ctx.storage.regenerateIndex();
-  return { id, version: result.versionEntry.version, checkpoint: result.checkpointNumber };
+  return {
+    id,
+    version: result.versionEntry.version,
+    checkpoint: result.checkpointNumber,
+    chain_hash: result.versionEntry.chain_hash,
+  };
 };
 
 const del: OperationExecutor = async (ctx, input: any) => {
   const id = await resolveId(ctx, input);
+  // Read the title BEFORE removing the file — callers report what they deleted,
+  // and after the delete there is nothing left to ask.
+  const { frontmatter } = await ctx.storage.readDocument(id);
   // deleteDocument throws DOCUMENT_NOT_FOUND when the id doesn't exist.
   await ctx.storage.deleteDocument(id);
   await ctx.storage.regenerateIndex();
-  return { id, deleted: true as const };
+  return { id, title: frontmatter.title, deleted: true as const };
 };
 
 const versions: OperationExecutor = async (ctx, input: any) => {

--- a/packages/engine/src/api/core-executors.ts
+++ b/packages/engine/src/api/core-executors.ts
@@ -19,7 +19,7 @@ import {
   normalizeStatus,
   isRejected,
 } from "../parser.js";
-import { normalizeDocumentId } from "../storage.js";
+import { normalizeDocumentId, assertSafeDocumentId } from "../storage.js";
 import { publishDocument, publishDocuments } from "../publish.js";
 import { VersionManager } from "../versioning.js";
 import { parseUri } from "../uri.js";
@@ -301,29 +301,77 @@ const create: OperationExecutor = async (ctx, input: any) => {
   };
 };
 
+/**
+ * Statuses that describe where a node sits in review, not a content release.
+ * Setting one is a metadata transition, so it doesn't publish by default — the
+ * rule CLI and mcp-server each hand-rolled before this op absorbed it.
+ */
+const UNPUBLISHED_STATUSES = new Set(["draft", "pending_review", "approved", "rejected"]);
+
 const update: OperationExecutor = async (ctx, input: any) => {
-  const id = await resolveId(ctx, input);
+  // Vetted, NOT normalized: normalizeDocumentId re-roots a bare slug under
+  // `nodes/`, which silently redirects every id from a flat-layout vault (they
+  // carry no prefix) to a document that doesn't exist. The storage layer
+  // already resolves an id for its own layout — all this has to do is refuse
+  // one that would escape the vault root.
+  const id: string = input.id;
+  assertSafeDocumentId(id);
   const existing = await ctx.storage.readDocument(id);
   // Guard BEFORE any write: republishing a rejected doc would flip it back into
   // retrieval, and writing first would mutate the file even though publish then
-  // rejects (no version/checksum/history). Mirrors OSS update_document.
-  if (isRejected(existing)) throw new RejectedDocumentError(id);
+  // rejects (no version/checksum/history). Naming a `status` is how a caller
+  // revives one, so only a status-less edit is refused — mirrors OSS
+  // update_document.
+  if (isRejected(existing) && input.status === undefined) throw new RejectedDocumentError(id);
   const frontmatter: Frontmatter = { ...existing.frontmatter };
-  if (input.tags) {
-    const merged = [...(frontmatter.tags ?? []), ...input.tags];
-    frontmatter.tags = normalizeUniqueTags(merged);
-  }
+  if (input.title) frontmatter.title = input.title;
+  if (input.status) frontmatter.status = input.status as Frontmatter["status"];
+  if (input.tags) frontmatter.tags = normalizeUniqueTags(input.tags);
   if (input.metadata) {
-    frontmatter.metadata = { ...(frontmatter.metadata ?? {}), ...input.metadata };
+    const merged: Record<string, unknown> = {
+      ...(frontmatter.metadata ?? {}),
+      ...input.metadata,
+    };
+    // A null value CLEARS the key. Over a JSON wire an absent key is
+    // indistinguishable from "leave this alone", so a merge with no null
+    // convention gives callers no way to remove metadata at all. Only keys the
+    // caller named are considered — a null already on disk is left alone.
+    for (const [key, value] of Object.entries(input.metadata)) {
+      if (value === null) delete merged[key];
+    }
+    frontmatter.metadata = merged;
   }
+  frontmatter.updated_at = new Date().toISOString();
   let body = existing.body;
   if (typeof input.content === "string") body = input.content;
   if (typeof input.append === "string") body = `${body}\n${input.append}`;
+  // The checksum describes the PUBLISHED body, so any body change invalidates
+  // it — including one whose publish then fails, which would otherwise leave a
+  // stale checksum on disk and make the next verified read cry external drift.
+  // Frontmatter-only edits keep it: the checksum covers the body alone.
+  if (typeof input.content === "string" || typeof input.append === "string") {
+    delete frontmatter.checksum;
+  }
+
+  const publish = input.publish ?? !(input.status && UNPUBLISHED_STATUSES.has(input.status));
+  // Only an unpublished write may carry a caller-assigned version: publish
+  // assigns its own, and stamping one first would put the node a version ahead
+  // of its history (the same trap context_create avoids).
+  if (!publish && input.version !== undefined) frontmatter.version = input.version;
   const node: ContextNode = { id, filePath: "", rawContent: "", frontmatter, body };
   assertValid(node);
   await ctx.storage.writeDocument(id, serializeDocument(node));
-  const result = await publishAndIndex(ctx, id);
-  return { id, version: result.version };
+  if (!publish) {
+    await ctx.storage.regenerateIndex();
+    return {
+      id,
+      version: frontmatter.version ?? 1,
+      status: frontmatter.status ?? "draft",
+      checkpoint: null,
+    };
+  }
+  const result = await publishAndIndex(ctx, id, input.note);
+  return { id, version: result.version, status: "published", checkpoint: result.checkpoint };
 };
 
 const publish: OperationExecutor = async (ctx, input: any) => {

--- a/packages/engine/src/api/core-executors.ts
+++ b/packages/engine/src/api/core-executors.ts
@@ -20,6 +20,7 @@ import {
   isRejected,
 } from "../parser.js";
 import { normalizeDocumentId, assertSafeDocumentId } from "../storage.js";
+import { filterDocuments } from "../filters.js";
 import { publishDocument, publishDocuments } from "../publish.js";
 import { VersionManager } from "../versioning.js";
 import { parseUri } from "../uri.js";
@@ -30,7 +31,7 @@ import type { OperationContext, OperationExecutor } from "./context.js";
 const MAX_HOPS = 10;
 
 /** ContextNode → the wire `nodeSummary` shape. Source nodes keep their block. */
-function toSummary(node: ContextNode, includeBody = false) {
+function toSummary(node: ContextNode, includeBody = false, includeFrontmatter = false) {
   return {
     id: node.id,
     title: node.frontmatter.title,
@@ -41,6 +42,7 @@ function toSummary(node: ContextNode, includeBody = false) {
       ? { source: node.frontmatter.source }
       : {}),
     ...(includeBody ? { body: node.body } : {}),
+    ...(includeFrontmatter ? { frontmatter: node.frontmatter } : {}),
   };
 }
 
@@ -194,18 +196,12 @@ const get: OperationExecutor = async (ctx, input: any) => {
 };
 
 const list: OperationExecutor = async (ctx, input: any) => {
-  let docs = await ctx.storage.discoverDocuments();
-  if (input.type) docs = docs.filter((d) => d.frontmatter.type === input.type);
-  if (input.status) {
-    const want = normalizeStatus(input.status);
-    docs = docs.filter((d) => normalizeStatus(d.frontmatter.status ?? "draft") === want);
-  }
-  if (input.tag) {
-    const want = String(input.tag).replace(/^#/, "");
-    docs = docs.filter((d) => d.frontmatter.tags?.some((t) => t.replace(/^#/, "") === want));
-  }
-  if (input.limit) docs = docs.slice(0, input.limit);
-  return { documents: docs.map((d) => toSummary(d)) };
+  // includeRetired, or `status: "rejected"` matches nothing: discovery drops
+  // retired documents before the filter ever sees them. filterDocuments hides
+  // them again whenever no status was asked for.
+  const docs = await ctx.storage.discoverDocuments({ includeRetired: true });
+  const kept = filterDocuments(docs, { ...input, includeRetired: input.include_retired });
+  return { documents: kept.map((d) => toSummary(d, input.full === true, input.full === true)) };
 };
 
 /**

--- a/packages/engine/src/api/core-executors.ts
+++ b/packages/engine/src/api/core-executors.ts
@@ -223,6 +223,7 @@ function buildDraftNode(input: {
   folder?: string;
   metadata?: Record<string, unknown>;
   id?: string;
+  status?: Frontmatter["status"];
   trigger?: string;
   tools_required?: string[];
   output_format?: SkillMeta["output_format"];
@@ -258,7 +259,7 @@ function buildDraftNode(input: {
           },
         }
       : {}),
-    status: "draft",
+    status: (input.status as Frontmatter["status"]) ?? "draft",
     created_at: now,
     // A node is "updated" at birth; without this a draft carries no
     // updated_at until its first edit, and every surface renders it blank.
@@ -273,6 +274,7 @@ const create: OperationExecutor = async (ctx, input: any) => {
   // WITHOUT one — pre-setting it makes the first published version 2 and leaves
   // no v1 keyframe. A draft never reaches publish, so it needs its own v1.
   if (input.publish === false) node.frontmatter.version = 1;
+  const createdStatus = node.frontmatter.status;
   assertValid(node);
   // Exclusive write: atomically refuses to clobber an existing doc (mirrors OSS
   // create_document) — no TOCTOU window, and blocks resurrecting a rejected doc
@@ -286,7 +288,7 @@ const create: OperationExecutor = async (ctx, input: any) => {
     return {
       id: node.id,
       version: node.frontmatter.version ?? 1,
-      status: "draft",
+      status: createdStatus,
       checkpoint: null,
     };
   }

--- a/packages/engine/src/api/core-executors.ts
+++ b/packages/engine/src/api/core-executors.ts
@@ -11,7 +11,7 @@
  * existing surfaces (published-only search, index regeneration after publish,
  * status/tag normalization, document validation before write).
  */
-import type { ContextNode, Frontmatter } from "../types.js";
+import type { ContextNode, Frontmatter, SkillMeta } from "../types.js";
 import {
   serializeDocument,
   validateDocument,
@@ -111,13 +111,20 @@ function assertValid(node: ContextNode): void {
 }
 
 /** Publish via publishDocument, then regenerate context.yaml (matches OSS). */
-async function publishAndIndex(ctx: OperationContext, id: string): Promise<{ version: number }> {
-  const res = await publishDocument(ctx.storage, id, { editedBy: ctx.actor ?? "engine" });
+async function publishAndIndex(
+  ctx: OperationContext,
+  id: string,
+  note?: string,
+): Promise<{ version: number; checkpoint: number }> {
+  const res = await publishDocument(ctx.storage, id, {
+    editedBy: ctx.actor ?? "engine",
+    ...(note ? { note } : {}),
+  });
   // publishDocument does NOT touch context.yaml; graph-mode reads (the default
   // context_query) seed from it, so a stale index would hide the write. OSS
   // mcp-server/CLI both regenerate here.
   await ctx.storage.regenerateIndex();
-  return { version: res.versionEntry.version };
+  return { version: res.versionEntry.version, checkpoint: res.checkpointNumber };
 }
 
 const query: OperationExecutor = async (ctx, input: any) => {
@@ -215,32 +222,81 @@ function buildDraftNode(input: {
   tags?: unknown[];
   folder?: string;
   metadata?: Record<string, unknown>;
+  id?: string;
+  trigger?: string;
+  tools_required?: string[];
+  output_format?: SkillMeta["output_format"];
+  inputs?: SkillMeta["inputs"];
+  guard_rails?: string[];
 }): ContextNode {
+  const now = new Date().toISOString();
   const folderSegments = String(input.folder ?? "")
     .split("/")
     .map(slugify)
     .filter(Boolean);
-  const id = normalizeDocumentId(["nodes", ...folderSegments, requireSlug(input.title)].join("/"));
+  // An explicit id wins outright — callers that mint their own ids (system
+  // nodes, path-addressed tools) still get the traversal/prefix normalization.
+  const id = input.id
+    ? normalizeDocumentId(input.id)
+    : normalizeDocumentId(["nodes", ...folderSegments, requireSlug(input.title)].join("/"));
   const frontmatter: Frontmatter = {
     title: input.title,
     type: (input.type as Frontmatter["type"]) ?? "document",
     ...(input.tags ? { tags: normalizeUniqueTags(input.tags) } : {}),
     ...(input.metadata ? { metadata: input.metadata } : {}),
+    // Skill nodes carry a `skill` block — `trigger` is required there for
+    // type:"skill" and the block must be ABSENT on every other type, so these
+    // cannot ride along inside `metadata`.
+    ...(input.trigger
+      ? {
+          skill: {
+            trigger: input.trigger,
+            ...(input.inputs ? { inputs: input.inputs } : {}),
+            ...(input.tools_required ? { tools_required: input.tools_required } : {}),
+            ...(input.output_format ? { output_format: input.output_format } : {}),
+            ...(input.guard_rails ? { guard_rails: input.guard_rails } : {}),
+          },
+        }
+      : {}),
     status: "draft",
-    created_at: new Date().toISOString(),
+    created_at: now,
+    // A node is "updated" at birth; without this a draft carries no
+    // updated_at until its first edit, and every surface renders it blank.
+    updated_at: now,
   };
   return { id, filePath: "", rawContent: "", frontmatter, body: input.content };
 }
 
 const create: OperationExecutor = async (ctx, input: any) => {
   const node = buildDraftNode(input);
+  // Publish assigns the version (spec §6), so a published node must go to disk
+  // WITHOUT one — pre-setting it makes the first published version 2 and leaves
+  // no v1 keyframe. A draft never reaches publish, so it needs its own v1.
+  if (input.publish === false) node.frontmatter.version = 1;
   assertValid(node);
   // Exclusive write: atomically refuses to clobber an existing doc (mirrors OSS
   // create_document) — no TOCTOU window, and blocks resurrecting a rejected doc
   // the way the pre-check + separate write could race.
   await ctx.storage.writeDocument(node.id, serializeDocument(node), { exclusive: true });
-  const result = await publishAndIndex(ctx, node.id);
-  return { id: node.id, version: result.version };
+  // Governed callers create the node WITHOUT publishing: the write has to clear
+  // review before it becomes retrievable. Still regenerate the index so the
+  // draft is discoverable to the surfaces that list drafts.
+  if (input.publish === false) {
+    await ctx.storage.regenerateIndex();
+    return {
+      id: node.id,
+      version: node.frontmatter.version ?? 1,
+      status: "draft",
+      checkpoint: null,
+    };
+  }
+  const result = await publishAndIndex(ctx, node.id, input.note);
+  return {
+    id: node.id,
+    version: result.version,
+    status: "published",
+    checkpoint: result.checkpoint,
+  };
 };
 
 const update: OperationExecutor = async (ctx, input: any) => {

--- a/packages/engine/src/api/core-executors.ts
+++ b/packages/engine/src/api/core-executors.ts
@@ -543,6 +543,8 @@ const packs: OperationExecutor = async (ctx) => {
       description: p.description,
       query: p.query,
       agent_instructions: p.agent_instructions,
+      ...(p.includes ? { includes: p.includes } : {}),
+      ...(p.excludes ? { excludes: p.excludes } : {}),
     })),
   };
 };

--- a/packages/engine/src/api/core-executors.ts
+++ b/packages/engine/src/api/core-executors.ts
@@ -454,26 +454,6 @@ const versions: OperationExecutor = async (ctx, input: any) => {
   };
 };
 
-const overview: OperationExecutor = async (ctx) => {
-  const docs = await ctx.storage.discoverDocuments();
-  const byType: Record<string, number> = {};
-  const byStatus: Record<string, number> = {};
-  const tags = new Set<string>();
-  for (const d of docs) {
-    const t = d.frontmatter.type ?? "document";
-    byType[t] = (byType[t] ?? 0) + 1;
-    const s = d.frontmatter.status ?? "draft";
-    byStatus[s] = (byStatus[s] ?? 0) + 1;
-    for (const tag of d.frontmatter.tags ?? []) tags.add(tag);
-  }
-  return {
-    total: docs.length,
-    by_type: byType,
-    by_status: byStatus,
-    tags: [...tags].sort(),
-    nodes: docs.map((d) => toSummary(d)),
-  };
-};
 
 const reconstruct: OperationExecutor = async (ctx, input: any) => {
   const id = await resolveId(ctx, input);
@@ -500,8 +480,44 @@ const verify: OperationExecutor = async (ctx) => {
   return { valid: report.valid, errors: report.errors };
 };
 
-const init: OperationExecutor = async (ctx) => {
-  return { context_md: await ctx.storage.readContextMd() };
+const init: OperationExecutor = async (ctx, input: any) => {
+  // includeRetired so `by_status` can report `rejected` at all — discovery drops
+  // retired documents otherwise, and a manifest that silently omits a whole
+  // status is worse than one that reports zero.
+  const [context_md, config, docs] = await Promise.all([
+    ctx.storage.readContextMd(),
+    ctx.storage.readConfig(),
+    ctx.storage.discoverDocuments({ includeRetired: true }),
+  ]);
+  const byType: Record<string, number> = {};
+  const byStatus: Record<string, number> = {};
+  const tags = new Set<string>();
+  for (const d of docs) {
+    const t = d.frontmatter.type ?? "document";
+    byType[t] = (byType[t] ?? 0) + 1;
+    const s = d.frontmatter.status ?? "draft";
+    byStatus[s] = (byStatus[s] ?? 0) + 1;
+    for (const tag of d.frontmatter.tags ?? []) tags.add(tag);
+  }
+  const listed = input?.limit ? docs.slice(0, input.limit) : docs;
+  return {
+    context_md,
+    vault_path: ctx.storage.root,
+    config: config
+      ? {
+          name: config.name,
+          ...(config.description ? { description: config.description } : {}),
+          servers: config.servers ? Object.keys(config.servers) : [],
+        }
+      : null,
+    total: docs.length,
+    by_type: byType,
+    by_status: byStatus,
+    tags: [...tags].sort(),
+    // Counts and tags answer most opening questions; a large vault's node list
+    // dwarfs them, so it is opt-in.
+    ...(input?.include_nodes ? { nodes: listed.map((d) => toSummary(d)) } : {}),
+  };
 };
 
 const packs: OperationExecutor = async (ctx) => {
@@ -580,7 +596,6 @@ export const CORE_EXECUTORS: Readonly<Record<string, OperationExecutor>> = Objec
   context_delete: del,
   context_versions: versions,
   context_reconstruct: reconstruct,
-  context_overview: overview,
   context_verify: verify,
   context_init: init,
   context_packs: packs,

--- a/packages/engine/src/api/core-executors.ts
+++ b/packages/engine/src/api/core-executors.ts
@@ -103,26 +103,33 @@ async function resolveId(
       "VALIDATION_FAILED",
     );
   }
-  // Vetted, NOT normalized: normalizeDocumentId re-roots a bare slug under
-  // `nodes/`, which silently redirects every id from a flat-layout vault (they
-  // carry no prefix) to a document that does not exist. The storage layer
-  // resolves an id for its own layout — same rule context_update and
-  // context_import's `ids` already follow.
-  if (sel.id) {
-    assertSafeDocumentId(sel.id);
-    return sel.id;
-  }
-  if (sel.uri) {
-    const path = parseUri(sel.uri).path;
-    assertSafeDocumentId(path);
-    return path;
-  }
-  const docs = await ctx.storage.discoverDocuments();
+  if (sel.id) return sanitizeId(sel.id);
+  if (sel.uri) return sanitizeId(parseUri(sel.uri).path);
+  // includeRetired, or a title lookup cannot see a rejected document at all and
+  // falls through to the slug guess below — which quietly resolves to whatever
+  // sits at that slug, or to nothing for a doc created with a custom id. The
+  // ops that let a steward read and revive a retired doc need this to work.
+  const docs = await ctx.storage.discoverDocuments({ includeRetired: true });
   const match = docs.find(
     (d) => d.frontmatter.title.toLowerCase() === String(sel.title).toLowerCase(),
   );
   if (match) return match.id;
   return normalizeDocumentId(requireSlug(String(sel.title)));
+}
+
+/**
+ * Clean a caller-supplied id without re-rooting it.
+ *
+ * `normalizeDocumentId` also prepends `nodes/` to any id with no slash, which
+ * silently redirects every id from a flat-layout vault (they carry no prefix)
+ * to a document that does not exist. The tidying half is still wanted: callers
+ * naturally build an id from a file path, and storage appends `.md` itself, so
+ * an un-stripped suffix resolves to `<id>.md.md`.
+ */
+function sanitizeId(raw: string): string {
+  const cleaned = raw.replace(/\.md$/, "").replace(/^\/+/, "");
+  assertSafeDocumentId(cleaned);
+  return cleaned;
 }
 
 /** Validate a node against the spec (§13) before it is written/published. */
@@ -302,10 +309,16 @@ function buildDraftNode(input: {
 
 const create: OperationExecutor = async (ctx, input: any) => {
   const node = buildDraftNode(input);
+  // A rejected node cannot be published — publish refuses one by design. Left
+  // to fall through, the write below lands and publish then throws, stranding a
+  // file on disk with no version and no history, and making the caller's retry
+  // fail with DOCUMENT_ALREADY_EXISTS for a create it believes never happened.
+  // Refuse before anything is written.
+  const publish = node.frontmatter.status === "rejected" ? false : input.publish !== false;
   // Publish assigns the version (spec §6), so a published node must go to disk
   // WITHOUT one — pre-setting it makes the first published version 2 and leaves
   // no v1 keyframe. A draft never reaches publish, so it needs its own v1.
-  if (input.publish === false) node.frontmatter.version = 1;
+  if (!publish) node.frontmatter.version = 1;
   const createdStatus = node.frontmatter.status;
   assertValid(node);
   // Exclusive write: atomically refuses to clobber an existing doc (mirrors OSS
@@ -315,7 +328,7 @@ const create: OperationExecutor = async (ctx, input: any) => {
   // Governed callers create the node WITHOUT publishing: the write has to clear
   // review before it becomes retrievable. Still regenerate the index so the
   // draft is discoverable to the surfaces that list drafts.
-  if (input.publish === false) {
+  if (!publish) {
     await ctx.storage.regenerateIndex();
     return {
       id: node.id,
@@ -351,10 +364,13 @@ const update: OperationExecutor = async (ctx, input: any) => {
   const existing = await ctx.storage.readDocument(id);
   // Guard BEFORE any write: republishing a rejected doc would flip it back into
   // retrieval, and writing first would mutate the file even though publish then
-  // rejects (no version/checksum/history). Naming a `status` is how a caller
-  // revives one, so only a status-less edit is refused — mirrors OSS
-  // update_document.
-  if (isRejected(existing) && input.status === undefined) throw new RejectedDocumentError(id);
+  // rejects (no version/checksum/history). Reviving one — moving it to some
+  // OTHER status — is allowed; re-asserting `rejected` is not, or a client that
+  // echoes the current status back alongside an edit silently rewrites the body
+  // of a document that stays rejected.
+  if (isRejected(existing) && (input.status === undefined || input.status === "rejected")) {
+    throw new RejectedDocumentError(id);
+  }
   const frontmatter: Frontmatter = { ...existing.frontmatter };
   if (input.title) frontmatter.title = input.title;
   if (input.status) frontmatter.status = input.status as Frontmatter["status"];
@@ -385,7 +401,15 @@ const update: OperationExecutor = async (ctx, input: any) => {
     delete frontmatter.checksum;
   }
 
-  const publish = input.publish ?? !(input.status && UNPUBLISHED_STATUSES.has(input.status));
+  // A rejected result never publishes, whatever the caller asked for: publish
+  // refuses a rejected doc, so an explicit `publish: true` alongside
+  // `status: "rejected"` would write the edit and then throw, leaving the file
+  // mutated and its checksum dropped. The derived default already lands here;
+  // this makes it true of the explicit flag too.
+  const publish =
+    frontmatter.status === "rejected"
+      ? false
+      : (input.publish ?? !(input.status && UNPUBLISHED_STATUSES.has(input.status)));
   // Only an unpublished write may carry a caller-assigned version: publish
   // assigns its own, and stamping one first would put the node a version ahead
   // of its history (the same trap context_create avoids).

--- a/packages/engine/src/api/core-executors.ts
+++ b/packages/engine/src/api/core-executors.ts
@@ -91,8 +91,30 @@ async function resolveId(
   ctx: OperationContext,
   sel: { id?: string; uri?: string; title?: string },
 ): Promise<string> {
-  if (sel.id) return normalizeDocumentId(sel.id);
-  if (sel.uri) return normalizeDocumentId(parseUri(sel.uri).path);
+  // Enforced here rather than as a `.refine` on the descriptors: a refine turns
+  // the input into a ZodEffects with no `.shape`, and an MCP tool registered
+  // from that advertises no parameters at all. Same error, raised a moment
+  // later, and every transport reports it the same way.
+  if (!sel.id && !sel.uri && !sel.title) {
+    throw new ContextNestError(
+      "One of uri, id, or title is required",
+      "VALIDATION_FAILED",
+    );
+  }
+  // Vetted, NOT normalized: normalizeDocumentId re-roots a bare slug under
+  // `nodes/`, which silently redirects every id from a flat-layout vault (they
+  // carry no prefix) to a document that does not exist. The storage layer
+  // resolves an id for its own layout — same rule context_update and
+  // context_import's `ids` already follow.
+  if (sel.id) {
+    assertSafeDocumentId(sel.id);
+    return sel.id;
+  }
+  if (sel.uri) {
+    const path = parseUri(sel.uri).path;
+    assertSafeDocumentId(path);
+    return path;
+  }
   const docs = await ctx.storage.discoverDocuments();
   const match = docs.find(
     (d) => d.frontmatter.title.toLowerCase() === String(sel.title).toLowerCase(),
@@ -189,10 +211,21 @@ const search: OperationExecutor = async (ctx, input: any) => {
 
 const get: OperationExecutor = async (ctx, input: any) => {
   const id = await resolveId(ctx, input);
-  const node = await ctx.storage.readDocument(id);
+  const node = await ctx.storage.readDocument(
+    id,
+    input.verify_checksum ? { verifyChecksum: true } : undefined,
+  );
   // Consistent rejected handling (the descriptor advertises REJECTED_DOCUMENT).
-  if (isRejected(node)) throw new RejectedDocumentError(node.id);
-  return { id: node.id, frontmatter: node.frontmatter, body: node.body };
+  // Surfaces that let a steward see and revive a retired document opt out —
+  // reading one is not the same as republishing it.
+  if (isRejected(node) && !input.allow_rejected) throw new RejectedDocumentError(node.id);
+  return {
+    id: node.id,
+    frontmatter: node.frontmatter,
+    body: node.body,
+    ...(input.include_raw ? { raw: node.rawContent } : {}),
+    ...(node.pendingChange ? { pendingChange: node.pendingChange } : {}),
+  };
 };
 
 const list: OperationExecutor = async (ctx, input: any) => {

--- a/packages/engine/src/api/core.ts
+++ b/packages/engine/src/api/core.ts
@@ -583,6 +583,11 @@ const packSummary = z.object({
   description: z.string().optional(),
   query: z.string().optional(),
   agent_instructions: z.string().optional(),
+  // A pack's membership rules are part of the pack. Omitting them made this a
+  // lossy view of what is on disk, so a caller listing packs had to read the
+  // file itself to see what a pack actually selects.
+  includes: z.array(z.string()).optional(),
+  excludes: z.array(z.string()).optional(),
 });
 
 const packsOp: OperationDescriptor = {

--- a/packages/engine/src/api/core.ts
+++ b/packages/engine/src/api/core.ts
@@ -31,6 +31,10 @@ const nodeSummary = z.object({
   status: z.enum(STATUSES).default("draft"),
   tags: z.array(tag).optional(),
   body: z.string().optional(),
+  // Whole frontmatter, on request. Summaries carry the fields a browser needs;
+  // a caller that renders or gates the document needs the rest (version,
+  // author, timestamps, metadata) and would otherwise re-read every file.
+  frontmatter: frontmatterSchema.optional(),
   // Source nodes carry their `source` block so agents can hydrate them
   // (spec §1.9, §5). Present only for type:"source".
   source: z.record(z.unknown()).optional(),
@@ -178,12 +182,32 @@ const listOp: OperationDescriptor = {
   namespace: "core",
   description: "Browse vault contents with optional type, tag, status, or limit filters.",
   input: z.object({
-    type: z.enum(NODE_TYPES).optional().describe("Filter by node type"),
-    tag: tag.optional().describe("Filter by tag"),
+    // An array as well as a single value: callers that browse a family of types
+    // (every runnable type, say) would otherwise have to list, then re-filter.
+    type: z
+      .union([z.enum(NODE_TYPES), z.array(z.enum(NODE_TYPES))])
+      .optional()
+      .describe("Filter by node type, or by several"),
+    tag: tag.optional().describe("Filter by tag (leading # optional, case-insensitive)"),
     // Accept status synonyms (spec §1.5.1 "implementations SHOULD accept
     // synonyms and normalize"); the executor normalizes before comparing.
-    status: z.string().optional().describe("Filter by status (aliases normalized)"),
+    status: z
+      .string()
+      .optional()
+      .describe("Filter by status (aliases normalized). Retired nodes are hidden unless asked for."),
     limit: z.number().int().positive().optional().describe("Max nodes to return"),
+    include_retired: z
+      .boolean()
+      .optional()
+      .describe(
+        "Keep retired nodes even with no status filter. For governed surfaces, where a rejected node is still something its stewards act on rather than one removed from the vault.",
+      ),
+    full: z
+      .boolean()
+      .optional()
+      .describe(
+        "Return each node's full frontmatter and body instead of a summary. For callers that go on to render or gate the documents themselves and would otherwise have to read them all again.",
+      ),
   }),
   output: z.object({
     documents: z.array(nodeSummary),

--- a/packages/engine/src/api/core.ts
+++ b/packages/engine/src/api/core.ts
@@ -459,24 +459,10 @@ const versionsOp: OperationDescriptor = {
   errors: ["VALIDATION_FAILED", "DOCUMENT_NOT_FOUND", "INVALID_DOCUMENT_ID", "INVALID_URI"],
 };
 
-// ─── context_overview ────────────────────────────────────────────────────────
-
-const overviewOp: OperationDescriptor = {
-  name: "context_overview",
-  namespace: "core",
-  description:
-    "Vault manifest: node counts by type and status, the tag set, and a node list.",
-  input: z.object({}),
-  output: z.object({
-    total: z.number().int(),
-    by_type: z.record(z.number().int()),
-    by_status: z.record(z.number().int()),
-    tags: z.array(z.string()),
-    nodes: z.array(nodeSummary),
-  }),
-  errors: ["VALIDATION_FAILED"],
-  aliases: ["vault_info"],
-};
+// context_overview is gone: it returned counts, tags and a node list, all of
+// which context_init now returns alongside the vault's instructions and config.
+// Two operations meant two round trips to open a vault, and a `vault_info`
+// alias sitting on the one that returned none of what vault_info returns.
 
 // ─── context_reconstruct ─────────────────────────────────────────────────────
 
@@ -538,10 +524,37 @@ const verifyOp: OperationDescriptor = {
 const initOp: OperationDescriptor = {
   name: "context_init",
   namespace: "core",
-  description: "Load the vault's CONTEXT.md operating instructions (null if none).",
-  input: z.object({}),
-  output: z.object({ context_md: z.string().nullable() }),
+  description:
+    "Open a vault: its CONTEXT.md operating instructions, its configuration, and what it holds. Call this first in a session — it answers both 'how do I behave here' and 'what is here' in one round trip.",
+  input: z.object({
+    include_nodes: z
+      .boolean()
+      .optional()
+      .describe(
+        "Also list every node. Off by default: the counts and tags below answer most opening questions, and a large vault's node list dwarfs them.",
+      ),
+    limit: z.number().int().positive().optional().describe("Max nodes to list, with include_nodes"),
+  }),
+  output: z.object({
+    context_md: z.string().nullable().describe("The vault's operating instructions, if it has any"),
+    vault_path: z.string(),
+    config: z
+      .object({
+        name: z.string(),
+        description: z.string().optional(),
+        servers: z.array(z.string()).describe("Names of the MCP servers the vault declares"),
+      })
+      .nullable(),
+    total: z.number().int(),
+    by_type: z.record(z.number().int()),
+    by_status: z.record(z.number().int()),
+    tags: z.array(z.string()),
+    nodes: z.array(nodeSummary).optional().describe("Only with include_nodes"),
+  }),
   errors: ["VALIDATION_FAILED"],
+  // `vault_info` returns CONTEXT.md, the config and the vault path — this
+  // operation, not context_overview, which shares none of those fields.
+  aliases: ["vault_info"],
 };
 
 // ─── context_packs ───────────────────────────────────────────────────────────
@@ -626,7 +639,6 @@ export const CORE_OPERATIONS: readonly OperationDescriptor[] = [
   deleteOp,
   versionsOp,
   reconstructOp,
-  overviewOp,
   verifyOp,
   initOp,
   packsOp,

--- a/packages/engine/src/api/core.ts
+++ b/packages/engine/src/api/core.ts
@@ -45,19 +45,40 @@ const documentPayload = z.object({
   id: z.string(),
   frontmatter: frontmatterSchema,
   body: z.string(),
+  /** Exact stored bytes, frontmatter block included. Only with `include_raw`. */
+  raw: z.string().optional(),
+  /** Only with `verify_checksum`, and only when the live bytes have drifted. */
+  pendingChange: z
+    .object({
+      suggestion_id: z.string(),
+      detected_at: z.string(),
+      source: z.string(),
+      proposed_hash: z.string(),
+    })
+    .optional(),
 });
 
 /** Address a single node by URI, id, or title — shared by get/delete/publish/versions. */
 const nodeSelectorShape = {
   uri: z.string().optional().describe("Document URI, e.g. contextnest://nodes/api-design"),
-  id: z.string().optional().describe("Document id / path"),
+  id: z
+    .string()
+    .optional()
+    .describe(
+      "Document id / path, exactly as stored (e.g. \"nodes/api-design\"). Not re-rooted — a flat-layout vault's ids carry no nodes/ prefix.",
+    ),
   title: z.string().optional().describe("Document title"),
 };
-const SELECTOR_REQUIRED = { message: "One of uri, id, or title is required" };
-const hasSelector = (v: { uri?: string; id?: string; title?: string }) =>
-  Boolean(v.uri || v.id || v.title);
-
-const nodeSelector = z.object(nodeSelectorShape).refine(hasSelector, SELECTOR_REQUIRED);
+/**
+ * Deliberately a plain object, NOT `.refine(one of uri/id/title)`.
+ *
+ * A refine makes the input a ZodEffects, which has no `.shape` — and an MCP
+ * tool is registered from exactly that. The SDK accepts the undefined shape and
+ * publishes a tool advertising NO parameters at all, so a client cannot tell
+ * what to send. `resolveId` raises the same VALIDATION_FAILED at execution
+ * time, which every transport surfaces identically.
+ */
+const nodeSelector = z.object(nodeSelectorShape);
 
 // ─── context_search ──────────────────────────────────────────────────────────
 
@@ -152,18 +173,28 @@ const getOp: OperationDescriptor = {
   namespace: "core",
   description:
     "Get the full content of a single node by contextnest:// URI, id, or title.",
-  input: z
-    .object({
-      uri: z
-        .string()
-        .optional()
-        .describe("Document URI, e.g. contextnest://nodes/api-design"),
-      id: z.string().optional().describe("Document id / path"),
-      title: z.string().optional().describe("Document title"),
-    })
-    .refine((v) => Boolean(v.uri || v.id || v.title), {
-      message: "One of uri, id, or title is required",
-    }),
+  // Plain object, no `.refine` — see the note on nodeSelector.
+  input: z.object({
+    ...nodeSelectorShape,
+    include_raw: z
+      .boolean()
+      .optional()
+      .describe(
+        "Also return the exact stored bytes (frontmatter block included) as `raw`, for callers that render or re-serve the file verbatim.",
+      ),
+    verify_checksum: z
+      .boolean()
+      .optional()
+      .describe(
+        "Detect drift on read. When the live bytes no longer match the published checksum, the last-approved content is returned with `pendingChange` describing the difference, instead of the live bytes.",
+      ),
+    allow_rejected: z
+      .boolean()
+      .optional()
+      .describe(
+        "Return a rejected node instead of refusing. Reading one is not the same as republishing it — surfaces that let a steward see and revive retired documents set this.",
+      ),
+  }),
   output: documentPayload,
   errors: [
     "VALIDATION_FAILED",
@@ -409,18 +440,17 @@ const versionsOp: OperationDescriptor = {
   name: "context_versions",
   namespace: "core",
   description: "Version history of a node (newest entries last).",
-  input: z
-    .object({
-      ...nodeSelectorShape,
-      // Off by default on purpose: a doc with dozens of versions would other-
-      // wise return dozens of patches, which is a lot of tokens to push into an
-      // agent that only asked who edited what and when.
-      include_diff: z
-        .boolean()
-        .optional()
-        .describe("Attach each version's change log (unified diff from the previous version)"),
-    })
-    .refine(hasSelector, SELECTOR_REQUIRED),
+  // Plain object, no `.refine` — see the note on nodeSelector.
+  input: z.object({
+    ...nodeSelectorShape,
+    // Off by default on purpose: a doc with dozens of versions would other-
+    // wise return dozens of patches, which is a lot of tokens to push into an
+    // agent that only asked who edited what and when.
+    include_diff: z
+      .boolean()
+      .optional()
+      .describe("Attach each version's change log (unified diff from the previous version)"),
+  }),
   output: z.object({
     id: z.string(),
     keyframe_interval: z.number().int(),
@@ -454,16 +484,11 @@ const reconstructOp: OperationDescriptor = {
   name: "context_reconstruct",
   namespace: "core",
   description: "Reconstruct the full content of a specific past version of a node.",
-  input: z
-    .object({
-      uri: z.string().optional().describe("Document URI"),
-      id: z.string().optional().describe("Document id / path"),
-      title: z.string().optional().describe("Document title"),
-      version: z.number().int().positive().describe("Version number to reconstruct"),
-    })
-    .refine((v) => Boolean(v.uri || v.id || v.title), {
-      message: "One of uri, id, or title is required",
-    }),
+  // Plain object, no `.refine` — see the note on nodeSelector.
+  input: z.object({
+    ...nodeSelectorShape,
+    version: z.number().int().positive().describe("Version number to reconstruct"),
+  }),
   output: z.object({
     id: z.string(),
     version: z.number().int(),

--- a/packages/engine/src/api/core.ts
+++ b/packages/engine/src/api/core.ts
@@ -227,6 +227,12 @@ const createOp: OperationDescriptor = {
       .string()
       .optional()
       .describe("Version-history note recorded against the publish (audit trail)."),
+    status: z
+      .enum(STATUSES)
+      .optional()
+      .describe(
+        "Initial lifecycle status (default draft). Only meaningful with publish:false — publishing sets `published` regardless.",
+      ),
     // These assemble the `skill` block, which is REQUIRED for type:"skill" and
     // must be absent on every other type — so they cannot ride inside
     // `metadata`. Supplying `trigger` is what creates the block.

--- a/packages/engine/src/api/core.ts
+++ b/packages/engine/src/api/core.ts
@@ -266,25 +266,60 @@ const createOp: OperationDescriptor = {
 const updateOp: OperationDescriptor = {
   name: "context_update",
   namespace: "core",
-  description: "Update an existing node — replace content, append, or add tags.",
-  input: z
-    .object({
-      id: z.string().optional().describe("Id of node to update"),
-      title: z.string().optional().describe("Title of node to update"),
-      content: z.string().optional().describe("New content (replaces body)"),
-      append: z.string().optional().describe("Content to append"),
-      tags: z.array(tag).optional().describe("Tags to add"),
-      metadata: z
-        .record(z.unknown())
-        .optional()
-        .describe("Extra frontmatter metadata to merge into frontmatter.metadata."),
-    })
-    .refine((v) => Boolean(v.id || v.title), {
-      message: "One of id or title is required",
-    }),
+  description: "Update an existing node — edit frontmatter fields and/or body, then publish.",
+  // `title` is the NEW title, not a selector: every surface addresses a node by
+  // id/path and sends title only to rename. Selecting by title here collided
+  // with that and served no caller.
+  input: z.object({
+    id: z
+      .string()
+      .describe(
+        "Id of the node to update, exactly as stored (e.g. \"nodes/api-design\"). Not re-rooted — a flat-layout vault's ids carry no nodes/ prefix.",
+      ),
+    title: z.string().optional().describe("New title"),
+    content: z.string().optional().describe("New content (replaces body)"),
+    append: z.string().optional().describe("Content to append"),
+    tags: z.array(tag).optional().describe("New tags (replaces existing)"),
+    metadata: z
+      .record(z.unknown())
+      .optional()
+      .describe(
+        "Frontmatter metadata to merge into frontmatter.metadata. A null value clears that key.",
+      ),
+    status: z
+      .enum(STATUSES)
+      .optional()
+      .describe(
+        "New lifecycle status. Canonical values only — normalize aliases with `normalizeStatus` before calling.",
+      ),
+    note: z
+      .string()
+      .optional()
+      .describe("Version-history note recorded against the publish (audit trail)."),
+    publish: z
+      .boolean()
+      .optional()
+      .describe(
+        "Publish the edit (default true). Defaults to FALSE when `status` names a non-published lifecycle value — those are metadata transitions, not content releases. An explicit value always wins.",
+      ),
+    version: z
+      .number()
+      .int()
+      .min(1)
+      .optional()
+      .describe(
+        "Explicit version to stamp, for governed callers that assign version numbers themselves (a draft revision awaiting review). Ignored when publishing, which assigns the version.",
+      ),
+  }),
   output: z.object({
     id: z.string(),
     version: z.number().int().min(1),
+    status: z.enum(STATUSES).describe("Resulting status — `published` unless the edit stayed a draft"),
+    checkpoint: z
+      .number()
+      .int()
+      .nullable()
+      .describe("Checkpoint sealing the publish, or null when the edit did not publish"),
   }),
   errors: [
     "VALIDATION_FAILED",

--- a/packages/engine/src/api/core.ts
+++ b/packages/engine/src/api/core.ts
@@ -211,10 +211,45 @@ const createOp: OperationDescriptor = {
       .record(z.unknown())
       .optional()
       .describe("Extra frontmatter metadata (e.g. a binding's scope). Merged into frontmatter.metadata."),
+    id: z
+      .string()
+      .optional()
+      .describe(
+        "Explicit document id, overriding the one derived from title + folder. For callers that mint their own ids (deterministic/system nodes) or address documents by path.",
+      ),
+    publish: z
+      .boolean()
+      .optional()
+      .describe(
+        "Publish on create (default true). Pass false to leave the node a draft — governed surfaces use this when a write must clear review before becoming retrievable.",
+      ),
+    note: z
+      .string()
+      .optional()
+      .describe("Version-history note recorded against the publish (audit trail)."),
+    // These assemble the `skill` block, which is REQUIRED for type:"skill" and
+    // must be absent on every other type — so they cannot ride inside
+    // `metadata`. Supplying `trigger` is what creates the block.
+    trigger: z.string().optional().describe("Skill trigger description (required for type:skill)"),
+    tools_required: z.array(z.string()).optional().describe("Tools a skill needs to run"),
+    output_format: z
+      .enum(["markdown", "json", "text", "code"])
+      .optional()
+      .describe("Skill output format"),
+    // Shape-checked by frontmatter validation rather than restated here, so the
+    // skill block has exactly one authoritative schema.
+    inputs: z.array(z.record(z.unknown())).optional().describe("Skill input parameters"),
+    guard_rails: z.array(z.string()).optional().describe("Skill execution constraints"),
   }),
   output: z.object({
     id: z.string(),
     version: z.number().int().min(1),
+    status: z.enum(STATUSES).describe("Resulting status — draft when publish:false"),
+    checkpoint: z
+      .number()
+      .int()
+      .nullable()
+      .describe("Checkpoint sealing the publish, or null when created as a draft"),
   }),
   errors: ["VALIDATION_FAILED", "INVALID_DOCUMENT_ID", "DOCUMENT_ALREADY_EXISTS"],
   aliases: ["create_document"],

--- a/packages/engine/src/api/core.ts
+++ b/packages/engine/src/api/core.ts
@@ -30,6 +30,7 @@ const nodeSummary = z.object({
   type: z.enum(NODE_TYPES).default("document"),
   status: z.enum(STATUSES).default("draft"),
   tags: z.array(tag).optional(),
+  description: z.string().optional(),
   body: z.string().optional(),
   // Whole frontmatter, on request. Summaries carry the fields a browser needs;
   // a caller that renders or gates the document needs the rest (version,
@@ -123,6 +124,12 @@ const queryOp: OperationDescriptor = {
       .boolean()
       .optional()
       .describe("Force full-load mode, bypassing graph traversal"),
+    include_drafts: z
+      .boolean()
+      .optional()
+      .describe(
+        "Include unpublished documents (default: published only). For authoring surfaces, where the point is to find the draft you are working on.",
+      ),
   }),
   output: z.object({
     documents: z.array(nodeSummary),
@@ -392,11 +399,18 @@ const publishOp: OperationDescriptor = {
   namespace: "core",
   description:
     "Publish a node: bump version, compute checksum, seal a version entry + checkpoint.",
-  input: nodeSelector,
+  input: z.object({
+    ...nodeSelectorShape,
+    note: z
+      .string()
+      .optional()
+      .describe("Version-history note recorded against the publish (audit trail)."),
+  }),
   output: z.object({
     id: z.string(),
     version: z.number().int().min(1),
     checkpoint: z.number().int().min(1),
+    chain_hash: z.string().describe("Hash chaining this version to the one before it"),
   }),
   errors: [
     "VALIDATION_FAILED",
@@ -415,7 +429,11 @@ const deleteOp: OperationDescriptor = {
   namespace: "core",
   description: "Delete a node and its version history from the vault.",
   input: nodeSelector,
-  output: z.object({ id: z.string(), deleted: z.literal(true) }),
+  output: z.object({
+    id: z.string(),
+    title: z.string().describe("Title of the deleted node, read before removal"),
+    deleted: z.literal(true),
+  }),
   errors: ["VALIDATION_FAILED", "DOCUMENT_NOT_FOUND", "INVALID_DOCUMENT_ID", "INVALID_URI"],
   aliases: ["delete_document"],
 };

--- a/packages/engine/src/filters.ts
+++ b/packages/engine/src/filters.ts
@@ -1,0 +1,80 @@
+import type { ContextNode } from "./types.js";
+import { normalizeStatus } from "./parser.js";
+
+/**
+ * Filters accepted by {@link filterDocuments} and by the `context_list`
+ * operation that wraps it.
+ */
+export interface DocumentFilters {
+  /** One node type, or several to keep (e.g. every runnable type). */
+  type?: string | readonly string[];
+  /** Tag to match. The leading `#` is optional and case is ignored. */
+  tag?: string;
+  /** Lifecycle status. Aliases are normalized before comparing. */
+  status?: string;
+  /** Max documents to return, applied last. */
+  limit?: number;
+  /**
+   * Keep retired nodes even when no `status` filter is given. Off by default,
+   * matching ordinary retrieval. Governed surfaces set it: there a rejected
+   * document is still something the caller may need to see and act on, rather
+   * than something removed from the vault.
+   */
+  includeRetired?: boolean;
+}
+
+/**
+ * Narrow a discovered document list by type / tag / status / limit.
+ *
+ * Shared so every surface filters identically — the CLI, the MCP server and
+ * Community each grew their own copy of this and each got a different subset of
+ * the rules right. Callers pass their own document list rather than a storage
+ * handle, because Community filters documents it has already read and gated.
+ *
+ * Note the caller must discover with `{ includeRetired: true }` for a
+ * `status: "rejected"` filter to have anything to match: retired documents are
+ * dropped at discovery otherwise, and the filter then runs on a list they were
+ * never in.
+ */
+export function filterDocuments(
+  docs: readonly ContextNode[],
+  filters: DocumentFilters = {},
+): ContextNode[] {
+  let out = [...docs];
+
+  if (filters.type) {
+    const wanted = new Set(
+      typeof filters.type === "string" ? [filters.type] : filters.type,
+    );
+    // Default to "document": the field is optional in frontmatter, and a
+    // literal comparison silently skips every document that omits it — which
+    // is most of them.
+    out = out.filter((d) => wanted.has(d.frontmatter.type ?? "document"));
+  }
+
+  if (filters.status) {
+    const wanted = normalizeStatus(filters.status);
+    out = out.filter(
+      (d) => normalizeStatus(d.frontmatter.status ?? "draft") === wanted,
+    );
+  } else if (!filters.includeRetired) {
+    // No status asked for: keep retired documents out of ordinary retrieval,
+    // the way every surface's default listing does.
+    out = out.filter((d) => d.frontmatter.status !== "rejected");
+  }
+
+  if (filters.tag) {
+    // Compare bare and case-insensitively. The parser `#`-prefixes tags on
+    // read, so a filter value normalized the other way (`#` stripped) matches
+    // nothing at all — a filter that silently returns empty is worse than one
+    // that errors.
+    const wanted = bareTag(filters.tag);
+    out = out.filter((d) => d.frontmatter.tags?.some((t) => bareTag(t) === wanted));
+  }
+
+  return filters.limit ? out.slice(0, filters.limit) : out;
+}
+
+function bareTag(tag: string): string {
+  return tag.trim().replace(/^#+/, "").toLowerCase();
+}

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -205,6 +205,11 @@ export type {
 export { NestStorage, UNSTAGED_DRIFT_SENTINEL, normalizeDocumentId } from "./storage.js";
 export type { LayoutMode, ReadDocumentOptions } from "./storage.js";
 
+// Document filtering — shared by context_list and by surfaces that filter a
+// document list they already hold.
+export { filterDocuments } from "./filters.js";
+export type { DocumentFilters } from "./filters.js";
+
 // URI
 export { parseUri, canonicalizeUri, serializeUri, extractPath } from "./uri.js";
 

--- a/packages/engine/src/schemas.ts
+++ b/packages/engine/src/schemas.ts
@@ -15,6 +15,12 @@ export const NODE_TYPES = [
   "tool",
   "reference",
   "skill",
+  // Types the ecosystem already stores. Their absence here meant a vault
+  // holding them failed validation even though every surface writes and reads
+  // them — the vocabulary has to cover what is actually on disk.
+  "agent",
+  "artifact",
+  "table",
 ] as const;
 
 export const STATUSES = [
@@ -139,7 +145,10 @@ export const HASH_CHAIN_EVENT_TYPES = [
 export const ZONE_ID_PATTERN = /^[a-z][a-z0-9_-]*$/;
 
 /** Tag pattern: optional # prefix, then letter, then alphanumeric/underscore/hyphen (§13 rule 5) */
-export const TAG_PATTERN = /^#?[a-zA-Z][a-zA-Z0-9_-]*$/;
+// `:` allows namespaced tags (`#dept:engineering`, `#team:platform`), which the
+// ecosystem already writes. Strictly a widening — every previously valid tag
+// still matches.
+export const TAG_PATTERN = /^#?[a-zA-Z][a-zA-Z0-9_:-]*$/;
 
 /** Checksum pattern (§13 rule 8) */
 export const CHECKSUM_PATTERN = /^sha256:[a-f0-9]{64}$/;
@@ -147,7 +156,9 @@ export const CHECKSUM_PATTERN = /^sha256:[a-f0-9]{64}$/;
 /** contextnest:// URI pattern */
 export const CONTEXT_NEST_URI_PATTERN = /^contextnest:\/\//;
 
-const tagSchema = z.string().regex(TAG_PATTERN, "Tag must match pattern: ^#?[a-zA-Z][a-zA-Z0-9_-]*$");
+const tagSchema = z
+  .string()
+  .regex(TAG_PATTERN, `Tag must match pattern: ${TAG_PATTERN.source}`);
 
 const skillInputSchema = z.object({
   name: z.string().min(1),

--- a/packages/engine/src/types.ts
+++ b/packages/engine/src/types.ts
@@ -3,7 +3,7 @@
  * See CONTEXT_NEST_SPEC-v3.md for the full specification.
  */
 
-/** Node types (§1.6) */
+/** Node types (§1.6). Keep in lockstep with `NODE_TYPES` in schemas.ts. */
 export type NodeType =
   | "document"
   | "snippet"
@@ -13,7 +13,10 @@ export type NodeType =
   | "source"
   | "tool"
   | "reference"
-  | "skill";
+  | "skill"
+  | "agent"
+  | "artifact"
+  | "table";
 
 /** Document status (§1.5)
  *

--- a/packages/engine/src/versioning.ts
+++ b/packages/engine/src/versioning.ts
@@ -156,6 +156,19 @@ export class VersionManager {
       );
     }
 
+    // The walk below starts at the nearest keyframe at or before the target and
+    // replays diffs forward. Ask for a version the history does not contain and
+    // there are no diffs to replay, so it returns the keyframe's content as
+    // though it were the version requested — a silently wrong answer in the one
+    // place that must never give one. Refuse instead.
+    if (!history.versions.some((entry) => entry.version === targetVersion)) {
+      throw new ContextNestError(
+        `Version ${targetVersion} not found for ${docId}`,
+        "VERSION_NOT_FOUND",
+        "§6",
+      );
+    }
+
     // Find the nearest keyframe at or before target version
     let keyframeVersion = -1;
     for (const entry of history.versions) {

--- a/packages/mcp-server/src/__tests__/mcp-server.regression.test.ts
+++ b/packages/mcp-server/src/__tests__/mcp-server.regression.test.ts
@@ -54,6 +54,7 @@ const EXPECTED_TOOLS = [
   "context_update",
   "context_list",
   "context_versions",
+  "context_get",
 ] as const;
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
@@ -162,6 +163,28 @@ describe("[regression] MCP server e2e — protocol & smoke", () => {
       expect((t.description ?? "").length).toBeGreaterThan(0);
       expect(t.inputSchema).toBeDefined();
     }
+  });
+
+  // A catalog tool is registered from `op.input.shape`, which is undefined on
+  // any descriptor whose input is a ZodEffects (i.e. one carrying a `.refine`).
+  // The SDK accepts that and publishes a tool advertising NO parameters at all,
+  // so a client cannot tell what to send — and asserting only that inputSchema
+  // "is defined" above sails straight past it.
+  it.each([
+    ["context_create", ["title", "content"]],
+    ["context_update", ["id", "content", "status"]],
+    ["context_list", ["type", "tag", "status", "limit"]],
+    ["context_versions", ["id", "title", "include_diff"]],
+    ["context_get", ["uri", "id", "title", "include_raw", "allow_rejected"]],
+    ["context_import", ["documents", "ids"]],
+  ])("%s advertises its declared inputs", async (name, expected) => {
+    const { tools } = await client.listTools();
+    const tool = tools.find((t) => t.name === name);
+    expect(tool).toBeDefined();
+    const props = Object.keys(
+      (tool!.inputSchema as { properties?: Record<string, unknown> }).properties ?? {},
+    );
+    expect(props).toEqual(expect.arrayContaining(expected));
   });
 
   it("vault_info returns identity and the configured servers", async () => {

--- a/packages/mcp-server/src/__tests__/mcp-server.regression.test.ts
+++ b/packages/mcp-server/src/__tests__/mcp-server.regression.test.ts
@@ -59,6 +59,12 @@ const EXPECTED_TOOLS = [
   "context_verify",
   "context_packs",
   "context_nests",
+  "context_search",
+  "context_query",
+  "context_resolve",
+  "context_publish",
+  "context_delete",
+  "context_reconstruct",
 ] as const;
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
@@ -181,6 +187,9 @@ describe("[regression] MCP server e2e — protocol & smoke", () => {
     ["context_versions", ["id", "title", "include_diff"]],
     ["context_get", ["uri", "id", "title", "include_raw", "allow_rejected"]],
     ["context_init", ["include_nodes", "limit"]],
+    ["context_search", ["query", "limit"]],
+    ["context_query", ["query", "hops", "full", "include_drafts"]],
+    ["context_resolve", ["selector", "max_tokens", "hops"]],
     ["context_import", ["documents", "ids"]],
   ])("%s advertises its declared inputs", async (name, expected) => {
     const { tools } = await client.listTools();

--- a/packages/mcp-server/src/__tests__/mcp-server.regression.test.ts
+++ b/packages/mcp-server/src/__tests__/mcp-server.regression.test.ts
@@ -51,6 +51,7 @@ const EXPECTED_TOOLS = [
   // catalog tool (e.g. create_document) stays registered but is deprecated.
   "context_import",
   "context_create",
+  "context_update",
 ] as const;
 
 // ─── Helpers ────────────────────────────────────────────────────────────────

--- a/packages/mcp-server/src/__tests__/mcp-server.regression.test.ts
+++ b/packages/mcp-server/src/__tests__/mcp-server.regression.test.ts
@@ -52,6 +52,8 @@ const EXPECTED_TOOLS = [
   "context_import",
   "context_create",
   "context_update",
+  "context_list",
+  "context_versions",
 ] as const;
 
 // ─── Helpers ────────────────────────────────────────────────────────────────

--- a/packages/mcp-server/src/__tests__/mcp-server.regression.test.ts
+++ b/packages/mcp-server/src/__tests__/mcp-server.regression.test.ts
@@ -47,8 +47,10 @@ const EXPECTED_TOOLS = [
   "approve_suggestion",
   "reject_suggestion",
   // Catalog-driven: name, description and schema come from the engine's
-  // operation catalog rather than being declared here.
+  // operation catalog rather than being declared here. The legacy twin of a
+  // catalog tool (e.g. create_document) stays registered but is deprecated.
   "context_import",
+  "context_create",
 ] as const;
 
 // ─── Helpers ────────────────────────────────────────────────────────────────

--- a/packages/mcp-server/src/__tests__/mcp-server.regression.test.ts
+++ b/packages/mcp-server/src/__tests__/mcp-server.regression.test.ts
@@ -55,6 +55,9 @@ const EXPECTED_TOOLS = [
   "context_list",
   "context_versions",
   "context_get",
+  "context_init",
+  "context_verify",
+  "context_packs",
 ] as const;
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
@@ -176,6 +179,7 @@ describe("[regression] MCP server e2e — protocol & smoke", () => {
     ["context_list", ["type", "tag", "status", "limit"]],
     ["context_versions", ["id", "title", "include_diff"]],
     ["context_get", ["uri", "id", "title", "include_raw", "allow_rejected"]],
+    ["context_init", ["include_nodes", "limit"]],
     ["context_import", ["documents", "ids"]],
   ])("%s advertises its declared inputs", async (name, expected) => {
     const { tools } = await client.listTools();

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -82,7 +82,7 @@ const permissiveRbac: RbacHook = {
 
 // ─── Tool: vault_info ──────────────────────────────────────────────────────────
 
-server.tool("vault_info", "Get vault identity (CONTEXT.md) and configuration summary", {}, async () => {
+server.tool("vault_info", "DEPRECATED — use context_init, which returns this plus what the vault holds. Get vault identity (CONTEXT.md) and configuration summary", {}, async () => {
   const contextMd = await storage.readContextMd();
   const config = await storage.readConfig();
 
@@ -513,7 +513,7 @@ server.tool(
 
 // ─── Tool: verify_integrity ────────────────────────────────────────────────────
 
-server.tool("verify_integrity", "Verify integrity of all hash chains in the vault", {}, async () => {
+server.tool("verify_integrity", "DEPRECATED — use context_verify. Verify integrity of all hash chains in the vault", {}, async () => {
   const report = await storage.verifyVaultIntegrity();
   return {
     content: [
@@ -1141,6 +1141,9 @@ registerCatalogTool("context_create");
 registerCatalogTool("context_update");
 registerCatalogTool("context_list");
 registerCatalogTool("context_get");
+registerCatalogTool("context_init");
+registerCatalogTool("context_verify");
+registerCatalogTool("context_packs");
 // No legacy twin: nothing here listed version history before — read_version
 // fetches one version's content, which is a different question.
 registerCatalogTool("context_versions");

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -582,7 +582,7 @@ server.tool(
 
 server.tool(
   "create_document",
-  "Create a new document in the vault with frontmatter and optional body content",
+  "DEPRECATED — use context_create. Create a new document in the vault with frontmatter and optional body content. Kept for existing clients: it wraps the body in a heading and fills skill defaults, which context_create does not.",
   {
     path: z.string().describe("Document path (e.g., 'nodes/api-design')"),
     title: z.string().describe("Document title"),
@@ -1101,22 +1101,28 @@ server.tool(
   },
 );
 
-// ─── Tool: context_import ──────────────────────────────────────────────────────
+// ─── Catalog-driven tools (canonical `context_*` names) ───────────────────────
 
-// First catalog-driven tool in this server: the schema, description and
-// implementation all come from the engine's operation catalog, so this surface
-// cannot drift from the CLI/Community ones. The SDK wants a ZodRawShape, so we
-// hand it the descriptor's own `.shape` rather than restating the schema here.
-const importOp = engineApi.getOperation("context_import");
-if (importOp) {
+/**
+ * Register an engine catalog operation as an MCP tool. Name, description and
+ * schema all come from the descriptor, so this surface cannot drift from the
+ * CLI and Community ones. The SDK wants a ZodRawShape, hence the `.shape`.
+ *
+ * These are the canonical names. The legacy tools above (`create_document`,
+ * `read_document`, …) stay registered and behave exactly as before; they are
+ * deprecated in favour of these and will be removed in a future major.
+ */
+function registerCatalogTool(name: string): void {
+  const op = engineApi.getOperation(name);
+  if (!op) return;
   server.tool(
-    importOp.name,
-    importOp.description,
-    (importOp.input as z.ZodObject<z.ZodRawShape>).shape,
+    op.name,
+    op.description,
+    (op.input as z.ZodObject<z.ZodRawShape>).shape,
     async (input) => {
-      // No onProgress — MCP has no progress channel; the operation is identical
+      // No onProgress — MCP has no progress channel; operations are identical
       // without one.
-      const result = await engineApi.run(importOp.name, input, {
+      const result = await engineApi.run(op.name, input, {
         storage,
         query: new GraphQueryEngine(storage),
         versions: new VersionManager(storage),
@@ -1129,6 +1135,9 @@ if (importOp) {
     },
   );
 }
+
+registerCatalogTool("context_import");
+registerCatalogTool("context_create");
 
 // ─── Start server ──────────────────────────────────────────────────────────────
 

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -116,7 +116,7 @@ server.tool("vault_info", "DEPRECATED — use context_init, which returns this p
 
 server.tool(
   "resolve",
-  "Execute a selector query to find matching documents using graph traversal",
+  "DEPRECATED — use context_query, which this has always been: a graph-traversal selector query. (context_resolve is a different operation — it returns full bodies within a token budget.) Execute a selector query to find matching documents using graph traversal",
   {
     selector: z.string().describe("Selector query expression (e.g., '#engineering + type:document')"),
     hops: z.number().optional().describe("Graph traversal depth (default: 2). More hops = more context, slower. Fewer hops = faster, less context."),
@@ -469,7 +469,7 @@ server.tool(
 
 server.tool(
   "search",
-  "Full-text search across vault documents with graph traversal",
+  "DEPRECATED — use context_search. Full-text search across vault documents with graph traversal",
   {
     query: z.string().describe("Search query"),
     hops: z.number().optional().describe("Graph traversal depth from search results (default: 2)"),
@@ -557,7 +557,7 @@ server.tool(
 
 server.tool(
   "read_version",
-  "Read a specific version of a document",
+  "DEPRECATED — use context_reconstruct. Read a specific version of a document",
   {
     path: z.string().describe("Document path (e.g., 'nodes/api-design')"),
     version: z.number().describe("Version number to reconstruct"),
@@ -842,7 +842,7 @@ server.tool(
 
 server.tool(
   "delete_document",
-  "Delete a document and its version history from the vault",
+  "DEPRECATED — use context_delete. Delete a document and its version history from the vault",
   {
     path: z.string().describe("Document path (e.g., 'nodes/api-design')"),
   },
@@ -874,7 +874,7 @@ server.tool(
 
 server.tool(
   "publish_document",
-  "Publish a document: bump version, compute checksum, create version entry and checkpoint",
+  "DEPRECATED — use context_publish. Publish a document: bump version, compute checksum, create version entry and checkpoint",
   {
     path: z.string().describe("Document path (e.g., 'nodes/api-design')"),
     author: z.string().optional().default("mcp@contextnest.local").describe("Author email"),
@@ -1144,6 +1144,12 @@ registerCatalogTool("context_get");
 registerCatalogTool("context_init");
 registerCatalogTool("context_verify");
 registerCatalogTool("context_packs");
+registerCatalogTool("context_search");
+registerCatalogTool("context_query");
+registerCatalogTool("context_resolve");
+registerCatalogTool("context_publish");
+registerCatalogTool("context_delete");
+registerCatalogTool("context_reconstruct");
 // No legacy twin: nothing here listed version history before — read_version
 // fetches one version's content, which is a different question.
 registerCatalogTool("context_versions");

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -694,7 +694,7 @@ server.tool(
 
 server.tool(
   "update_document",
-  "Update an existing document's frontmatter fields and/or body content",
+  "DEPRECATED — use context_update. Update an existing document's frontmatter fields and/or body content. Kept for existing clients: it accepts status aliases and wraps the body, which context_update does not.",
   {
     path: z.string().describe("Document path (e.g., 'nodes/api-design')"),
     title: z.string().optional().describe("New title"),
@@ -1138,6 +1138,7 @@ function registerCatalogTool(name: string): void {
 
 registerCatalogTool("context_import");
 registerCatalogTool("context_create");
+registerCatalogTool("context_update");
 
 // ─── Start server ──────────────────────────────────────────────────────────────
 

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -168,7 +168,7 @@ server.tool(
 
 server.tool(
   "read_document",
-  "Read a single document by its contextnest:// URI or path",
+  "DEPRECATED — use context_get. Read a single document by its contextnest:// URI or path. Kept for existing clients: it takes URI and path in one field, where context_get separates uri, id and title.",
   { uri: z.string().describe("Document URI (e.g., 'contextnest://nodes/api-design') or path (e.g., 'nodes/api-design')") },
   async ({ uri }) => {
     let docId: string;
@@ -1140,6 +1140,7 @@ registerCatalogTool("context_import");
 registerCatalogTool("context_create");
 registerCatalogTool("context_update");
 registerCatalogTool("context_list");
+registerCatalogTool("context_get");
 // No legacy twin: nothing here listed version history before — read_version
 // fetches one version's content, which is a different question.
 registerCatalogTool("context_versions");

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -206,7 +206,7 @@ server.tool(
 
 server.tool(
   "list_documents",
-  "List all documents with optional filters",
+  "DEPRECATED — use context_list. List all documents with optional filters.",
   {
     type: z.string().optional().describe("Filter by node type"),
     status: z
@@ -1139,6 +1139,10 @@ function registerCatalogTool(name: string): void {
 registerCatalogTool("context_import");
 registerCatalogTool("context_create");
 registerCatalogTool("context_update");
+registerCatalogTool("context_list");
+// No legacy twin: nothing here listed version history before — read_version
+// fetches one version's content, which is a different question.
+registerCatalogTool("context_versions");
 
 // ─── Start server ──────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

The CLI, the MCP server and Community each carried their own copy of "create a document", "edit one", "list them", "read one", "search", "publish", "delete" and "open a vault". The copies drifted, so the same action produced different results depending on which surface you used. This moves the whole core namespace onto the engine's operation catalog, which is now the single implementation every surface calls.

Each operation grew the inputs a surface previously had to bypass it to get, so adoption removed duplicated logic rather than adding a layer on top of it. Where an operation could not fully serve a surface, that surface kept its implementation and the reason is recorded rather than papered over.

## What changed

**Documents.** `context_create` accepts a caller-supplied id, a draft-only mode for governed writes, and the skill block it previously could not express. `context_update` sets a status and a version note, decides on its own whether an edit publishes, and takes `title` as the new title. `context_get` returns raw bytes, detects drift on read, and can read a retired document. `context_delete` reports what it deleted.

**Browsing.** `context_list` filters by several types at once and can return whole documents. `context_query` includes drafts on request. `context_search` takes a limit. Node summaries carry a description.

**Vaults.** `context_init` opens a vault in one call, returning its instructions, configuration, path and contents together. `context_packs` returns each pack's membership rules instead of a lossy subset.

**Removed.** `context_overview` is gone — everything it returned, `context_init` returns, and its `vault_info` alias sat on an operation that returned none of what that name promises.

**Vocabulary.** `agent`, `artifact` and `table` join the node types, and tags accept namespacing. All of these were already being written and read across the ecosystem while failing validation.

**Surfaces.** Every core CLI command now runs through the catalog, plus a new `ctx info` that opens a vault; `ctx history` gains change logs, `ctx list` and `ctx search` gain limits. Sixteen catalog-backed MCP tools are registered, with their hand-written twins kept, unchanged, and marked deprecated.

## Bugs fixed

**Reconstructing a version that does not exist returned a different version's content.** Reconstruction starts at the nearest keyframe at or before the target and replays change logs forward, so asking for a version the history does not contain left nothing to replay and returned the keyframe's content as though it were the version requested — silently, in the one place that must never answer silently wrong. It surfaced a regression test that had been passing on exactly that: it asked for version 2 of a document left at version 1 and matched on a title both versions share.

**An operation with a refined input could not be reached over MCP at all.** The refinement erased the shape a tool is registered from, and the SDK published a tool advertising no parameters, so no client could tell what to send. A test now asserts every catalog tool advertises its declared inputs — the previous check only asserted a schema existed, which an empty one satisfies.

**Reads and writes against a flat-layout vault failed.** Ids were re-rooted under a prefix those vaults do not use, so every id pointed at a document that does not exist. Ids are vetted rather than rewritten now, across every operation that takes one.

**Two filters could never match.** A retired-status filter ran against a list retired documents had already been dropped from, and a type filter compared against an optional field with no default, so the most common type matched nothing. Vault counts had the same defect and could never report a rejected node.

**A new document's history began at version 2 with no first keyframe**, because the version was written before publish assigned one.

**A failed publish left a stale checksum behind**, which the next verified read reported as an external edit that never happened.

## Impact

Behaviour changes worth knowing before merging:

- `context_update` takes `title` as the new title. It was previously a way to select the document to edit — a meaning no surface used, since all of them address documents by id or path.
- `context_update` replaces tags rather than merging them, matching every surface and `context_create`. A caller wanting the old behaviour sends the merged set.
- `context_update` refuses a rejected document only when no status is given, so naming one revives it.
- Metadata treats a null value as "clear this key". Without it a merge left callers no way to remove metadata at all.
- `ctx add` now produces version 1, not 2. Existing documents are unaffected.
- Reconstructing a version that is not in the history now fails instead of returning nearby content.
- `context_overview` no longer exists.

Three commands deliberately keep their own implementations. `ctx verify` checks each document chain and reports unreadable histories per document, which is strictly more than the vault-level integrity operation. `ctx resolve` evaluates a selector and lists matches — despite the shared word, that is not `context_resolve`, which returns full bodies within a token budget. And `ctx init` creates a vault where `context_init` opens one, so the new command is `ctx info`.

Community consumes this release and depends on all of it; its pin needs bumping to the published version before that side merges.

700 engine unit tests and 131 regression tests pass, with type checks clean across the engine, CLI and MCP server.