### PR TITLE
feat(cli): file safety — confirm before writing, dry-run, and an action log

### DIFF
--- a/.changeset/olive-moons-swim.md
+++ b/.changeset/olive-moons-swim.md
@@ -1,0 +1,32 @@
+---
+"@promptowl/contextnest-cli": patch
+---
+
+Fix: starter recipes scaffolded documents with an invalid node type
+
+Every node in all five populated starter recipes (`developer`, `executive`,
+`analyst`, `team`, `sales`) shipped `type: context` — a value that has never
+been part of `NODE_TYPES`. `ctx init --starter` writes and publishes without
+validating, so the vault looked healthy until the first `ctx update` or
+`ctx validate` on a scaffolded document, which failed with:
+
+```
+Rule 6: Invalid enum value. Expected 'document' | … | 'table', received 'context'
+```
+
+All 15 nodes now declare `type: document`.
+
+Two tests lock it down: a unit test runs the real parser and validator over
+every node of every registered recipe (so any invalid frontmatter value fails
+fast, not just this field), and a regression test asserts that a freshly
+initialized starter vault passes `ctx validate` and that a scaffolded document
+can be updated.
+
+**Existing vaults are not migrated.** A vault created by an earlier release
+still holds `type: context` on disk and will keep failing validation. Fix it in
+place, e.g.:
+
+```bash
+grep -rl '^type: context$' nodes/ | xargs sed -i 's/^type: context$/type: document/'
+ctx index
+```

--- a/.changeset/tall-pumas-shake.md
+++ b/.changeset/tall-pumas-shake.md
@@ -1,0 +1,32 @@
+---
+"@promptowl/contextnest-cli": minor
+---
+
+CLI file-safety hardening: confirmation prompts, `--dry-run`, and an action log
+
+No `ctx` command now writes to your working directory without saying so.
+
+- **`--dry-run`** on every write command. It runs the real operation against a
+  throwaway copy of the vault, reports the exact files that would change, and
+  leaves your vault untouched — so the preview never drifts from what the
+  command actually does.
+- **Action log.** Write commands end with the list of files created (`+`),
+  modified (`~`) or deleted (`-`), computed by diffing the vault before and
+  after. Written to stderr so `--json` output and redirected stdout stay clean.
+- **Confirmation prompts.** Interactive runs ask first; destructive commands
+  (`delete`, `checkpoint rebuild`, `drift approve`, `vault remove`, re-running
+  `init` over an existing vault, overwriting a `read --out` target, `push`)
+  default to "no". Non-interactive callers are never blocked on stdin —
+  additive commands proceed, destructive ones refuse unless `--yes`/`--force`
+  is passed.
+- **No silent overwrites.** `ctx read --html --out <file>` refuses to clobber an
+  existing file without `--force`.
+- **Safer egress.** `ctx push` lists the documents leaving the machine before
+  sending them, refuses plaintext HTTP to a non-loopback host (which would
+  expose documents and the API key on the wire), and accepts the API key from
+  `CONTEXTNEST_API_KEY` so it need not appear in argv or shell history. The
+  same protocol check covers a `PROMPTOWL_API_URL` override.
+
+Behavior change for scripts: `ctx delete`, `ctx checkpoint rebuild`,
+`ctx drift approve`, `ctx vault remove` and `ctx push` now require `--yes` (or
+`--force`) when there is no TTY.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -101,6 +101,41 @@ After `ctx init`, the CLI prints a starter-specific instruction block to stdout.
 - `ctx reconstruct <path> <version>` — Reconstruct a specific version. A version the history does not contain is now refused rather than answered with a neighbouring version's content
 - `ctx verify` — Verify all hash chains (reports a `history.yaml` it cannot read instead of skipping it)
 
+### File Safety
+
+No command writes to your working directory without telling you. Three global
+flags govern every write:
+
+| Flag | Effect |
+|------|--------|
+| `--dry-run` | Runs the command against a throwaway copy of the vault, prints the exact files it *would* touch, and leaves your vault untouched |
+| `-y, --yes` | Skips confirmation prompts — the "prior explicit consent" for scripts and CI |
+| `--force`   | Overwrites an existing file, repoints a taken vault alias, or allows a plaintext-HTTP push |
+
+```bash
+ctx add nodes/spec --title "Spec" --dry-run   # preview, writes nothing
+ctx delete nodes/spec --yes                   # destructive, so it needs the flag
+ctx read nodes/spec --html --out out.html     # refuses to clobber out.html without --force
+```
+
+**Action log.** Every write command ends with the list of files it created
+(`+`), modified (`~`) or deleted (`-`), computed by comparing the vault before
+and after — so it reflects what actually happened, not what was intended. The
+log goes to **stderr**, leaving `--json` output and redirected stdout clean.
+
+**Confirmation.** On a terminal, write commands ask before proceeding.
+Destructive ones (`delete`, `checkpoint rebuild`, `drift approve`,
+`vault remove`, re-running `init` over an existing vault, overwriting an
+`--out` file, `push`) default to *no*. Without a TTY nothing blocks on stdin:
+additive commands take their own argv as consent, destructive ones **refuse**
+unless `--yes` or `--force` was passed.
+
+**Network egress.** `ctx push` lists the documents leaving your machine and
+asks before sending them. Plaintext HTTP to a non-loopback host is refused —
+it would put both the documents and your API key on the wire in the clear.
+Prefer `CONTEXTNEST_API_KEY` over `--key`: command-line arguments are visible
+to other processes and land in shell history.
+
 ### Errors
 
 Every failure prints as a single line — `Error [CODE]: message` for engine

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -123,6 +123,11 @@ ctx read nodes/spec --html --out out.html     # refuses to clobber out.html with
 and after — so it reflects what actually happened, not what was intended. The
 log goes to **stderr**, leaving `--json` output and redirected stdout clean.
 
+`--dry-run` covers the vault registry too: `ctx vault add|remove|default|describe`
+run against a throwaway copy of `~/.contextnest/`, so a preview fails on an
+alias collision or an unregistered alias exactly where the real command would,
+rather than promising something that can't happen.
+
 **Confirmation.** On a terminal, write commands ask before proceeding.
 Destructive ones (`delete`, `checkpoint rebuild`, `drift approve`,
 `vault remove`, re-running `init` over an existing vault, overwriting an

--- a/packages/cli/src/__tests__/cli.regression.test.ts
+++ b/packages/cli/src/__tests__/cli.regression.test.ts
@@ -12,7 +12,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, afterAll } from "vitest";
-import { execFileSync, execFile } from "node:child_process";
+import { execFileSync, execFile, spawnSync } from "node:child_process";
 import { promisify } from "node:util";
 import {
   mkdtempSync,
@@ -79,21 +79,18 @@ function runCtxResult(
   cwd: string,
   args: string[],
 ): { status: number; stdout: string; stderr: string } {
-  try {
-    const stdout = execFileSync("node", [distPath, ...args], {
-      cwd,
-      env: ENV,
-      encoding: "utf-8",
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-    return { status: 0, stdout, stderr: "" };
-  } catch (err: any) {
-    return {
-      status: typeof err.status === "number" ? err.status : 1,
-      stdout: err.stdout?.toString() ?? "",
-      stderr: err.stderr?.toString() ?? "",
-    };
-  }
+  // spawnSync, not execFileSync: stderr has to come back on the SUCCESS path
+  // too, since that is where the file-safety action log is written.
+  const res = spawnSync("node", [distPath, ...args], {
+    cwd,
+    env: ENV,
+    encoding: "utf-8",
+  });
+  return {
+    status: typeof res.status === "number" ? res.status : 1,
+    stdout: res.stdout ?? "",
+    stderr: res.stderr ?? "",
+  };
 }
 
 function initVault(cwd: string): void {
@@ -539,7 +536,7 @@ describe("[regression] ctx delete", () => {
   it("removes the document and its version history", () => {
     expect(existsSync(join(tmp, "nodes", "disposable.md"))).toBe(true);
 
-    const out = runCtx(tmp, ["delete", "nodes/disposable"]);
+    const out = runCtx(tmp, ["delete", "nodes/disposable", "--yes"]);
     expect(out).toMatch(/Deleted nodes\/disposable/);
 
     expect(existsSync(join(tmp, "nodes", "disposable.md"))).toBe(false);
@@ -642,7 +639,7 @@ describe("[regression] ctx checkpoint", () => {
   });
 
   it("rebuild reconstructs checkpoint history from per-document histories", () => {
-    const out = runCtx(tmp, ["checkpoint", "rebuild"]);
+    const out = runCtx(tmp, ["checkpoint", "rebuild", "--yes"]);
     expect(out).toMatch(/Rebuilt \d+ checkpoints/);
   });
 
@@ -822,6 +819,29 @@ describe("[regression] ctx validate --json (valid)", () => {
 describe("[regression] ctx pack", () => {
   beforeEach(() => initStarter(tmp, "developer"));
 
+  // Every starter node shipped `type: context`, which is not in NODE_TYPES.
+  // `init --starter` writes and publishes without validating, so the vault
+  // looked fine until the user ran `ctx update` or `ctx validate` on a
+  // scaffolded document. Nothing scaffolded may be born spec-invalid.
+  it("init --starter produces a vault that validates clean", () => {
+    const res = runCtxResult(tmp, ["validate", "--json"]);
+    const report = JSON.parse(res.stdout);
+    expect(report.errors).toEqual([]);
+    expect(report.valid).toBe(true);
+    expect(res.status).toBe(0);
+  });
+
+  it("a scaffolded document can be updated without a validation error", () => {
+    const out = runCtx(tmp, [
+      "update",
+      "nodes/architecture/architecture-overview",
+      "--tags",
+      "architecture, overview",
+      "--yes",
+    ]);
+    expect(out).toMatch(/Updated and published/);
+  });
+
   it("init --starter scaffolds documents and at least one pack", () => {
     const docs = JSON.parse(runCtx(tmp, ["list", "--json"]));
     expect(docs.length).toBeGreaterThan(0);
@@ -891,6 +911,7 @@ describe("[regression] ctx push", () => {
         "--server", server.url,
         "--nest", "nest-1",
         "--key", "cnst_testkey",
+        "--yes",
       ]);
       expect(out).toMatch(/Pushed 1 document/);
 
@@ -959,7 +980,7 @@ describe("[regression] flows", () => {
     expect(runCtx(tmp, ["reconstruct", "nodes/lc", "2"])).toContain("second body");
 
     // delete removes the doc and its version history; reads then fail
-    runCtx(tmp, ["delete", "nodes/lc"]);
+    runCtx(tmp, ["delete", "nodes/lc", "--yes"]);
     expect(existsSync(join(tmp, "nodes", "lc.md"))).toBe(false);
     expect(existsSync(join(tmp, "nodes", ".versions", "lc"))).toBe(false);
     expect(runCtxResult(tmp, ["read", "nodes/lc"]).status).not.toBe(0);
@@ -1009,7 +1030,7 @@ describe("[regression] flows", () => {
     expect(JSON.parse(runCtx(tmp, ["drift", "list", "nodes/policy", "--json"])).count).toBe(1);
 
     // approving merges the edit and bumps the version
-    const approved = JSON.parse(runCtx(tmp, ["drift", "approve", "nodes/policy", sid, "--json"]));
+    const approved = JSON.parse(runCtx(tmp, ["drift", "approve", "nodes/policy", sid, "--json", "--yes"]));
     expect(approved.versionEntry.version).toBe(2);
 
     // the suggestion is archived and the vault is clean again
@@ -1136,5 +1157,86 @@ describe("[regression] integrity — keyframe tamper", () => {
     const parsed = JSON.parse(res.stdout);
     expect(parsed.valid).toBe(false);
     expect(parsed.errors.map((e: { type: string }) => e.type)).toContain("content_hash_mismatch");
+  });
+});
+
+// ─── file safety ─────────────────────────────────────────────────────────────
+// Q2 hardening: no ctx subcommand may touch the working directory without the
+// user seeing it coming (confirmation or an explicit flag), being able to
+// preview it (--dry-run), and being told exactly what happened (action log).
+
+describe("[regression] file safety", () => {
+  beforeEach(() => {
+    initVault(tmp);
+  });
+
+  it("prints an action log naming every file a write command touched", () => {
+    const res = runCtxResult(tmp, ["add", "nodes/logged", "--title", "Logged"]);
+    expect(res.status).toBe(0);
+    expect(res.stderr).toMatch(/file\(s\) changed:/);
+    expect(res.stderr).toContain("nodes/logged.md");
+    expect(res.stderr).toContain("nodes/.versions/logged/v1.md");
+    expect(res.stderr).toContain("context.yaml");
+  });
+
+  it("keeps the action log off stdout so --json output stays parseable", () => {
+    runCtx(tmp, ["add", "nodes/machine", "--title", "Machine"]);
+    const stdout = runCtx(tmp, ["list", "--json"]);
+    expect(() => JSON.parse(stdout)).not.toThrow();
+  });
+
+  it("--dry-run reports the real file list and writes nothing", () => {
+    const res = runCtxResult(tmp, ["add", "nodes/ghost", "--title", "Ghost", "--dry-run"]);
+    expect(res.status).toBe(0);
+    expect(res.stderr).toContain("Dry run — no files were written.");
+    expect(res.stderr).toContain("+ nodes/ghost.md");
+    expect(existsSync(join(tmp, "nodes", "ghost.md"))).toBe(false);
+  });
+
+  it("--dry-run leaves an existing document byte-identical", () => {
+    runCtx(tmp, ["add", "nodes/keep", "--title", "Keep", "--body", "original"]);
+    const docPath = join(tmp, "nodes", "keep.md");
+    const before = readFileSync(docPath, "utf-8");
+
+    runCtx(tmp, ["update", "nodes/keep", "--body", "rewritten", "--dry-run"]);
+    expect(readFileSync(docPath, "utf-8")).toBe(before);
+  });
+
+  it("delete refuses non-interactively without --yes, and the document survives", () => {
+    runCtx(tmp, ["add", "nodes/doomed", "--title", "Doomed"]);
+    const res = runCtxResult(tmp, ["delete", "nodes/doomed"]);
+    expect(res.status).toBe(1);
+    expect(res.stderr).toMatch(/Refusing without confirmation/);
+    expect(existsSync(join(tmp, "nodes", "doomed.md"))).toBe(true);
+
+    runCtx(tmp, ["delete", "nodes/doomed", "--yes"]);
+    expect(existsSync(join(tmp, "nodes", "doomed.md"))).toBe(false);
+  });
+
+  it("read --out will not clobber an existing file without --force", () => {
+    runCtx(tmp, ["add", "nodes/rendered", "--title", "Rendered"]);
+    const outFile = join(tmp, "render.html");
+    writeFileSync(outFile, "PRE-EXISTING");
+
+    const res = runCtxResult(tmp, ["read", "nodes/rendered", "--html", "--out", outFile]);
+    expect(res.status).toBe(1);
+    expect(readFileSync(outFile, "utf-8")).toBe("PRE-EXISTING");
+
+    runCtx(tmp, ["read", "nodes/rendered", "--html", "--out", outFile, "--force"]);
+    expect(readFileSync(outFile, "utf-8")).toContain("<html");
+  });
+
+  it("push refuses to send vault contents over plaintext HTTP to a remote host", () => {
+    const res = runCtxResult(tmp, [
+      "push",
+      "--server",
+      "http://vault-exfil.example.com",
+      "--nest",
+      "n1",
+      "--key",
+      "cnst_test",
+    ]);
+    expect(res.status).toBe(1);
+    expect(res.stderr).toMatch(/plaintext HTTP/);
   });
 });

--- a/packages/cli/src/__tests__/cli.regression.test.ts
+++ b/packages/cli/src/__tests__/cli.regression.test.ts
@@ -1240,3 +1240,69 @@ describe("[regression] file safety", () => {
     expect(res.stderr).toMatch(/plaintext HTTP/);
   });
 });
+
+// ─── file safety — dry-run fidelity ──────────────────────────────────────────
+// The claim these guard is that --dry-run reports the REAL result. Four spots
+// originally bypassed the sandbox and printed a hand-written "would ..." line,
+// which could disagree with what the command actually does.
+
+describe("[regression] file safety — dry-run fidelity", () => {
+  it("vault add --dry-run fails on an alias collision, like the real command", () => {
+    initVault(tmp);
+    runCtx(tmp, ["vault", "add", "taken", tmp, "--yes"]);
+
+    // Registering a DIFFERENT path under a taken alias needs --force. The dry
+    // run must refuse it too, rather than promising a mapping that can't happen.
+    const other = mkdtempSync(join(tmpdir(), "cn-other-vault-"));
+    try {
+      initVault(other);
+      const dry = runCtxResult(tmp, ["vault", "add", "taken", other, "--dry-run"]);
+      expect(dry.status).not.toBe(0);
+      expect(dry.stdout + dry.stderr).toMatch(/already exists/);
+
+      // And the dry run left the real registry alone.
+      const list = JSON.parse(runCtx(tmp, ["vault", "list", "--json"]));
+      const taken = list.find((v: { alias: string }) => v.alias === "taken");
+      expect(taken.path).toBe(tmp);
+    } finally {
+      rmSync(other, { recursive: true, force: true });
+    }
+  });
+
+  it("vault remove --dry-run fails for an alias that isn't registered", () => {
+    initVault(tmp);
+    const res = runCtxResult(tmp, ["vault", "remove", "never-registered", "--dry-run"]);
+    expect(res.status).not.toBe(0);
+  });
+
+  it("vault add --dry-run does not write to the registry", () => {
+    initVault(tmp);
+    runCtx(tmp, ["vault", "add", "ghost-alias", tmp, "--dry-run"]);
+    const list = JSON.parse(runCtx(tmp, ["vault", "list", "--json"]));
+    expect(list.map((v: { alias: string }) => v.alias)).not.toContain("ghost-alias");
+  });
+
+  it("init --dry-run on an existing vault reports rewrites as modified, not created", () => {
+    initVault(tmp);
+    const res = runCtxResult(tmp, ["init", "--name", "again", "--yes", "--dry-run"]);
+    expect(res.status).toBe(0);
+    // config.yaml already exists, so re-initializing modifies it. Reporting it
+    // as created would mean the sandbox never saw the existing vault.
+    expect(res.stderr).toMatch(/~ \.context\/config\.yaml/);
+    expect(res.stderr).not.toMatch(/\+ \.context\/config\.yaml/);
+  });
+
+  it("read --out --dry-run marks an existing target as modified, not created", () => {
+    initVault(tmp);
+    runCtx(tmp, ["add", "nodes/previewed", "--title", "Previewed"]);
+    const outFile = join(tmp, "preview.html");
+    writeFileSync(outFile, "PRE-EXISTING");
+
+    const res = runCtxResult(tmp, [
+      "read", "nodes/previewed", "--html", "--out", outFile, "--force", "--dry-run",
+    ]);
+    expect(res.status).toBe(0);
+    expect(res.stderr).toContain(`~ ${outFile}`);
+    expect(readFileSync(outFile, "utf-8")).toBe("PRE-EXISTING");
+  });
+});

--- a/packages/cli/src/__tests__/cli.regression.test.ts
+++ b/packages/cli/src/__tests__/cli.regression.test.ts
@@ -1306,3 +1306,92 @@ describe("[regression] file safety — dry-run fidelity", () => {
     expect(readFileSync(outFile, "utf-8")).toBe("PRE-EXISTING");
   });
 });
+
+// ─── file safety — consent gate coverage ─────────────────────────────────────
+
+describe("[regression] file safety — command coverage", () => {
+  // VAULT_WRITE_COMMANDS / REGISTRY_WRITE_COMMANDS in index.ts are
+  // hand-maintained. A rename that misses them costs those commands their
+  // --dry-run sandbox and action log with no other symptom, so assert every
+  // listed name still resolves to a real command.
+  const CLASSIFIED = [
+    "init", "add", "update", "delete", "publish", "index", "welcome",
+    "checkpoint rebuild", "drift stage", "drift approve", "drift reject",
+    "vault add", "vault describe", "vault remove", "vault default",
+  ];
+
+  it.each(CLASSIFIED)("`ctx %s` still exists", (name) => {
+    const res = runCtxResult(tmp, [...name.split(" "), "--help"]);
+    expect(res.status).toBe(0);
+    expect(res.stdout).toMatch(/Usage:/);
+  });
+
+  // Every destructive command must refuse without a TTY unless consent was
+  // given up front. delete / vault remove are covered above; these are the
+  // rest of the set the PR description calls out.
+  it("checkpoint rebuild refuses without --yes", () => {
+    initVault(tmp);
+    runCtx(tmp, ["add", "nodes/cp", "--title", "CP"]);
+    const res = runCtxResult(tmp, ["checkpoint", "rebuild"]);
+    expect(res.status).toBe(1);
+    expect(res.stderr).toMatch(/Refusing without confirmation/);
+  });
+
+  it("push refuses without --yes", async () => {
+    initVault(tmp);
+    runCtx(tmp, ["add", "nodes/sendable", "--title", "Sendable"]);
+    const server = await startMockEngine(() => ({
+      published: 1,
+      context_md_updated: false,
+      node_ids: ["n0"],
+    }));
+    try {
+      const res = runCtxResult(tmp, [
+        "push", "--server", server.url, "--nest", "n1", "--key", "cnst_k",
+      ]);
+      expect(res.status).toBe(1);
+      expect(res.stderr).toMatch(/Refusing without confirmation/);
+      // Nothing reached the server.
+      expect(server.lastBody()).toBeUndefined();
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("drift approve refuses without --yes", () => {
+    initVault(tmp);
+    runCtx(tmp, ["add", "nodes/policy3", "--title", "Policy", "--body", "original"]);
+    appendFileSync(join(tmp, "nodes", "policy3.md"), "\n\nout-of-band edit\n");
+    const staged = JSON.parse(runCtx(tmp, ["drift", "stage", "nodes/policy3", "--json"]));
+
+    const res = runCtxResult(tmp, ["drift", "approve", "nodes/policy3", staged.suggestion_id]);
+    expect(res.status).toBe(1);
+    expect(res.stderr).toMatch(/Refusing without confirmation/);
+    // The canonical document was not rewritten.
+    expect(JSON.parse(runCtx(tmp, ["drift", "list", "nodes/policy3", "--json"])).count).toBe(1);
+  });
+});
+
+// ─── file safety — vault layout collisions ───────────────────────────────────
+
+describe("[regression] file safety — generic folder names in a vault", () => {
+  // The prune list keeps node_modules out of the snapshot and the dry-run copy.
+  // Matching those names at any depth would make real documents invisible: a
+  // vault is free-form, and "build" / "out" / "target" are ordinary words.
+  beforeEach(() => initVault(tmp));
+
+  it("logs writes to a document folder whose name collides with a build dir", () => {
+    const res = runCtxResult(tmp, ["add", "nodes/build/pipeline", "--title", "Pipeline"]);
+    expect(res.status).toBe(0);
+    expect(res.stderr).toContain("+ nodes/build/pipeline.md");
+  });
+
+  it("previews such a document against a complete sandbox copy", () => {
+    runCtx(tmp, ["add", "nodes/out/formats", "--title", "Formats", "--body", "original"]);
+    const res = runCtxResult(tmp, ["update", "nodes/out/formats", "--body", "revised", "--dry-run"]);
+    expect(res.status).toBe(0);
+    // Modified, not created — the subtree made it into the sandbox copy.
+    expect(res.stderr).toContain("~ nodes/out/formats.md");
+    expect(readFileSync(join(tmp, "nodes", "out", "formats.md"), "utf-8")).toContain("original");
+  });
+});

--- a/packages/cli/src/__tests__/safety.test.ts
+++ b/packages/cli/src/__tests__/safety.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Unit checks for the file-safety rails (`src/safety.ts`).
+ *
+ * The pieces the action log and `--dry-run` stand on: the snapshot must
+ * notice a same-size in-place edit (the case a size+mtime fingerprint would
+ * miss), must not follow symlinks out of the tree, and must classify
+ * create/modify/delete correctly. End-to-end behavior of the flags is
+ * covered by the `[regression] file safety` block in cli.regression.test.ts.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, symlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { snapshot, diffSnapshots, assertSafeEndpoint, configureSafety } from "../safety.js";
+
+let root: string;
+let outside: string;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "cn-safety-"));
+  outside = mkdtempSync(join(tmpdir(), "cn-outside-"));
+  configureSafety({});
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+  rmSync(outside, { recursive: true, force: true });
+});
+
+const snap = (dir: string) => {
+  const s = snapshot(dir);
+  if (!s) throw new Error("snapshot bailed out");
+  return s;
+};
+
+describe("snapshot + diffSnapshots", () => {
+  it("classifies created, modified and deleted files", () => {
+    mkdirSync(join(root, "nodes"), { recursive: true });
+    writeFileSync(join(root, "nodes", "keep.md"), "keep");
+    writeFileSync(join(root, "nodes", "gone.md"), "gone");
+    const before = snap(root);
+
+    writeFileSync(join(root, "nodes", "new.md"), "new");
+    writeFileSync(join(root, "nodes", "keep.md"), "edited");
+    rmSync(join(root, "nodes", "gone.md"));
+
+    expect(diffSnapshots(before, snap(root))).toEqual([
+      { action: "deleted", path: "nodes/gone.md" },
+      { action: "modified", path: "nodes/keep.md" },
+      { action: "created", path: "nodes/new.md" },
+    ]);
+  });
+
+  it("detects an in-place edit that keeps the file the same size", () => {
+    writeFileSync(join(root, "a.md"), "aaaa");
+    const before = snap(root);
+    writeFileSync(join(root, "a.md"), "bbbb");
+    expect(diffSnapshots(before, snap(root))).toEqual([{ action: "modified", path: "a.md" }]);
+  });
+
+  it("reports nothing when the tree is untouched", () => {
+    writeFileSync(join(root, "a.md"), "a");
+    expect(diffSnapshots(snap(root), snap(root))).toEqual([]);
+  });
+
+  it("skips pruned directories so a vault inside a repo stays auditable", () => {
+    mkdirSync(join(root, "node_modules", "pkg"), { recursive: true });
+    writeFileSync(join(root, "node_modules", "pkg", "index.js"), "x");
+    writeFileSync(join(root, "a.md"), "a");
+    expect([...snap(root).keys()]).toEqual(["a.md"]);
+  });
+
+  it("does not follow symlinks out of the tree", () => {
+    writeFileSync(join(outside, "secret.txt"), "secret");
+    try {
+      symlinkSync(outside, join(root, "link"), "dir");
+    } catch {
+      return; // unprivileged Windows without developer mode — nothing to assert
+    }
+    expect([...snap(root).keys()]).toEqual([]);
+  });
+});
+
+describe("assertSafeEndpoint", () => {
+  it("accepts https", () => {
+    expect(assertSafeEndpoint("https://api.example.com", "--server").protocol).toBe("https:");
+  });
+
+  it("accepts plaintext http on loopback", () => {
+    expect(assertSafeEndpoint("http://localhost:3737", "--server").hostname).toBe("localhost");
+    expect(assertSafeEndpoint("http://127.0.0.1:3737", "--server").hostname).toBe("127.0.0.1");
+  });
+
+  it("refuses plaintext http to a remote host", () => {
+    expect(() => assertSafeEndpoint("http://example.com", "--server")).toThrow(/plaintext HTTP/);
+  });
+
+  it("allows a remote plaintext host only under --force", () => {
+    configureSafety({ force: true });
+    expect(assertSafeEndpoint("http://example.com", "--server").hostname).toBe("example.com");
+  });
+
+  it("refuses non-http protocols and malformed URLs", () => {
+    expect(() => assertSafeEndpoint("file:///etc/passwd", "--server")).toThrow(/must be http/);
+    expect(() => assertSafeEndpoint("not a url", "--server")).toThrow(/not a valid URL/);
+  });
+});

--- a/packages/cli/src/__tests__/safety.test.ts
+++ b/packages/cli/src/__tests__/safety.test.ts
@@ -88,9 +88,20 @@ describe("assertSafeEndpoint", () => {
     expect(assertSafeEndpoint("https://api.example.com", "--server").protocol).toBe("https:");
   });
 
-  it("accepts plaintext http on loopback", () => {
-    expect(assertSafeEndpoint("http://localhost:3737", "--server").hostname).toBe("localhost");
-    expect(assertSafeEndpoint("http://127.0.0.1:3737", "--server").hostname).toBe("127.0.0.1");
+  it("accepts plaintext http anywhere in the loopback range", () => {
+    // 127.0.0.0/8 is all loopback, not just 127.0.0.1 — some local setups bind
+    // elsewhere in the block.
+    for (const host of ["localhost", "127.0.0.1", "127.0.0.2", "127.1.2.3", "[::1]"]) {
+      expect(assertSafeEndpoint(`http://${host}:3737`, "--server").protocol).toBe("http:");
+    }
+  });
+
+  it("does not mistake a non-loopback host for one", () => {
+    // "1270.0.0.1" is deliberately absent — Node rejects it at URL parse time,
+    // so it never reaches the loopback check and throws a different message.
+    for (const host of ["127.example.com", "12.7.0.1", "227.0.0.1"]) {
+      expect(() => assertSafeEndpoint(`http://${host}`, "--server")).toThrow(/plaintext HTTP/);
+    }
   });
 
   it("refuses plaintext http to a remote host", () => {

--- a/packages/cli/src/__tests__/safety.test.ts
+++ b/packages/cli/src/__tests__/safety.test.ts
@@ -72,6 +72,39 @@ describe("snapshot + diffSnapshots", () => {
     expect([...snap(root).keys()]).toEqual(["a.md"]);
   });
 
+  it("prunes a nested node_modules — a monorepo vault has several", () => {
+    mkdirSync(join(root, "pkg", "node_modules", "dep"), { recursive: true });
+    writeFileSync(join(root, "pkg", "node_modules", "dep", "i.js"), "x");
+    writeFileSync(join(root, "pkg", "keep.md"), "k");
+    expect([...snap(root).keys()]).toEqual(["pkg/keep.md"]);
+  });
+
+  it("does NOT prune a generic build-ish name below the root", () => {
+    // A vault is free-form: nodes/build/pipeline.md is a legitimate document.
+    // Pruning by basename at any depth would make it invisible to both the
+    // action log and the dry-run sandbox copy.
+    for (const name of ["build", "out", "dist", "target", "coverage", "venv"]) {
+      mkdirSync(join(root, "nodes", name), { recursive: true });
+      writeFileSync(join(root, "nodes", name, "doc.md"), "d");
+    }
+    const keys = [...snap(root).keys()].sort();
+    expect(keys).toEqual([
+      "nodes/build/doc.md",
+      "nodes/coverage/doc.md",
+      "nodes/dist/doc.md",
+      "nodes/out/doc.md",
+      "nodes/target/doc.md",
+      "nodes/venv/doc.md",
+    ]);
+  });
+
+  it("does prune those same names at the vault root", () => {
+    mkdirSync(join(root, "dist"), { recursive: true });
+    writeFileSync(join(root, "dist", "bundle.js"), "x");
+    writeFileSync(join(root, "a.md"), "a");
+    expect([...snap(root).keys()]).toEqual(["a.md"]);
+  });
+
   it("does not follow symlinks out of the tree", () => {
     writeFileSync(join(outside, "secret.txt"), "secret");
     try {

--- a/packages/cli/src/__tests__/vault-registry.test.ts
+++ b/packages/cli/src/__tests__/vault-registry.test.ts
@@ -82,7 +82,11 @@ describe("ctx vault — central registry", () => {
     expect(list).toContain("work");
     expect(list).toContain("Work vault");
 
-    run(["vault", "remove", "work"], tmp);
+    // Unregistering is destructive, so a non-interactive caller must say --yes.
+    expect(() => run(["vault", "remove", "work"], tmp)).toThrow();
+    expect(run(["vault", "list"], tmp)).toContain("work");
+
+    run(["vault", "remove", "work", "--yes"], tmp);
     const listAfter = run(["vault", "list"], tmp);
     expect(listAfter).not.toContain("work");
   });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -47,6 +47,7 @@ import {
   readRegistry,
   findLocalVault,
   getRegistryPath,
+  getRegistryDir,
   ALIAS_PATTERN,
   normalizeStatus,
   normalizeDocumentId,
@@ -72,6 +73,8 @@ import {
   openWriteScope,
   closeWriteScope,
   noteExternalWrite,
+  openRegistrySandbox,
+  registryPathForLog,
   sandboxPath,
   realRootPath,
   isDryRun,
@@ -231,7 +234,8 @@ let selectedVaultAlias: string | undefined;
  * of the vault, and `ctx query` sits on the hot path for every agent turn.
  *
  * Commands that write OUTSIDE the vault (`vault *`, `push`, `read --out`)
- * are absent on purpose — they report through `recordExternalWrite` instead.
+ * are absent on purpose — they report through `noteExternalWrite` or, for the
+ * registry, through `REGISTRY_WRITE_COMMANDS` below.
  */
 const VAULT_WRITE_COMMANDS = new Set([
   "init",
@@ -247,6 +251,18 @@ const VAULT_WRITE_COMMANDS = new Set([
   "drift reject",
 ]);
 
+/**
+ * Commands whose write target is the global registry rather than a vault.
+ * They get the registry redirected into a throwaway copy under --dry-run, so
+ * the real engine calls still run and still refuse what they would refuse.
+ */
+const REGISTRY_WRITE_COMMANDS = new Set([
+  "vault add",
+  "vault describe",
+  "vault remove",
+  "vault default",
+]);
+
 /** Full space-separated path of a command, e.g. `drift approve`. */
 function commandPath(cmd: Command): string {
   const parts: string[] = [];
@@ -260,11 +276,38 @@ program.hook("preAction", async (_thisCommand, actionCommand) => {
   configureSafety({ dryRun: opts.dryRun, yes: opts.yes, force: opts.force });
 
   const name = commandPath(actionCommand);
+
+  if (REGISTRY_WRITE_COMMANDS.has(name)) {
+    // openRegistrySandbox redirects CONTEXTNEST_CONFIG_DIR under --dry-run and
+    // returns the real directory, so the log names the registry the user has
+    // rather than the throwaway copy the run wrote into.
+    const realRegistryDir = await openRegistrySandbox();
+    await openWriteScope(getRegistryDir(), {
+      sandbox: false,
+      absolutePaths: true,
+      displayRoot: realRegistryDir,
+    });
+    return;
+  }
+
   if (!VAULT_WRITE_COMMANDS.has(name)) return;
-  // `init` targets a directory that is not a vault yet — and often an entire
-  // source tree — so its sandbox starts empty rather than as a copy.
-  const isInit = name === "init";
-  await openWriteScope(isInit ? getInitRoot() : getVaultRoot(), { copy: !isInit });
+
+  if (name === "init") {
+    // A first-time init targets a directory that is not a vault yet — and is
+    // often an entire source tree — so there is nothing worth copying. But
+    // init is ALSO how a vault is re-initialized, and that rewrites
+    // config.yaml, agent configs and the index. Seeding the sandbox from an
+    // existing vault is what makes those log as modified rather than created.
+    const root = getInitRoot();
+    const alreadyAVault = fs.existsSync(pathMod.join(root, ".context", "config.yaml"));
+    // Registering the alias runs for real against a throwaway registry, so a
+    // dry-run init surfaces an alias collision instead of glossing over it.
+    await openRegistrySandbox();
+    await openWriteScope(root, { copy: alreadyAVault });
+    return;
+  }
+
+  await openWriteScope(getVaultRoot());
 });
 
 program.hook("postAction", () => {
@@ -863,14 +906,6 @@ program
     const registerVault = (): void => {
       if (!registerAlias) return;
       const resolvedRoot = pathMod.resolve(displayRoot);
-      // The registry lives in ~/.contextnest/ — outside the dry-run sandbox,
-      // so it has to be skipped by hand rather than redirected.
-      if (isDryRun()) {
-        console.error(
-          chalk.dim(`  [dry run] would register vault alias "${registerAlias}" → ${resolvedRoot}`),
-        );
-        return;
-      }
       // Own-property check: a `--vault __proto__` would otherwise read back
       // Object.prototype here and crash on `resolve(existing.path)` before
       // addVault got the chance to reject the alias.
@@ -895,8 +930,14 @@ program
       try {
         // force is safe here: the alias is either free or already points to
         // this same vault (idempotent re-init).
-        noteExternalWrite(getRegistryPath());
-        const reg = addVault(registerAlias, resolvedRoot, {
+        //
+        // Register the directory that was actually initialized: under
+        // --dry-run that is the sandbox, and addVault refuses a path with no
+        // .context/config.yaml — the real one has none yet. The registry it
+        // writes to is a throwaway copy in that case, so the alias rules,
+        // collision check and --force handling all still run for real.
+        noteExternalWrite(registryPathForLog());
+        const reg = addVault(registerAlias, pathMod.resolve(root), {
           description: registerDescription,
           setDefault: opts.setDefault,
           force: true,
@@ -1006,8 +1047,11 @@ program
       if (opts.out) await ensureOverwritable(outPath, "Output file");
 
       if (isDryRun()) {
+        // Same created/modified distinction the snapshot diff makes elsewhere;
+        // previewing an overwrite must not read as a fresh file.
+        const existed = fs.existsSync(outPath);
         console.error(chalk.bold.cyan("Dry run — no files were written."));
-        console.error(`  ${chalk.green("+")} ${outPath}`);
+        console.error(`  ${existed ? chalk.yellow("~") : chalk.green("+")} ${outPath}`);
         return;
       }
 
@@ -1331,7 +1375,7 @@ async function publishAll(storage: NestStorage, author: string): Promise<void> {
     return;
   }
 
-  for (const id of ids) console.log(chalk.dim(`  ${id}`));
+  for (const id of ids) console.error(chalk.dim(`  ${id}`));
   await confirmOrExit(`Publish the ${ids.length} document(s) above?`);
 
   const ctx = opContext(storage, author, (done, total) => {
@@ -2172,7 +2216,9 @@ program
 
     // Egress is the one action here that can't be undone by deleting a file,
     // so show what leaves the machine before it leaves.
-    for (const doc of filtered) console.log(chalk.dim(`  ${doc.id}`));
+    // stderr, like the action log: this is disclosure about the run, not the
+    // command's result, and stdout has to stay clean for redirection.
+    for (const doc of filtered) console.error(chalk.dim(`  ${doc.id}`));
     await confirmOrExit(
       `Send the ${documents.length} document(s) above${contextMd ? " and CONTEXT.md" : ""} to ${serverUrl}?`,
       { destructive: true },
@@ -2445,7 +2491,7 @@ vaultCmd
       console.log(
         chalk.dim(`No vaults registered. Add one with: ${chalk.yellow("ctx vault add <alias> [path]")}`),
       );
-      console.log(chalk.dim(`Registry: ${getRegistryPath()}`));
+      console.log(chalk.dim(`Registry: ${registryPathForLog()}`));
       return;
     }
     console.log(chalk.bold("\nRegistered vaults:\n"));
@@ -2456,7 +2502,7 @@ vaultCmd
       if (v.description) console.log(`     ${chalk.dim(v.description)}`);
       console.log(`     ${chalk.dim(v.path)}`);
     }
-    console.log(`\n  ${chalk.dim("* = default")}   ${chalk.dim("registry: " + getRegistryPath())}\n`);
+    console.log(`\n  ${chalk.dim("* = default")}   ${chalk.dim("registry: " + registryPathForLog())}\n`);
   });
 
 vaultCmd
@@ -2483,15 +2529,10 @@ vaultCmd
         }
         target = pathMod.resolve(local);
       }
-      // The registry is a single shared file outside any vault, so the sandbox
-      // can't cover it — dry runs report and stop instead.
-      if (isDryRun()) {
-        console.error(chalk.bold.cyan("Dry run — no files were written."));
-        console.error(`  ${chalk.yellow("~")} ${getRegistryPath()}  (would map "${alias}" → ${target})`);
-        return;
-      }
-      await confirmOrExit(`Register "${alias}" → ${target} in ${getRegistryPath()}?`);
-      noteExternalWrite(getRegistryPath());
+      // Under --dry-run the registry directory is a throwaway copy, so addVault
+      // runs for real: an alias collision or a path that isn't a vault fails
+      // here exactly as it would without the flag.
+      await confirmOrExit(`Register "${alias}" → ${target} in ${registryPathForLog()}?`);
       const reg = addVault(alias, target, {
         description: opts.description,
         setDefault: opts.setDefault,
@@ -2513,13 +2554,7 @@ vaultCmd
   .description("Set the description for a registered alias (omit the text to clear it)")
   .action(async (alias: string, description: string | undefined) => {
     try {
-      if (isDryRun()) {
-        console.error(chalk.bold.cyan("Dry run — no files were written."));
-        console.error(`  ${chalk.yellow("~")} ${getRegistryPath()}  (would describe "${alias}")`);
-        return;
-      }
-      await confirmOrExit(`Update the description of "${alias}" in ${getRegistryPath()}?`);
-      noteExternalWrite(getRegistryPath());
+      await confirmOrExit(`Update the description of "${alias}" in ${registryPathForLog()}?`);
       setVaultDescription(alias, description);
       console.log(
         description
@@ -2538,17 +2573,11 @@ vaultCmd
   .description("Unregister a vault alias")
   .action(async (alias: string) => {
     try {
-      if (isDryRun()) {
-        console.error(chalk.bold.cyan("Dry run — no files were written."));
-        console.error(`  ${chalk.yellow("~")} ${getRegistryPath()}  (would unregister "${alias}")`);
-        return;
-      }
       await confirmOrExit(
-        `Unregister "${alias}" from ${getRegistryPath()}? The vault's files are left alone.`,
+        `Unregister "${alias}" from ${registryPathForLog()}? The vault's files are left alone.`,
         { destructive: true },
       );
       // removeVault reports wasDefault from its single read — no pre-read needed.
-      noteExternalWrite(getRegistryPath());
       const { wasDefault } = removeVault(alias);
       console.log(chalk.yellow(`Removed vault alias "${alias}"`));
       if (wasDefault) {
@@ -2572,13 +2601,7 @@ vaultCmd
   .description("Set the default vault")
   .action(async (alias: string) => {
     try {
-      if (isDryRun()) {
-        console.error(chalk.bold.cyan("Dry run — no files were written."));
-        console.error(`  ${chalk.yellow("~")} ${getRegistryPath()}  (would default to "${alias}")`);
-        return;
-      }
-      await confirmOrExit(`Make "${alias}" the default vault in ${getRegistryPath()}?`);
-      noteExternalWrite(getRegistryPath());
+      await confirmOrExit(`Make "${alias}" the default vault in ${registryPathForLog()}?`);
       setDefaultVault(alias);
       console.log(chalk.green(`Default vault is now "${chalk.bold(alias)}"`));
     } catch (err) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -67,6 +67,19 @@ import { getStarter, listStarters } from "./starters/index.js";
 import { detectAgentTools, type AgentTool } from "./agent-tools.js";
 import { generateWelcomeHtml, openInBrowser } from "./welcome-html.js";
 import { renderDocumentHtml } from "./render-html.js";
+import {
+  configureSafety,
+  openWriteScope,
+  closeWriteScope,
+  noteExternalWrite,
+  sandboxPath,
+  realRootPath,
+  isDryRun,
+  isForce,
+  confirmOrExit,
+  ensureOverwritable,
+  assertSafeEndpoint,
+} from "./safety.js";
 
 const program = new Command();
 
@@ -77,7 +90,12 @@ program
   // Global selector: target a registered vault by alias from any directory.
   // When omitted, resolution falls back to env vars, the local vault, then the
   // registry default (see resolveVaultPath precedence in the engine).
-  .option("--vault <alias>", "Target a registered vault by alias (see `ctx vault list`)");
+  .option("--vault <alias>", "Target a registered vault by alias (see `ctx vault list`)")
+  // File-safety rails — global so every write command answers to the same
+  // three flags. See safety.ts for the mechanics.
+  .option("--dry-run", "Preview a write command against a throwaway copy of the vault; touch nothing")
+  .option("-y, --yes", "Skip confirmation prompts (required for destructive commands in scripts/CI)")
+  .option("--force", "Overwrite existing files, and allow plaintext-HTTP pushes");
 
 // ---------------------------------------------------------------------------
 // Friendly top-level help
@@ -174,8 +192,18 @@ function renderRootHelp(): string {
   }
   lines.push(chalk.bold("GLOBAL OPTIONS"));
   lines.push(`${indent}${chalk.cyan("--vault <alias>".padEnd(col + 2))}target a registered vault by alias`);
+  lines.push(`${indent}${chalk.cyan("--dry-run".padEnd(col + 2))}preview a write command without touching the filesystem`);
+  lines.push(`${indent}${chalk.cyan("-y, --yes".padEnd(col + 2))}skip confirmation prompts`);
+  lines.push(`${indent}${chalk.cyan("--force".padEnd(col + 2))}allow overwriting existing files`);
   lines.push(`${indent}${chalk.cyan("-V, --version".padEnd(col + 2))}print the version number`);
   lines.push(`${indent}${chalk.cyan("-h, --help".padEnd(col + 2))}show this help`);
+  lines.push("");
+  lines.push(chalk.bold("FILE SAFETY"));
+  lines.push(`${indent}Every command that writes asks before it does, then prints the exact list of`);
+  lines.push(`${indent}files it created, modified or deleted. Nothing is overwritten silently.`);
+  lines.push(`${indent}${chalk.cyan("--dry-run")} runs the command against a temp copy of the vault and reports the`);
+  lines.push(`${indent}real file list without touching yours. In a non-interactive shell (agents, CI)`);
+  lines.push(`${indent}destructive commands refuse unless ${chalk.cyan("--yes")} or ${chalk.cyan("--force")} is passed.`);
   lines.push("");
   lines.push(chalk.dim(`Run ${chalk.reset("ctx <command> --help")}${chalk.dim(" for the options and details of any command.")}`));
   lines.push("");
@@ -197,14 +225,68 @@ program.configureHelp({
 // (`ctx --vault work list`) or after it (`ctx list --vault work`).
 let selectedVaultAlias: string | undefined;
 
-program.hook("preAction", (_thisCommand, actionCommand) => {
-  selectedVaultAlias = actionCommand.optsWithGlobals().vault as string | undefined;
+/**
+ * Commands that mutate the vault tree. Listed explicitly rather than audited
+ * unconditionally: the snapshot-diff behind the action log costs a full walk
+ * of the vault, and `ctx query` sits on the hot path for every agent turn.
+ *
+ * Commands that write OUTSIDE the vault (`vault *`, `push`, `read --out`)
+ * are absent on purpose — they report through `recordExternalWrite` instead.
+ */
+const VAULT_WRITE_COMMANDS = new Set([
+  "init",
+  "add",
+  "update",
+  "delete",
+  "publish",
+  "index",
+  "welcome",
+  "checkpoint rebuild",
+  "drift stage",
+  "drift approve",
+  "drift reject",
+]);
+
+/** Full space-separated path of a command, e.g. `drift approve`. */
+function commandPath(cmd: Command): string {
+  const parts: string[] = [];
+  for (let c: Command | null = cmd; c && c !== program; c = c.parent) parts.unshift(c.name());
+  return parts.join(" ");
+}
+
+program.hook("preAction", async (_thisCommand, actionCommand) => {
+  const opts = actionCommand.optsWithGlobals();
+  selectedVaultAlias = opts.vault as string | undefined;
+  configureSafety({ dryRun: opts.dryRun, yes: opts.yes, force: opts.force });
+
+  const name = commandPath(actionCommand);
+  if (!VAULT_WRITE_COMMANDS.has(name)) return;
+  // `init` targets a directory that is not a vault yet — and often an entire
+  // source tree — so its sandbox starts empty rather than as a copy.
+  const isInit = name === "init";
+  await openWriteScope(isInit ? getInitRoot() : getVaultRoot(), { copy: !isInit });
 });
+
+program.hook("postAction", () => {
+  closeWriteScope();
+});
+
+// Resolution is memoized: the preAction hook resolves once to open the write
+// scope, and re-resolving in the command body would repeat any stale-env
+// warning to the user.
+let resolvedVaultRoot: string | undefined;
 
 // Helper: resolve vault root. Delegates to the engine resolver, which applies
 // precedence: --vault flag > CONTEXTNEST_VAULT (alias) > CONTEXTNEST_VAULT_PATH
 // (path) > local vault (walk up cwd) > registry default > cwd.
+//
+// Under --dry-run this returns the sandbox copy instead, which is the single
+// point that keeps every downstream engine write off the user's real vault.
 function getVaultRoot(): string {
+  const sandbox = sandboxPath();
+  if (sandbox) return sandbox;
+  if (resolvedVaultRoot !== undefined) return resolvedVaultRoot;
+
   const resolved = resolveVaultPath({
     vaultAlias: selectedVaultAlias,
     cwd: process.cwd(),
@@ -215,7 +297,8 @@ function getVaultRoot(): string {
   if (resolved.warning && resolved.source !== "local") {
     console.error(chalk.yellow(`Warning: ${resolved.warning}`));
   }
-  return resolved.path;
+  resolvedVaultRoot = resolved.path;
+  return resolvedVaultRoot;
 }
 
 // Helper: resolve the target root for `ctx init`. Unlike getVaultRoot(), init
@@ -225,7 +308,9 @@ function getVaultRoot(): string {
 // wrong directory (the "misresolved to home" bug). The explicit env override
 // still wins.
 function getInitRoot(): string {
-  return process.env.CONTEXTNEST_VAULT_PATH || process.cwd();
+  // `||`, not `??`: an empty CONTEXTNEST_VAULT_PATH is how callers neutralize
+  // the override, and must fall through to cwd rather than mkdir("").
+  return sandboxPath() || process.env.CONTEXTNEST_VAULT_PATH || process.cwd();
 }
 
 function getStorage(): NestStorage {
@@ -730,6 +815,19 @@ program
     }
 
     const root = getInitRoot();
+    // Under --dry-run `root` is a sandbox; every user-facing decision (does a
+    // vault already live here? what alias would it get?) has to be made about
+    // the directory the user actually pointed at.
+    const displayRoot = realRootPath() ?? root;
+
+    if (fs.existsSync(pathMod.join(displayRoot, ".context", "config.yaml"))) {
+      await confirmOrExit(
+        `A Context Nest vault already exists at ${displayRoot} — re-initialize it? Existing documents are kept, but config.yaml and agent config files are rewritten.`,
+        { destructive: true },
+      );
+    } else {
+      await confirmOrExit(`Create a new Context Nest vault in ${displayRoot}?`);
+    }
 
     // Resolve the registry alias and description BEFORE creating the vault: the
     // description is written into .context/config.yaml by init(), so a prompted
@@ -743,7 +841,7 @@ program
     // ownership check below (addVault re-reads internally for its write).
     const registrySnapshot = readRegistry();
     if (!registerAlias) {
-      const defaultAlias = defaultAliasFor(root, registrySnapshot);
+      const defaultAlias = defaultAliasFor(displayRoot, registrySnapshot);
       if (canPrompt) {
         console.log(chalk.dim("\n  Register this vault so you can target it from anywhere with --vault:"));
         registerAlias = await promptAlias(defaultAlias);
@@ -757,14 +855,22 @@ program
 
     const storage = new NestStorage(root);
     await storage.init(opts.name, opts.layout as LayoutMode, registerDescription);
-    console.log(chalk.green(`\n  Initialized ${opts.layout} vault: ${root}`));
+    console.log(chalk.green(`\n  Initialized ${opts.layout} vault: ${displayRoot}`));
 
     // Registration is performed AFTER the starter is applied (see registerVault
     // below) so an interruption mid-starter never leaves a registry alias
     // pointing at a half-populated vault.
     const registerVault = (): void => {
       if (!registerAlias) return;
-      const resolvedRoot = pathMod.resolve(root);
+      const resolvedRoot = pathMod.resolve(displayRoot);
+      // The registry lives in ~/.contextnest/ — outside the dry-run sandbox,
+      // so it has to be skipped by hand rather than redirected.
+      if (isDryRun()) {
+        console.error(
+          chalk.dim(`  [dry run] would register vault alias "${registerAlias}" → ${resolvedRoot}`),
+        );
+        return;
+      }
       // Own-property check: a `--vault __proto__` would otherwise read back
       // Object.prototype here and crash on `resolve(existing.path)` before
       // addVault got the chance to reject the alias.
@@ -789,6 +895,7 @@ program
       try {
         // force is safe here: the alias is either free or already points to
         // this same vault (idempotent re-init).
+        noteExternalWrite(getRegistryPath());
         const reg = addVault(registerAlias, resolvedRoot, {
           description: registerDescription,
           setDefault: opts.setDefault,
@@ -797,7 +904,7 @@ program
         const isDefault = reg.default === registerAlias;
         console.log(
           chalk.green(
-            `  Registered vault "${chalk.bold(registerAlias)}"${isDefault ? " (default)" : ""} → ${root}`,
+            `  Registered vault "${chalk.bold(registerAlias)}"${isDefault ? " (default)" : ""} → ${resolvedRoot}`,
           ),
         );
       } catch (err) {
@@ -890,16 +997,29 @@ program
       const vaultName = config?.name || undefined;
       const html = renderDocumentHtml(doc, vaultName);
 
+      // `--out` is the one place the CLI writes to an arbitrary path the user
+      // named, so it gets the strictest guard: never clobber without consent.
+      const outPath = opts.out
+        ? pathMod.resolve(opts.out)
+        : pathMod.join(getVaultRoot(), ".context", `read-${id.replace(/\//g, "-")}.html`);
+
+      if (opts.out) await ensureOverwritable(outPath, "Output file");
+
+      if (isDryRun()) {
+        console.error(chalk.bold.cyan("Dry run — no files were written."));
+        console.error(`  ${chalk.green("+")} ${outPath}`);
+        return;
+      }
+
+      await mkdir(pathMod.dirname(outPath), { recursive: true });
+      noteExternalWrite(outPath);
+      await writeFile(outPath, html, "utf-8");
+
       if (opts.out) {
-        const outPath = pathMod.resolve(opts.out);
-        await writeFile(outPath, html, "utf-8");
         console.log(chalk.green(`Written to ${outPath}`));
       } else {
-        const tmpPath = pathMod.join(getVaultRoot(), ".context", `read-${id.replace(/\//g, "-")}.html`);
-        await mkdir(pathMod.dirname(tmpPath), { recursive: true });
-        await writeFile(tmpPath, html, "utf-8");
-        openInBrowser(tmpPath);
-        console.log(chalk.dim(`Opened in browser: ${tmpPath}`));
+        openInBrowser(outPath);
+        console.log(chalk.dim(`Opened in browser: ${outPath}`));
       }
       return;
     }
@@ -966,6 +1086,8 @@ program
         "DOCUMENT_EXISTS",
       );
     }
+
+    await confirmOrExit(`Create ${id}.md in ${realRootPath() ?? storage.root} and publish v1?`);
 
     const title = opts.title || id.split("/").pop()!.replace(/-/g, " ").replace(/\b\w/g, (c: string) => c.toUpperCase());
 
@@ -1171,6 +1293,8 @@ program
       process.exit(1);
     }
 
+    await confirmOrExit(`Publish ${normalizeDocumentId(path)} — cuts a new version and seals a checkpoint. Continue?`);
+
     const result = await createEngineApi().run<{
       id: string;
       version: number;
@@ -1206,6 +1330,9 @@ async function publishAll(storage: NestStorage, author: string): Promise<void> {
     console.log(chalk.dim("Nothing to publish — every document is already published."));
     return;
   }
+
+  for (const id of ids) console.log(chalk.dim(`  ${id}`));
+  await confirmOrExit(`Publish the ${ids.length} document(s) above?`);
 
   const ctx = opContext(storage, author, (done, total) => {
     // Single rewritten line; fall back to plain lines when piped to a file.
@@ -1476,6 +1603,10 @@ program
     // storage.regenerateIndex().
     const docs = await storage.discoverDocuments({ includeRetired: true });
 
+    await confirmOrExit(
+      `Regenerate context.yaml and INDEX.md in ${realRootPath() ?? storage.root}? Documents whose status is written in a legacy form are rewritten in place.`,
+    );
+
     // Status-canonicalization pass: rewrite any doc whose on-disk status
     // differs from its parsed (normalized) status. Only `ctx index` does
     // this — per-mutation calls to regenerateIndex stay cheap. After this
@@ -1538,6 +1669,8 @@ async function queryFromCloud(selector: string, opts: { json?: boolean }): Promi
 
   const [, org, packName] = match;
   const apiUrl = process.env.PROMPTOWL_API_URL || "https://api.promptowl.ai";
+  // The override carries the user's cloud token — same plaintext rule as push.
+  assertSafeEndpoint(apiUrl, "PROMPTOWL_API_URL");
   const token = await loadCloudToken();
 
   console.log(chalk.dim(`  ☁ Fetching from PromptOwl cloud...`));
@@ -1743,6 +1876,11 @@ program
     // is a content release or a lifecycle transition, so the CLI no longer
     // carries its own copy of that rule.
     const status = opts.status !== undefined ? normalizeStatus(opts.status) : undefined;
+
+    await confirmOrExit(
+      `Rewrite ${normalizeDocumentId(path)} in ${realRootPath() ?? storage.root}? The previous content stays recoverable from version history.`,
+    );
+
     const result = await createEngineApi().run<{
       id: string;
       version: number;
@@ -1794,6 +1932,10 @@ program
   .description("Delete a document and its version history")
   .action(async (path) => {
     const storage = getStorage();
+    await confirmOrExit(
+      `Delete ${normalizeDocumentId(path)} and its entire version history from ${realRootPath() ?? storage.root}? This cannot be undone.`,
+      { destructive: true },
+    );
     const result = await createEngineApi().run<{ id: string; title: string }>(
       "context_delete",
       { id: normalizeDocumentId(path) },
@@ -1935,6 +2077,10 @@ cpCmd
   .description("Rebuild checkpoint history from per-document histories")
   .action(async () => {
     const storage = getStorage();
+    await confirmOrExit(
+      `Rebuild checkpoint history in ${realRootPath() ?? storage.root}? The existing .versions/context_history.yaml is replaced.`,
+      { destructive: true },
+    );
     const cm = new CheckpointManager(storage);
     const history = await cm.rebuildCheckpointHistory();
     console.log(chalk.green(`Rebuilt ${history.checkpoints.length} checkpoints`));
@@ -1950,6 +2096,8 @@ program
     const storage = getStorage();
     const docs = await storage.discoverDocuments();
     const config = await storage.readConfig();
+
+    await confirmOrExit(`Rewrite .context/welcome.html in ${realRootPath() ?? getVaultRoot()}?`);
 
     const welcomePath = await generateWelcomeHtml({
       vaultPath: getVaultRoot(),
@@ -1969,7 +2117,8 @@ program
     console.log(chalk.green(`Generated welcome page: .context/welcome.html`));
     console.log(`  ${docs.length} documents across ${new Set(docs.map((d) => d.id.split("/")[0])).size} folders`);
 
-    if (opts.open !== false) {
+    // Don't open the sandbox copy — it is deleted the moment the run ends.
+    if (opts.open !== false && !isDryRun()) {
       openInBrowser(welcomePath);
       console.log(`  ${chalk.dim("Opened in browser")}`);
     }
@@ -1980,11 +2129,21 @@ program
 program
   .command("push")
   .description("Push the local vault to a hosted ContextNest server")
-  .requiredOption("--server <url>", "Hosted engine URL (e.g. http://localhost:3737)")
+  .requiredOption("--server <url>", "Hosted engine URL (https://…, or a localhost address)")
   .requiredOption("--nest <id>", "Target nest ID")
-  .requiredOption("--key <apiKey>", "API key (cnst_...)")
+  .option("--key <apiKey>", "API key (cnst_…). Prefer the CONTEXTNEST_API_KEY env var — argv is visible to other processes")
   .option("--include-drafts", "Include draft documents (default: published only)", false)
   .action(async (opts) => {
+    // A key on the command line is readable by anyone who can list processes,
+    // and lands in shell history. Accept it, but let the env var take over.
+    const apiKey = (opts.key as string | undefined) ?? process.env.CONTEXTNEST_API_KEY;
+    if (!apiKey) {
+      console.error(chalk.red("Missing API key — pass --key or set CONTEXTNEST_API_KEY."));
+      process.exit(1);
+    }
+    // Refuse to put documents and a bearer token on the wire in the clear.
+    assertSafeEndpoint(opts.server, "--server");
+
     const storage = getStorage();
     const docs = await storage.discoverDocuments();
 
@@ -2011,6 +2170,19 @@ program
     const serverUrl = opts.server.replace(/\/$/, "");
     const url = `${serverUrl}/nests/${opts.nest}/publish`;
 
+    // Egress is the one action here that can't be undone by deleting a file,
+    // so show what leaves the machine before it leaves.
+    for (const doc of filtered) console.log(chalk.dim(`  ${doc.id}`));
+    await confirmOrExit(
+      `Send the ${documents.length} document(s) above${contextMd ? " and CONTEXT.md" : ""} to ${serverUrl}?`,
+      { destructive: true },
+    );
+
+    if (isDryRun()) {
+      console.error(chalk.bold.cyan("Dry run — nothing was sent."));
+      return;
+    }
+
     console.log(chalk.dim(`Pushing ${documents.length} documents to ${serverUrl}...`));
 
     const body: Record<string, unknown> = { documents };
@@ -2021,7 +2193,7 @@ program
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          Authorization: `Bearer ${opts.key}`,
+          Authorization: `Bearer ${apiKey}`,
         },
         body: JSON.stringify(body),
       });
@@ -2109,6 +2281,8 @@ drift
     const zone = node.frontmatter.zone;
     const docTier: GovernanceTier = node.frontmatter.governance ?? "standard";
 
+    await confirmOrExit(`Stage the drifted bytes of ${id} as a suggestion under _suggestions/?`);
+
     const result = await stageSuggestion({
       storage,
       documentId: id,
@@ -2182,6 +2356,11 @@ drift
     const node = await storage.readDocument(id);
     const zone = node.frontmatter.zone ?? "default";
 
+    await confirmOrExit(
+      `Approve ${suggestionId}? This rewrites the canonical bytes of ${id}, bumps its version and extends the hash chain.`,
+      { destructive: true },
+    );
+
     const result = await approveSuggestion({
       storage,
       rbac: permissiveRbac,
@@ -2217,6 +2396,8 @@ drift
     const id = normalizeDocumentId(path);
     const node = await storage.readDocument(id);
     const zone = node.frontmatter.zone ?? "default";
+
+    await confirmOrExit(`Reject ${suggestionId} for ${id}? The suggestion is archived without merging.`);
 
     const result = await rejectSuggestion({
       storage,
@@ -2284,7 +2465,7 @@ vaultCmd
   .option("--description <text>", "Short label for this alias")
   .option("--set-default", "Make this the default vault")
   .option("--force", "Overwrite an existing alias")
-  .action((alias: string, path: string | undefined, opts) => {
+  .action(async (alias: string, path: string | undefined, opts) => {
     try {
       // With no explicit path, "register the vault I'm in" — resolve strictly
       // from the cwd walk-up, NOT getVaultRoot() (which honors CONTEXTNEST_VAULT
@@ -2302,10 +2483,20 @@ vaultCmd
         }
         target = pathMod.resolve(local);
       }
+      // The registry is a single shared file outside any vault, so the sandbox
+      // can't cover it — dry runs report and stop instead.
+      if (isDryRun()) {
+        console.error(chalk.bold.cyan("Dry run — no files were written."));
+        console.error(`  ${chalk.yellow("~")} ${getRegistryPath()}  (would map "${alias}" → ${target})`);
+        return;
+      }
+      await confirmOrExit(`Register "${alias}" → ${target} in ${getRegistryPath()}?`);
+      noteExternalWrite(getRegistryPath());
       const reg = addVault(alias, target, {
         description: opts.description,
         setDefault: opts.setDefault,
-        force: opts.force,
+        // A global --force means the same thing here as the local one.
+        force: opts.force || isForce(),
       });
       const isDefault = reg.default === alias;
       console.log(
@@ -2320,8 +2511,15 @@ vaultCmd
 vaultCmd
   .command("describe <alias> [description]")
   .description("Set the description for a registered alias (omit the text to clear it)")
-  .action((alias: string, description: string | undefined) => {
+  .action(async (alias: string, description: string | undefined) => {
     try {
+      if (isDryRun()) {
+        console.error(chalk.bold.cyan("Dry run — no files were written."));
+        console.error(`  ${chalk.yellow("~")} ${getRegistryPath()}  (would describe "${alias}")`);
+        return;
+      }
+      await confirmOrExit(`Update the description of "${alias}" in ${getRegistryPath()}?`);
+      noteExternalWrite(getRegistryPath());
       setVaultDescription(alias, description);
       console.log(
         description
@@ -2338,9 +2536,19 @@ vaultCmd
   .command("remove <alias>")
   .alias("rm")
   .description("Unregister a vault alias")
-  .action((alias: string) => {
+  .action(async (alias: string) => {
     try {
+      if (isDryRun()) {
+        console.error(chalk.bold.cyan("Dry run — no files were written."));
+        console.error(`  ${chalk.yellow("~")} ${getRegistryPath()}  (would unregister "${alias}")`);
+        return;
+      }
+      await confirmOrExit(
+        `Unregister "${alias}" from ${getRegistryPath()}? The vault's files are left alone.`,
+        { destructive: true },
+      );
       // removeVault reports wasDefault from its single read — no pre-read needed.
+      noteExternalWrite(getRegistryPath());
       const { wasDefault } = removeVault(alias);
       console.log(chalk.yellow(`Removed vault alias "${alias}"`));
       if (wasDefault) {
@@ -2362,8 +2570,15 @@ vaultCmd
 vaultCmd
   .command("default <alias>")
   .description("Set the default vault")
-  .action((alias: string) => {
+  .action(async (alias: string) => {
     try {
+      if (isDryRun()) {
+        console.error(chalk.bold.cyan("Dry run — no files were written."));
+        console.error(`  ${chalk.yellow("~")} ${getRegistryPath()}  (would default to "${alias}")`);
+        return;
+      }
+      await confirmOrExit(`Make "${alias}" the default vault in ${getRegistryPath()}?`);
+      noteExternalWrite(getRegistryPath());
       setDefaultVault(alias);
       console.log(chalk.green(`Default vault is now "${chalk.bold(alias)}"`));
     } catch (err) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -82,6 +82,8 @@ import {
   confirmOrExit,
   ensureOverwritable,
   assertSafeEndpoint,
+  assertNotRedirected,
+  NO_REDIRECT,
 } from "./safety.js";
 
 const program = new Command();
@@ -236,6 +238,13 @@ let selectedVaultAlias: string | undefined;
  * Commands that write OUTSIDE the vault (`vault *`, `push`, `read --out`)
  * are absent on purpose — they report through `noteExternalWrite` or, for the
  * registry, through `REGISTRY_WRITE_COMMANDS` below.
+ *
+ * MUST BE UPDATED when a write command is added or renamed. A command missing
+ * from both sets silently loses --dry-run redirection and its action log; the
+ * confirmation prompt is unaffected, since that lives at the call site. The
+ * `[regression] file safety — command coverage` suite catches a rename (every
+ * listed name has to resolve to a real command) but cannot catch a brand-new
+ * command nobody classified.
  */
 const VAULT_WRITE_COMMANDS = new Set([
   "init",
@@ -1046,17 +1055,13 @@ program
 
       if (opts.out) await ensureOverwritable(outPath, "Output file");
 
-      if (isDryRun()) {
-        // Same created/modified distinction the snapshot diff makes elsewhere;
-        // previewing an overwrite must not read as a fresh file.
-        const existed = fs.existsSync(outPath);
-        console.error(chalk.bold.cyan("Dry run — no files were written."));
-        console.error(`  ${existed ? chalk.yellow("~") : chalk.green("+")} ${outPath}`);
-        return;
-      }
+      // Record before writing, then let closeWriteScope render it — one
+      // implementation of the action log and the dry-run banner, so the two
+      // can't drift. It also picks created vs modified from what is on disk.
+      noteExternalWrite(outPath);
+      if (isDryRun()) return;
 
       await mkdir(pathMod.dirname(outPath), { recursive: true });
-      noteExternalWrite(outPath);
       await writeFile(outPath, html, "utf-8");
 
       if (opts.out) {
@@ -1720,6 +1725,7 @@ async function queryFromCloud(selector: string, opts: { json?: boolean }): Promi
   console.log(chalk.dim(`  ☁ Fetching from PromptOwl cloud...`));
 
   const res = await fetch(`${apiUrl}/v1/packs/${org}/${packName}/inject`, {
+    ...NO_REDIRECT,
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -1727,6 +1733,7 @@ async function queryFromCloud(selector: string, opts: { json?: boolean }): Promi
     },
     body: JSON.stringify({ selector: `pack:${packName}`, format: "markdown" }),
   });
+  assertNotRedirected(res, "The cloud endpoint");
 
   if (res.status === 429) {
     const body = await res.json() as { message?: string; upgrade_url?: string };
@@ -2236,6 +2243,7 @@ program
 
     try {
       const res = await fetch(url, {
+        ...NO_REDIRECT,
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -2243,6 +2251,9 @@ program
         },
         body: JSON.stringify(body),
       });
+      // A validated https:// server that answers 3xx would otherwise resend
+      // every document body to an unvalidated destination.
+      assertNotRedirected(res, "--server");
 
       if (!res.ok) {
         const err = await res.json().catch(() => ({ error: res.statusText }));
@@ -2510,7 +2521,7 @@ vaultCmd
   .description("Register a vault path under an alias (path defaults to the vault in the current directory)")
   .option("--description <text>", "Short label for this alias")
   .option("--set-default", "Make this the default vault")
-  .option("--force", "Overwrite an existing alias")
+  // No local --force: the global one (see the root command) covers it.
   .action(async (alias: string, path: string | undefined, opts) => {
     try {
       // With no explicit path, "register the vault I'm in" — resolve strictly
@@ -2536,8 +2547,7 @@ vaultCmd
       const reg = addVault(alias, target, {
         description: opts.description,
         setDefault: opts.setDefault,
-        // A global --force means the same thing here as the local one.
-        force: opts.force || isForce(),
+        force: isForce(),
       });
       const isDefault = reg.default === alias;
       console.log(

--- a/packages/cli/src/safety.ts
+++ b/packages/cli/src/safety.ts
@@ -1,0 +1,369 @@
+/**
+ * File-safety rails for the CLI.
+ *
+ * Three guarantees, all driven from one place so every command gets them:
+ *
+ *   1. **Dry run** (`--dry-run`) — the command runs for real, but against a
+ *      throwaway copy of the vault in a temp directory. Nothing under the
+ *      user's vault is touched, and the reported file list is what actually
+ *      happened rather than a hand-maintained guess that drifts from the
+ *      engine.
+ *   2. **Action log** — every write command snapshots the vault before and
+ *      after and prints exactly which files were created, modified or deleted.
+ *      Writes outside the vault (registry, `--out` files) are recorded
+ *      explicitly via `recordExternalWrite`.
+ *   3. **Confirmation** — `confirmOrExit` prompts on a TTY. Non-interactive
+ *      callers (agents, CI) are never blocked on stdin: an additive operation
+ *      proceeds on the strength of its own argv, while a destructive one
+ *      refuses unless `--yes` / `--force` was passed.
+ *
+ * ponytail: the snapshot hashes full file contents. Fine for markdown vaults;
+ * if someone starts storing large binaries here, switch to size+mtime and
+ * accept the same-millisecond blind spot.
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import pathMod from "node:path";
+import readline from "node:readline";
+import { createHash } from "node:crypto";
+import chalk from "chalk";
+
+// ─── Flags ──────────────────────────────────────────────────────────────────
+
+export interface SafetyFlags {
+  dryRun?: boolean;
+  yes?: boolean;
+  force?: boolean;
+}
+
+let flags: SafetyFlags = {};
+
+export function configureSafety(next: SafetyFlags): void {
+  flags = next;
+}
+
+export function isDryRun(): boolean {
+  return flags.dryRun === true;
+}
+
+export function isForce(): boolean {
+  return flags.force === true;
+}
+
+// ─── Vault snapshots ────────────────────────────────────────────────────────
+
+/**
+ * Directories never walked or copied. A vault often lives at the root of a
+ * real project (`ctx init` in a codebase), so without this the snapshot would
+ * hash node_modules and the dry-run copy would duplicate it.
+ */
+const PRUNE = new Set([
+  "node_modules",
+  ".git",
+  ".hg",
+  ".svn",
+  "dist",
+  "build",
+  "out",
+  "coverage",
+  ".next",
+  ".nuxt",
+  ".turbo",
+  ".venv",
+  "venv",
+  "__pycache__",
+  "target",
+  ".cache",
+]);
+
+/** Above this, auditing costs more than it's worth — the log is skipped. */
+const MAX_SCAN_FILES = 20_000;
+/** Above this, fingerprint by size+mtime instead of hashing the bytes. */
+const MAX_HASH_BYTES = 8 * 1024 * 1024;
+
+type Snapshot = Map<string, string>;
+
+export type Change = { action: "created" | "modified" | "deleted"; path: string };
+
+function fingerprint(abs: string, size: number, mtimeMs: number): string {
+  if (size > MAX_HASH_BYTES) return `size:${size}:${mtimeMs}`;
+  try {
+    return createHash("sha256").update(fs.readFileSync(abs)).digest("hex");
+  } catch {
+    // Unreadable (permissions, mid-write). Fall back to metadata so a later
+    // change still shows up rather than silently matching.
+    return `unreadable:${size}:${mtimeMs}`;
+  }
+}
+
+/**
+ * Walk `root` and fingerprint every regular file. Returns null when the tree
+ * is too large to audit honestly — callers degrade to "log skipped" rather
+ * than printing a partial list that reads as complete.
+ *
+ * Symlinks are never followed: a link inside the vault could otherwise point
+ * anywhere on disk and drag unrelated files into the report (or into the
+ * dry-run copy).
+ */
+export function snapshot(root: string): Snapshot | null {
+  const out: Snapshot = new Map();
+  const stack: string[] = [""];
+
+  while (stack.length > 0) {
+    const rel = stack.pop()!;
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(pathMod.join(root, rel), { withFileTypes: true });
+    } catch {
+      continue; // vanished or unreadable — nothing to report for it
+    }
+    for (const entry of entries) {
+      if (entry.isSymbolicLink()) continue;
+      const childRel = rel ? `${rel}/${entry.name}` : entry.name;
+      if (entry.isDirectory()) {
+        if (!PRUNE.has(entry.name)) stack.push(childRel);
+        continue;
+      }
+      if (!entry.isFile()) continue;
+      if (out.size >= MAX_SCAN_FILES) return null;
+      const abs = pathMod.join(root, childRel);
+      let st: fs.Stats;
+      try {
+        st = fs.statSync(abs);
+      } catch {
+        continue;
+      }
+      out.set(childRel, fingerprint(abs, st.size, st.mtimeMs));
+    }
+  }
+  return out;
+}
+
+/** Files that differ between two snapshots, sorted for stable output. */
+export function diffSnapshots(before: Snapshot, after: Snapshot): Change[] {
+  const changes: Change[] = [];
+  for (const [path, fp] of after) {
+    const prev = before.get(path);
+    if (prev === undefined) changes.push({ action: "created", path });
+    else if (prev !== fp) changes.push({ action: "modified", path });
+  }
+  for (const path of before.keys()) {
+    if (!after.has(path)) changes.push({ action: "deleted", path });
+  }
+  return changes.sort((a, b) => a.path.localeCompare(b.path));
+}
+
+// ─── Write scope ────────────────────────────────────────────────────────────
+
+let scopeRoot: string | null = null;
+let sandboxRoot: string | null = null;
+let originalRoot: string | null = null;
+let baseline: Snapshot | null = null;
+// Only flipped false when a scan bails out on size — commands that log purely
+// external writes never scan, and must not report their log as incomplete.
+let baselineUsable = true;
+const externalChanges: Change[] = [];
+
+/** The temp directory a dry run redirects vault writes into, if active. */
+export function sandboxPath(): string | null {
+  return sandboxRoot;
+}
+
+/** The real, user-facing root a dry run is standing in for. */
+export function realRootPath(): string | null {
+  return originalRoot;
+}
+
+// Belt and braces: a command that calls process.exit() (a declined
+// confirmation, a validation failure) skips closeWriteScope, so clean the
+// sandbox here too rather than leaving temp copies of people's vaults around.
+process.on("exit", () => {
+  if (sandboxRoot) {
+    try {
+      fs.rmSync(sandboxRoot, { recursive: true, force: true });
+    } catch {
+      /* best effort on the way out */
+    }
+  }
+});
+
+/**
+ * Begin auditing writes for one command.
+ *
+ * @param root  the vault the command targets.
+ * @param copy  seed the dry-run sandbox from `root`. False for `ctx init`,
+ *              which targets a directory that is not yet a vault (and may be
+ *              an entire source tree — copying it would be absurd).
+ */
+export async function openWriteScope(root: string, { copy = true } = {}): Promise<void> {
+  originalRoot = root;
+  if (isDryRun()) {
+    sandboxRoot = fs.mkdtempSync(pathMod.join(os.tmpdir(), "ctx-dryrun-"));
+    if (copy && fs.existsSync(root)) {
+      await fs.promises.cp(root, sandboxRoot, {
+        recursive: true,
+        verbatimSymlinks: true,
+        filter: (src) => !PRUNE.has(pathMod.basename(src)),
+      });
+    }
+    scopeRoot = sandboxRoot;
+  } else {
+    scopeRoot = root;
+  }
+  baseline = snapshot(scopeRoot);
+  baselineUsable = baseline !== null;
+}
+
+/** Record a write the vault snapshot cannot see (registry, `--out` targets). */
+export function recordExternalWrite(action: Change["action"], absPath: string): void {
+  externalChanges.push({ action, path: absPath });
+}
+
+/**
+ * Record an out-of-vault write, classifying it from what is on disk right now.
+ * Call this immediately BEFORE the write, or everything reads as "modified".
+ */
+export function noteExternalWrite(absPath: string): void {
+  recordExternalWrite(fs.existsSync(absPath) ? "modified" : "created", absPath);
+}
+
+/** Close the scope: print the action log and discard any dry-run sandbox. */
+export function closeWriteScope(): void {
+  if (!scopeRoot && externalChanges.length === 0) return;
+
+  const changes: Change[] = [...externalChanges];
+  if (scopeRoot && baseline) {
+    const after = snapshot(scopeRoot);
+    if (after) changes.push(...diffSnapshots(baseline, after));
+    else baselineUsable = false;
+  }
+  printActionLog(changes.sort((a, b) => a.path.localeCompare(b.path)));
+
+  if (sandboxRoot) fs.rmSync(sandboxRoot, { recursive: true, force: true });
+  scopeRoot = sandboxRoot = originalRoot = baseline = null;
+  baselineUsable = true;
+  externalChanges.length = 0;
+}
+
+/**
+ * The log goes to stderr, not stdout. It is commentary about the run rather
+ * than the command's result, and `--json` output / `ctx read --raw > file`
+ * have to stay machine-clean. A terminal user sees it either way.
+ */
+function printActionLog(changes: Change[]): void {
+  const dry = isDryRun();
+  if (dry) console.error(chalk.bold.cyan("\nDry run — no files were written."));
+
+  if (!baselineUsable) {
+    console.error(chalk.yellow("\nAction log skipped: too many files under the vault root to audit."));
+    return;
+  }
+  if (changes.length === 0) {
+    console.error(chalk.dim(dry ? "  No files would change." : "\nNo files changed."));
+    return;
+  }
+
+  const header = dry
+    ? `  ${changes.length} file(s) would change:`
+    : `\n${changes.length} file(s) changed:`;
+  console.error(chalk.bold(header));
+  for (const change of changes) {
+    const mark =
+      change.action === "created"
+        ? chalk.green("+")
+        : change.action === "deleted"
+          ? chalk.red("-")
+          : chalk.yellow("~");
+    console.error(`  ${mark} ${change.path}`);
+  }
+}
+
+// ─── Confirmation ───────────────────────────────────────────────────────────
+
+/**
+ * Ask before writing.
+ *
+ * A dry run always proceeds (it can only touch the sandbox). `--yes` /
+ * `--force` are the standing "prior explicit flag". Without a TTY there is
+ * nobody to ask: an additive operation takes the command line itself as
+ * consent, a destructive one refuses so a script can never silently shred a
+ * vault.
+ */
+export async function confirm(
+  question: string,
+  { destructive = false } = {},
+): Promise<boolean> {
+  if (isDryRun() || flags.yes === true || flags.force === true) return true;
+
+  const interactive = Boolean(process.stdin.isTTY && process.stdout.isTTY);
+  if (!interactive) {
+    if (!destructive) return true;
+    console.error(chalk.red(`Refusing without confirmation: ${question}`));
+    console.error(
+      chalk.dim("  Non-interactive session — re-run with --yes (or --force) to confirm, or --dry-run to preview."),
+    );
+    return false;
+  }
+
+  const hint = destructive ? "y/N" : "Y/n";
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  const answer = await new Promise<string>((resolve) => {
+    rl.question(`${question} ${chalk.dim(`[${hint}]`)} `, (a) => {
+      rl.close();
+      resolve(a);
+    });
+  });
+  const value = (answer.trim() || (destructive ? "n" : "y")).toLowerCase();
+  return value === "y" || value === "yes";
+}
+
+/** `confirm`, but a refusal ends the command with a non-zero exit. */
+export async function confirmOrExit(question: string, opts?: { destructive?: boolean }): Promise<void> {
+  if (await confirm(question, opts)) return;
+  console.error(chalk.yellow("Aborted — nothing was written."));
+  process.exit(1);
+}
+
+/**
+ * Guard a write that would clobber a file the command did not create.
+ * Silent overwrite is never an option: it takes `--force` or a live "yes".
+ */
+export async function ensureOverwritable(absPath: string, label = "File"): Promise<void> {
+  if (!fs.existsSync(absPath)) return;
+  if (isForce()) return;
+  await confirmOrExit(`${label} already exists: ${absPath} — overwrite it?`, { destructive: true });
+}
+
+// ─── Network egress ─────────────────────────────────────────────────────────
+
+const LOOPBACK = new Set(["localhost", "127.0.0.1", "::1", "[::1]"]);
+
+/**
+ * Validate an endpoint before vault contents (or a bearer token) leave the
+ * machine. Plaintext HTTP would put both on the wire in the clear, so it takes
+ * an explicit `--force` and only ever to a loopback address without one.
+ */
+export function assertSafeEndpoint(raw: string, what: string): URL {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    throw new Error(`${what} is not a valid URL: ${raw}`);
+  }
+  if (url.protocol === "https:") return url;
+  if (url.protocol !== "http:") {
+    throw new Error(`${what} must be http(s), got "${url.protocol}" — refusing to send vault contents.`);
+  }
+  if (LOOPBACK.has(url.hostname)) return url;
+  if (isForce()) {
+    console.error(
+      chalk.yellow(`Warning: sending vault contents to ${url.origin} over plaintext HTTP (--force).`),
+    );
+    return url;
+  }
+  throw new Error(
+    `${what} uses plaintext HTTP (${url.origin}). Vault contents and your API key would be sent unencrypted. ` +
+      `Use https://, a localhost address, or pass --force to accept the risk.`,
+  );
+}

--- a/packages/cli/src/safety.ts
+++ b/packages/cli/src/safety.ts
@@ -28,6 +28,7 @@ import pathMod from "node:path";
 import readline from "node:readline";
 import { createHash } from "node:crypto";
 import chalk from "chalk";
+import { getRegistryDir } from "@promptowl/contextnest-engine";
 
 // ─── Flags ──────────────────────────────────────────────────────────────────
 
@@ -163,6 +164,10 @@ let baseline: Snapshot | null = null;
 // Only flipped false when a scan bails out on size — commands that log purely
 // external writes never scan, and must not report their log as incomplete.
 let baselineUsable = true;
+let reportAbsolute = false;
+let registrySandbox: string | null = null;
+let realRegistryDir: string | null = null;
+let savedConfigDir: string | undefined;
 const externalChanges: Change[] = [];
 
 /** The temp directory a dry run redirects vault writes into, if active. */
@@ -175,13 +180,23 @@ export function realRootPath(): string | null {
   return originalRoot;
 }
 
+/** Copy a directory tree, skipping pruned subtrees and never resolving links. */
+function copyTree(from: string, to: string): Promise<void> {
+  return fs.promises.cp(from, to, {
+    recursive: true,
+    verbatimSymlinks: true,
+    filter: (src) => !PRUNE.has(pathMod.basename(src)),
+  });
+}
+
 // Belt and braces: a command that calls process.exit() (a declined
 // confirmation, a validation failure) skips closeWriteScope, so clean the
-// sandbox here too rather than leaving temp copies of people's vaults around.
+// sandboxes here too rather than leaving temp copies of people's data around.
 process.on("exit", () => {
-  if (sandboxRoot) {
+  for (const dir of [sandboxRoot, registrySandbox]) {
+    if (!dir) continue;
     try {
-      fs.rmSync(sandboxRoot, { recursive: true, force: true });
+      fs.rmSync(dir, { recursive: true, force: true });
     } catch {
       /* best effort on the way out */
     }
@@ -189,24 +204,63 @@ process.on("exit", () => {
 });
 
 /**
+ * Point the global vault registry at a throwaway copy for the rest of a dry
+ * run.
+ *
+ * Registry mutations live in `~/.contextnest/config.yaml`, outside any vault,
+ * so the vault sandbox can't cover them. Redirecting the directory lets the
+ * real engine calls run — alias collision checks, "is this actually a vault",
+ * "is this alias even registered" — so a dry run fails exactly where the real
+ * command would, instead of printing an optimistic "would …" for an operation
+ * that cannot succeed.
+ *
+ * No-op outside a dry run. `getRegistryDir()` reads the env var on every call,
+ * so this takes effect for engine code already imported.
+ */
+export async function openRegistrySandbox(): Promise<string> {
+  const real = realRegistryDir ?? getRegistryDir();
+  if (!isDryRun() || registrySandbox) return real;
+  realRegistryDir = real;
+  registrySandbox = fs.mkdtempSync(pathMod.join(os.tmpdir(), "ctx-dryrun-reg-"));
+  if (fs.existsSync(real)) await copyTree(real, registrySandbox);
+  savedConfigDir = process.env.CONTEXTNEST_CONFIG_DIR;
+  process.env.CONTEXTNEST_CONFIG_DIR = registrySandbox;
+  return real;
+}
+
+/**
+ * The registry path to show the user. `getRegistryPath()` follows the env var,
+ * which a dry run has pointed at a throwaway copy — never the path to print.
+ */
+export function registryPathForLog(): string {
+  return pathMod.join(realRegistryDir ?? getRegistryDir(), "config.yaml");
+}
+
+/**
  * Begin auditing writes for one command.
  *
- * @param root  the vault the command targets.
- * @param copy  seed the dry-run sandbox from `root`. False for `ctx init`,
- *              which targets a directory that is not yet a vault (and may be
- *              an entire source tree — copying it would be absurd).
+ * @param root     the directory the command writes into.
+ * @param copy     seed the dry-run sandbox from `root`. False only when there
+ *                 is nothing there worth copying — a first-time `ctx init`
+ *                 targets a directory that is not a vault yet, and may be an
+ *                 entire source tree.
+ * @param sandbox  create a dry-run sandbox. False when the caller already
+ *                 redirected the target (see `openRegistrySandbox`), so `root`
+ *                 is the throwaway copy already.
+ * @param absolutePaths  report changes by absolute path. For roots outside the
+ *                 vault, where a bare "config.yaml" would be ambiguous.
+ * @param displayRoot  the directory to name in output when `root` is already a
+ *                 throwaway copy.
  */
-export async function openWriteScope(root: string, { copy = true } = {}): Promise<void> {
-  originalRoot = root;
-  if (isDryRun()) {
+export async function openWriteScope(
+  root: string,
+  { copy = true, sandbox = true, absolutePaths = false, displayRoot = "" } = {},
+): Promise<void> {
+  originalRoot = displayRoot || root;
+  reportAbsolute = absolutePaths;
+  if (isDryRun() && sandbox) {
     sandboxRoot = fs.mkdtempSync(pathMod.join(os.tmpdir(), "ctx-dryrun-"));
-    if (copy && fs.existsSync(root)) {
-      await fs.promises.cp(root, sandboxRoot, {
-        recursive: true,
-        verbatimSymlinks: true,
-        filter: (src) => !PRUNE.has(pathMod.basename(src)),
-      });
-    }
+    if (copy && fs.existsSync(root)) await copyTree(root, sandboxRoot);
     scopeRoot = sandboxRoot;
   } else {
     scopeRoot = root;
@@ -235,14 +289,30 @@ export function closeWriteScope(): void {
   const changes: Change[] = [...externalChanges];
   if (scopeRoot && baseline) {
     const after = snapshot(scopeRoot);
-    if (after) changes.push(...diffSnapshots(baseline, after));
-    else baselineUsable = false;
+    if (after) {
+      // Report against the directory the user knows about, not the sandbox
+      // copy the dry run actually wrote into.
+      const base = originalRoot ?? scopeRoot;
+      for (const change of diffSnapshots(baseline, after)) {
+        changes.push(
+          reportAbsolute ? { ...change, path: pathMod.join(base, change.path) } : change,
+        );
+      }
+    } else baselineUsable = false;
   }
   printActionLog(changes.sort((a, b) => a.path.localeCompare(b.path)));
 
-  if (sandboxRoot) fs.rmSync(sandboxRoot, { recursive: true, force: true });
-  scopeRoot = sandboxRoot = originalRoot = baseline = null;
+  for (const dir of [sandboxRoot, registrySandbox]) {
+    if (dir) fs.rmSync(dir, { recursive: true, force: true });
+  }
+  if (registrySandbox) {
+    if (savedConfigDir === undefined) delete process.env.CONTEXTNEST_CONFIG_DIR;
+    else process.env.CONTEXTNEST_CONFIG_DIR = savedConfigDir;
+  }
+  scopeRoot = sandboxRoot = originalRoot = baseline = registrySandbox = realRegistryDir = null;
+  savedConfigDir = undefined;
   baselineUsable = true;
+  reportAbsolute = false;
   externalChanges.length = 0;
 }
 
@@ -337,7 +407,13 @@ export async function ensureOverwritable(absPath: string, label = "File"): Promi
 
 // ─── Network egress ─────────────────────────────────────────────────────────
 
-const LOOPBACK = new Set(["localhost", "127.0.0.1", "::1", "[::1]"]);
+const LOOPBACK_NAMES = new Set(["localhost", "::1", "[::1]"]);
+/** The whole of 127.0.0.0/8 is loopback, not just 127.0.0.1. */
+const LOOPBACK_V4 = /^127\.(?:\d{1,3}\.){2}\d{1,3}$/;
+
+function isLoopback(hostname: string): boolean {
+  return LOOPBACK_NAMES.has(hostname) || LOOPBACK_V4.test(hostname);
+}
 
 /**
  * Validate an endpoint before vault contents (or a bearer token) leave the
@@ -355,7 +431,7 @@ export function assertSafeEndpoint(raw: string, what: string): URL {
   if (url.protocol !== "http:") {
     throw new Error(`${what} must be http(s), got "${url.protocol}" — refusing to send vault contents.`);
   }
-  if (LOOPBACK.has(url.hostname)) return url;
+  if (isLoopback(url.hostname)) return url;
   if (isForce()) {
     console.error(
       chalk.yellow(`Warning: sending vault contents to ${url.origin} over plaintext HTTP (--force).`),

--- a/packages/cli/src/safety.ts
+++ b/packages/cli/src/safety.ts
@@ -55,28 +55,38 @@ export function isForce(): boolean {
 // ─── Vault snapshots ────────────────────────────────────────────────────────
 
 /**
- * Directories never walked or copied. A vault often lives at the root of a
- * real project (`ctx init` in a codebase), so without this the snapshot would
- * hash node_modules and the dry-run copy would duplicate it.
+ * A vault often lives at the root of a real project (`ctx init` in a codebase),
+ * so the snapshot would otherwise hash node_modules and the dry-run copy would
+ * duplicate it. But a vault is also free-form — `ctx add nodes/build/pipeline`
+ * is perfectly legal — so pruning by basename at any depth would make real
+ * documents invisible to both the action log and the sandbox copy.
+ *
+ * Hence two lists. Names that are never a plausible document folder are pruned
+ * wherever they appear (a monorepo has node_modules several levels down).
+ * Ordinary English words that merely happen to be build-output conventions are
+ * pruned only at the vault root, where they are the tool's directory rather
+ * than the user's.
  */
-const PRUNE = new Set([
+const PRUNE_ANYWHERE = new Set([
   "node_modules",
   ".git",
   ".hg",
   ".svn",
-  "dist",
-  "build",
-  "out",
-  "coverage",
   ".next",
   ".nuxt",
   ".turbo",
   ".venv",
-  "venv",
   "__pycache__",
-  "target",
   ".cache",
 ]);
+
+/** Pruned only as a direct child of the scope root. See PRUNE_ANYWHERE. */
+const PRUNE_AT_ROOT = new Set(["dist", "build", "out", "coverage", "target", "venv"]);
+
+/** @param depth 0 for a direct child of the scope root. */
+function shouldPrune(name: string, depth: number): boolean {
+  return PRUNE_ANYWHERE.has(name) || (depth === 0 && PRUNE_AT_ROOT.has(name));
+}
 
 /** Above this, auditing costs more than it's worth — the log is skipped. */
 const MAX_SCAN_FILES = 20_000;
@@ -123,7 +133,8 @@ export function snapshot(root: string): Snapshot | null {
       if (entry.isSymbolicLink()) continue;
       const childRel = rel ? `${rel}/${entry.name}` : entry.name;
       if (entry.isDirectory()) {
-        if (!PRUNE.has(entry.name)) stack.push(childRel);
+        const depth = rel === "" ? 0 : rel.split("/").length;
+        if (!shouldPrune(entry.name, depth)) stack.push(childRel);
         continue;
       }
       if (!entry.isFile()) continue;
@@ -180,12 +191,29 @@ export function realRootPath(): string | null {
   return originalRoot;
 }
 
-/** Copy a directory tree, skipping pruned subtrees and never resolving links. */
+/**
+ * Copy a directory tree, skipping pruned subtrees and never resolving links.
+ *
+ * The filter must prune on exactly the same rule as `snapshot()`, or a dry run
+ * would preview against a tree the action log then reports differently.
+ *
+ * ponytail: a full byte copy, so a dry run costs the size of the vault rather
+ * than the size of the change. Fine for markdown (and MAX_SCAN_FILES bounds it
+ * anyway). Hardlinks would be cheaper but are unsafe — not every engine write
+ * goes through write-temp-then-rename, and an in-place truncate would reach
+ * through the link into the real vault, which is the one thing a dry run must
+ * never do. If large vaults become a problem, use a filesystem-level reflink
+ * (`cp --reflink`, ReFS/APFS clone) where available.
+ */
 function copyTree(from: string, to: string): Promise<void> {
   return fs.promises.cp(from, to, {
     recursive: true,
     verbatimSymlinks: true,
-    filter: (src) => !PRUNE.has(pathMod.basename(src)),
+    filter: (src) => {
+      const rel = pathMod.relative(from, src);
+      if (rel === "") return true; // the root itself
+      return !shouldPrune(pathMod.basename(src), rel.split(pathMod.sep).length - 1);
+    },
   });
 }
 
@@ -407,7 +435,8 @@ export async function ensureOverwritable(absPath: string, label = "File"): Promi
 
 // ─── Network egress ─────────────────────────────────────────────────────────
 
-const LOOPBACK_NAMES = new Set(["localhost", "::1", "[::1]"]);
+// `new URL(...).hostname` always brackets IPv6, so a bare "::1" never appears.
+const LOOPBACK_NAMES = new Set(["localhost", "[::1]"]);
 /** The whole of 127.0.0.0/8 is loopback, not just 127.0.0.1. */
 const LOOPBACK_V4 = /^127\.(?:\d{1,3}\.){2}\d{1,3}$/;
 
@@ -441,5 +470,32 @@ export function assertSafeEndpoint(raw: string, what: string): URL {
   throw new Error(
     `${what} uses plaintext HTTP (${url.origin}). Vault contents and your API key would be sent unencrypted. ` +
       `Use https://, a localhost address, or pass --force to accept the risk.`,
+  );
+}
+
+/**
+ * `fetch` options that keep a validated endpoint validated.
+ *
+ * Checking the URL we were given only covers the first hop: by default `fetch`
+ * follows a 3xx, so a validated `https://` server could redirect the request —
+ * document bodies and all — to plaintext or to another host. The Fetch spec
+ * strips `Authorization` across origins, but the vault contents still travel.
+ * Refusing to follow makes the endpoint that was checked the endpoint that is
+ * used.
+ */
+export const NO_REDIRECT: RequestInit = { redirect: "manual" };
+
+/**
+ * Reject a response that tried to send us somewhere else. Pair with
+ * `NO_REDIRECT`, which turns a 3xx into a returned response rather than a
+ * silently-followed hop.
+ */
+export function assertNotRedirected(res: Response, what: string): void {
+  if (res.status < 300 || res.status >= 400) return;
+  const location = res.headers.get("location");
+  throw new Error(
+    `${what} redirected (${res.status}${location ? ` → ${location}` : ""}). ` +
+      `Refusing to follow: the destination has not been validated, and vault contents would travel with the request. ` +
+      `Point --server at the final URL instead.`,
   );
 }

--- a/packages/cli/src/starters/__tests__/starter-frontmatter.test.ts
+++ b/packages/cli/src/starters/__tests__/starter-frontmatter.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Every starter node must survive the same validation a hand-written document
+ * does.
+ *
+ * All 15 starter nodes shipped `type: context` — a value that has never been
+ * in `NODE_TYPES`. Nothing caught it because `ctx init --starter` writes and
+ * publishes without validating, so the vault looked healthy right up until the
+ * user ran `ctx update` or `ctx validate` on a scaffolded document and hit
+ * "Rule 6: Invalid enum value … received 'context'". These assertions run the
+ * real parser + validator over every node of every recipe, so a bad frontmatter
+ * value can't ship again — whatever field it's in.
+ */
+
+import { describe, it, expect } from "vitest";
+import { parseDocument, validateDocument, NODE_TYPES } from "@promptowl/contextnest-engine";
+import { listStarters, getStarter } from "../index.js";
+
+const starters = listStarters().map((s) => getStarter(s.id)!);
+
+describe("starter node frontmatter", () => {
+  it("covers every registered recipe", () => {
+    expect(starters.length).toBeGreaterThan(0);
+    expect(starters.every(Boolean)).toBe(true);
+  });
+
+  it.each(starters.map((s) => [s.id, s] as const))(
+    "%s — every node passes spec validation",
+    (_id, starter) => {
+      for (const node of starter.nodes) {
+        const doc = parseDocument(`${node.path}.md`, node.content, node.path);
+        const result = validateDocument(doc);
+        expect(
+          result.errors.map((e) => `${node.path}: rule ${e.rule} ${e.message}`),
+        ).toEqual([]);
+        expect(result.valid).toBe(true);
+      }
+    },
+  );
+
+  it.each(starters.map((s) => [s.id, s] as const))(
+    "%s — every node declares a known type",
+    (_id, starter) => {
+      for (const node of starter.nodes) {
+        const declared = node.content.match(/^type:\s*(.+)$/m)?.[1]?.trim();
+        expect(declared, `${node.path} has no type`).toBeDefined();
+        expect(NODE_TYPES as readonly string[]).toContain(declared!);
+      }
+    },
+  );
+});

--- a/packages/cli/src/starters/index.ts
+++ b/packages/cli/src/starters/index.ts
@@ -56,7 +56,7 @@ const developer: Starter = {
       path: "nodes/architecture/architecture-overview",
       content: `---
 title: Architecture Overview
-type: context
+type: document
 tags: [architecture, overview, tech-stack]
 priority: high
 status: draft
@@ -121,7 +121,7 @@ _Replace with your actual architecture._
       path: "nodes/onboarding/getting-started",
       content: `---
 title: Developer Getting Started Guide
-type: context
+type: document
 tags: [onboarding, setup, getting-started]
 priority: high
 status: draft
@@ -188,7 +188,7 @@ Good first issues for getting familiar with the codebase:
       path: "nodes/standards/coding-conventions",
       content: `---
 title: Coding Conventions
-type: context
+type: document
 tags: [standards, conventions, code-quality]
 priority: high
 status: published
@@ -282,7 +282,7 @@ const executive: Starter = {
       path: "nodes/strategy/strategic-priorities",
       content: `---
 title: Strategic Priorities
-type: context
+type: document
 tags: [strategy, priorities, planning]
 priority: high
 status: draft
@@ -335,7 +335,7 @@ Equally important as priorities — what have we explicitly decided NOT to pursu
       path: "nodes/operations/decision-framework",
       content: `---
 title: Decision-Making Framework
-type: context
+type: document
 tags: [operations, decisions, framework, governance]
 priority: high
 status: published
@@ -394,7 +394,7 @@ status: published
       path: "nodes/leadership/alignment-playbook",
       content: `---
 title: Stakeholder Alignment Playbook
-type: context
+type: document
 tags: [leadership, alignment, communication, stakeholders]
 priority: medium
 status: published
@@ -490,7 +490,7 @@ const analyst: Starter = {
       path: "nodes/methodologies/research-framework",
       content: `---
 title: Research Framework
-type: context
+type: document
 tags: [methodology, research, framework, analysis]
 priority: high
 status: published
@@ -554,7 +554,7 @@ status: published
       path: "nodes/reporting/report-template",
       content: `---
 title: Report Template
-type: context
+type: document
 tags: [reporting, template, deliverable]
 priority: medium
 status: published
@@ -629,7 +629,7 @@ _Supporting data, source list, methodology details_
       path: "nodes/sources/source-catalog",
       content: `---
 title: Source Catalog
-type: context
+type: document
 tags: [sources, data, catalog, reliability]
 priority: high
 status: draft
@@ -715,7 +715,7 @@ const team: Starter = {
       path: "nodes/processes/how-we-work",
       content: `---
 title: How We Work
-type: context
+type: document
 tags: [processes, team, norms, rituals]
 priority: high
 status: draft
@@ -766,7 +766,7 @@ status: draft
       path: "nodes/onboarding/first-30-days",
       content: `---
 title: First 30 Days
-type: context
+type: document
 tags: [onboarding, new-hire, checklist]
 priority: high
 status: published
@@ -825,7 +825,7 @@ status: published
       path: "nodes/knowledge/team-faq",
       content: `---
 title: Team FAQ
-type: context
+type: document
 tags: [knowledge, faq, team, questions]
 priority: medium
 status: draft
@@ -918,7 +918,7 @@ const sales: Starter = {
       path: "nodes/playbooks/objection-handling",
       content: `---
 title: Objection Handling Playbook
-type: context
+type: document
 tags: [playbook, objections, sales, responses]
 priority: high
 status: draft
@@ -982,7 +982,7 @@ When you hear an objection on a call, search this document or ask your AI to pul
       path: "nodes/competitive/battlecard-template",
       content: `---
 title: Competitive Battlecard Template
-type: context
+type: document
 tags: [competitive, battlecard, positioning]
 priority: high
 status: draft
@@ -1051,7 +1051,7 @@ _Questions to ask early that expose the competitor's weaknesses:_
       path: "nodes/enablement/product-knowledge",
       content: `---
 title: Product Knowledge Guide
-type: context
+type: document
 tags: [enablement, product, knowledge, features]
 priority: high
 status: draft

--- a/packages/engine/vitest.config.ts
+++ b/packages/engine/vitest.config.ts
@@ -3,5 +3,12 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     include: ["src/__tests__/**/*.test.ts"],
+    // Integrity and history suites fsync every write (durable hash chains), and
+    // fsync is slow on the Windows CI runners — slow enough to blow past the 5s
+    // default when the whole workspace runs in parallel, which surfaced as
+    // timeouts plus ENOTEMPTY as cleanup raced the still-running test. Same
+    // headroom the CLI config already carries for the same reason.
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
   },
 });


### PR DESCRIPTION
## Summary

The CLI created and overwrote files without clear consent, so developers couldn't tell what had just happened to their working directory. This adds consent, preview, and disclosure to every command that writes.

Also fixes a bug found while testing: every starter recipe scaffolded documents with a node type the spec doesn't define, so any vault created from a starter failed validation on first edit.

## What changed

**Ask first.** Write commands confirm before proceeding, destructive ones defaulting to "no". Nothing blocks on stdin without a terminal: additive commands take the command line itself as consent, destructive ones refuse unless consent was given up front by flag.

**Preview anything.** `--dry-run` runs the real operation against a throwaway copy of the vault and reports the exact files it would touch. The preview is the real result rather than a description of intent, so it can't drift from what the command actually does.

**Say what happened.** Every write command ends with the list of files it created, modified or deleted, derived by comparing the vault before and after. It goes to stderr, keeping machine-readable output clean.

**Never overwrite silently.** Clobbering an existing file takes an explicit flag or a live confirmation.

**Don't leak on the way out.** Pushing to a hosted server now lists the documents leaving the machine before sending them, refuses plaintext HTTP to anything but localhost (which would expose both the documents and the API key in transit), and accepts the key from the environment so it needn't sit in shell history or be visible to other processes.

**Starter recipes produce valid documents.** The write path doesn't validate but the edit path does, so scaffolded vaults looked healthy until the first update. Now covered by tests that validate every node of every recipe.

## Impact

Interactive users get a prompt and a receipt on every write. Nothing is overwritten without them saying so, and `--dry-run` makes any command safe to try.

**Breaking for scripts and CI.** Destructive commands — delete, checkpoint rebuild, drift approve, vault remove, push — now require an explicit consent flag when there's no terminal. Additive commands are unchanged, so the agent plugins that shell out to this CLI need no updates.

**Not migrated.** Vaults created before the starter fix still hold the invalid type on disk and will keep failing validation. The changeset documents the one-line fix; a migration command is a follow-up.