### PR TITLE
Own the whole folder-import flow, and publish measured performance characteristics

### DIFF
--- a/.changeset/import-a-vault-in-one-call.md
+++ b/.changeset/import-a-vault-in-one-call.md
@@ -1,0 +1,47 @@
+---
+"@promptowl/contextnest-engine": minor
+---
+
+Give `context_import` the whole folder-import flow, instead of half of it.
+
+Importing an existing vault took two passes over every document before
+publishing even started. The importer scanned the vault itself, rewrote each
+file to stamp its own metadata (an `author` that is the importing user, a title
+falling back to the filename), and only then handed the ids back to be
+published — which rewrites each file again. On a network-backed mount that is
+two extra round trips per document, and the scan is duplicated work the engine
+had already done.
+
+Three additions close that gap:
+
+- `files[]` writes an existing vault's files in **verbatim**, at their own
+  relative paths. Nothing is synthesized, so the source's frontmatter survives
+  (`version`, `checksum`, custom keys a generated draft would drop), and files
+  that are not documents travel too — `.versions/<doc>/history.yaml` included,
+  which is what lets an imported version chain still reconstruct. Paths are
+  guarded: `..` and absolute paths are rejected per-file rather than aborting
+  the import.
+- `publish: false` stages files without publishing them. An upload that arrives
+  in several batches can stage every batch and publish once at the end, so the
+  import seals ONE checkpoint rather than one per batch.
+- `discover: true` makes the vault itself the input. The engine scans, decides
+  publish-vs-hold from each file's own frontmatter, publishes the batch under a
+  single checkpoint, and returns a record per document (`id`, `title`,
+  `version`, `status`, `tags`, `content`) — enough for a governance layer to
+  record the import without re-reading the vault. `exclude_ids` skips what an
+  earlier run already took, so a re-import is idempotent.
+
+The metadata stamp now rides along with the publish write through a new
+`frontmatter` hook on `publishDocuments`, so it costs no pass of its own.
+
+Two supporting pieces:
+
+- `parser.explicitStatus(node)` returns the status the author actually wrote, or
+  `null`. `parseDocument` defaults a missing `status` to `draft`, so
+  `frontmatter.status` cannot tell a deliberate draft from a status-less
+  hand-authored note. Import needs that distinction: a status-less file is fair
+  game to publish, an explicit `draft` or `pending_review` must stay
+  unpublished. Aliases are normalized first, so an import cannot slip a
+  not-yet-approved document past the hold by spelling its status differently.
+- `storage.writeVaultFile(relPath, content)` writes a file into the vault
+  verbatim under a path-traversal guard, parsing nothing.

--- a/.changeset/import-a-vault-in-one-call.md
+++ b/.changeset/import-a-vault-in-one-call.md
@@ -31,6 +31,18 @@ Three additions close that gap:
   record the import without re-reading the vault. `exclude_ids` skips what an
   earlier run already took, so a re-import is idempotent.
 
+**Publishing is opt-in.** Only a document whose frontmatter explicitly says
+`published` or `approved` gets published. Everything else is held as a draft,
+including a document that states no status at all — saying nothing is not
+consent. A vault of hand-authored notes carries no governance state, and
+importing it should not decide on the author's behalf that every note is fit to
+serve to an AI. Held is recoverable, since you can approve what belongs;
+published-by-default is not, because the exposure has already happened by the
+time anyone reviews it. A held document is stamped with an explicit
+`status: draft` rather than left implied, so a file read outside the engine is
+never ambiguous — except where the author already stated `pending_review` or
+`rejected`, which is theirs to keep.
+
 The metadata stamp now rides along with the publish write through a new
 `frontmatter` hook on `publishDocuments`, so it costs no pass of its own.
 

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,84 @@
+name: Benchmarks
+
+# Two cadences, because the sizes cost very different amounts of time.
+#
+# Every PR gets the cheap gate (100 → 1,000 documents), which is where a
+# quadratic path already shows its shape — fast enough that nobody is tempted
+# to skip it. The full sweep including 10,000 documents runs nightly and on
+# demand: it is the number published in the README, and it takes long enough
+# that putting it on every PR would get the job disabled within a month.
+on:
+  pull_request:
+    branches: [main, development]
+  push:
+    branches: [main, development]
+  schedule:
+    # 03:00 UTC daily — the full sweep, against whatever landed that day.
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: bench-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  benchmark:
+    name: Performance budget
+    runs-on: ubuntu-latest
+    # A quadratic regression makes the 10k sweep run effectively forever. Cap
+    # it so the symptom is a failed job, not a six-hour one.
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # The harness runs against the built bundle, which is also the thing users
+      # actually install — so dist/ has to exist before benchmarking.
+      - name: Build
+        run: pnpm build
+
+      # Nightly and manual runs do the full sweep; PR and push runs stop at
+      # 1,000 documents.
+      - name: Choose sizes
+        id: sizes
+        run: |
+          if [ "${{ github.event_name }}" = "schedule" ] || [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "value=100,1000,10000" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=100,1000" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Fails the job when an operation's per-document cost grows beyond its
+      # budget — i.e. when it stops scaling linearly. See bench/check.mjs for
+      # why the gate is on scaling shape rather than absolute milliseconds.
+      - name: Run benchmarks and enforce the performance budget
+        working-directory: packages/engine
+        run: node bench/check.mjs --sizes ${{ steps.sizes.outputs.value }}
+
+      - name: Upload benchmark results
+        # Results are worth having even when the budget was breached — that run
+        # is the one you want the numbers from.
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-results-${{ github.run_id }}
+          path: packages/engine/bench/results-ci.json
+          if-no-files-found: warn

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,8 @@ fixtures/*
 # Test coverage output
 coverage/
 
+
+# Benchmark output — machine-specific timings and V8 profiles. The committed
+# baseline is bench/budget.json, not any one run.
+packages/engine/bench/results-*.json
+packages/engine/bench/profiles/

--- a/README.md
+++ b/README.md
@@ -101,6 +101,53 @@ After `ctx init`, the CLI prints a starter-specific instruction block to stdout.
 | [@promptowl/contextnest-engine](https://www.npmjs.com/package/@promptowl/contextnest-engine) | Core library — parsing, storage, versioning, integrity | AGPL-3.0 |
 | [@promptowl/contextnest-mcp-server](https://www.npmjs.com/package/@promptowl/contextnest-mcp-server) | MCP server for AI agent access | AGPL-3.0 |
 
+## Performance
+
+How the engine behaves as a vault grows. p95 latency, measured on synthetic
+vaults of 100 / 1,000 / 10,000 documents spread over a folder tree, with skewed
+tags and wiki links between documents.
+
+| Operation | 100 docs | 1,000 docs | 10,000 docs | Scaling |
+|---|---|---|---|---|
+| `context_query` (retrieval) | 6ms | 74ms | **841ms** | linear (1.14×) |
+| `context_search` | 21ms | 174ms | **1.3s** | linear (0.76×) |
+| `context_list` | 12ms | 177ms | **1.4s** | linear (0.77×) |
+| `discoverDocuments` (vault crawl) | 11ms | 263ms | **1.2s** | linear (0.45×) |
+| `regenerateIndex` | 66ms | 383ms | **3.8s** | linear (0.98×) |
+| `context_import` (bulk import) | 0.7s | 11.3s | **108s** | linear (0.95×) |
+| Peak RSS | 74 MB | 126 MB | **262 MB** | linear |
+
+"Scaling" is the change in **per-document** cost from 1,000 to 10,000
+documents. 1.0× means the cost of a vault is proportional to what is in it —
+ten times the documents, ten times the work, no worse. Every operation measures
+between 0.45× and 1.15×, so nothing here degrades as a vault grows.
+
+Two honest caveats. Bulk import is linear but expensive in absolute terms:
+importing 10,000 documents takes around two minutes, because every document is
+published, versioned and hash-chained on the way in. And these numbers come
+from a developer machine (Node 22, win32-x64), so read them as orders of
+magnitude and scaling shape, not as a spec your hardware will reproduce.
+
+The suite lives in [`packages/engine/bench`](packages/engine/bench) and runs in
+CI. Reproduce it yourself:
+
+```bash
+pnpm build
+cd packages/engine
+pnpm bench                      # 100 / 1,000 / 10,000 documents
+pnpm bench --sizes 100,1000     # quicker
+pnpm bench:check                # run, then enforce the performance budget
+pnpm bench:profile              # writes a V8 CPU profile to bench/profiles/
+```
+
+`bench:check` is the CI gate. It fails when an operation's per-document cost
+grows beyond its budget — that is, when something stops scaling linearly. The
+budget is expressed as scaling shape rather than millisecond ceilings on
+purpose: CI runners differ in speed by several times, so ceilings tight enough
+to catch a real regression would fail constantly on a slow runner, and loose
+enough to survive one they would catch nothing. See
+[`bench/budget.json`](packages/engine/bench/budget.json).
+
 ## Prerequisites
 
 - **Node.js** >= 20.0.0

--- a/packages/engine/bench/budget.json
+++ b/packages/engine/bench/budget.json
@@ -1,0 +1,98 @@
+{
+  "$comment": [
+    "Performance budget, enforced by bench/check.mjs.",
+    "",
+    "Each rule bounds how much an operation's PER-DOCUMENT cost may grow as the",
+    "vault gets 10x bigger. 1.0 is perfectly linear: the cost of a vault is",
+    "proportional to what is in it. A value climbing well above 1 means the",
+    "operation does work that grows faster than the document count, which is the",
+    "failure this budget exists to catch.",
+    "",
+    "Why growth and not milliseconds: CI runners vary by several times in speed",
+    "and are noisy neighbours. Absolute ceilings tight enough to catch a real",
+    "regression would fail constantly on a slow runner; loose enough to survive",
+    "one and they catch nothing. Per-document growth has the same shape on fast",
+    "and slow hardware.",
+    "",
+    "Two tiers, because the two size pairs are not equally trustworthy:",
+    "",
+    "  1000 -> 10000 is the REAL gate. At these sizes a run takes long enough",
+    "  that fixed startup costs and machine jitter are rounding errors, so the",
+    "  measured growth is the engine's actual shape. Every op measures 0.95x to",
+    "  1.15x here today — linear. These ceilings are tight.",
+    "",
+    "  100 -> 1000 is a smoke tripwire only. A 100-document run finishes in",
+    "  10-30ms, where fixed costs dominate and back-to-back runs on the same",
+    "  machine have disagreed by more than 2x. Gating tightly on this pair would",
+    "  produce flaky failures that teach people to ignore the job. The ceilings",
+    "  are loose on purpose: they catch a catastrophic regression on every PR,",
+    "  and nothing subtler. Do not tighten them without first making the small",
+    "  sizes reproducible."
+  ],
+  "scaling": [
+    {
+      "op": "discoverDocuments",
+      "from": 1000,
+      "to": 10000,
+      "maxGrowth": 1.4,
+      "note": "Measured 0.45x. The whole-vault crawl was batched in #66."
+    },
+    {
+      "op": "context_query",
+      "from": 1000,
+      "to": 10000,
+      "maxGrowth": 1.4,
+      "note": "Measured 1.14x. The retrieval path an agent hits on every request."
+    },
+    {
+      "op": "context_search",
+      "from": 1000,
+      "to": 10000,
+      "maxGrowth": 1.4,
+      "note": "Measured 0.75x. Dominated by building the search index."
+    },
+    {
+      "op": "context_list",
+      "from": 1000,
+      "to": 10000,
+      "maxGrowth": 1.4,
+      "note": "Measured 0.77x."
+    },
+    {
+      "op": "regenerateIndex",
+      "from": 1000,
+      "to": 10000,
+      "maxGrowth": 1.4,
+      "note": "Measured 0.98x. Re-reads and re-sorts the whole vault, but linearly."
+    },
+    {
+      "op": "context_import_discover",
+      "from": 1000,
+      "to": 10000,
+      "maxGrowth": 1.4,
+      "note": "Measured 0.95x. Linear, but the largest absolute cost by far — ~108s for 10k documents. Linear is not the same as fast; this is the op to attack on constant factor, not on shape."
+    },
+
+    {
+      "op": "discoverDocuments",
+      "from": 100,
+      "to": 1000,
+      "maxGrowth": 3.0,
+      "note": "Smoke tripwire — see the note on small-size noise above."
+    },
+    {
+      "op": "context_query",
+      "from": 100,
+      "to": 1000,
+      "maxGrowth": 3.0,
+      "note": "Smoke tripwire."
+    },
+    {
+      "op": "context_import_discover",
+      "from": 100,
+      "to": 1000,
+      "maxGrowth": 3.0,
+      "note": "Smoke tripwire."
+    }
+  ]
+}

--- a/packages/engine/bench/check.mjs
+++ b/packages/engine/bench/check.mjs
@@ -1,0 +1,109 @@
+/**
+ * Performance budget gate.
+ *
+ * Runs the benchmarks and fails if the engine's scaling has regressed.
+ *
+ * The gate is deliberately NOT a table of millisecond ceilings. CI runners
+ * differ by several times in speed, and shared runners are noisy neighbours;
+ * absolute budgets tight enough to catch a real regression would fail
+ * constantly on a slow runner, and budgets loose enough to survive one would
+ * catch nothing. Either way the job gets muted, which is worse than no gate.
+ *
+ * What is stable across hardware is SHAPE. An operation that costs the same per
+ * document at 1k and at 10k is linear; one whose per-document cost climbs is
+ * not, and that is the failure the ticket is actually about — "engine slows
+ * down as vault size grows". A quadratic path shows the same climb on a fast
+ * runner as a slow one.
+ *
+ * So: per-operation scaling tolerance, expressed as how much the per-document
+ * cost may grow across a 10× increase in vault size. Anything comfortably under
+ * 2× is linear with measurement noise; the tolerances in budget.json are set
+ * per operation, above today's measured value with headroom, and tightened as
+ * each hot path is fixed.
+ *
+ * Usage:
+ *   node bench/check.mjs                     # run benchmarks, then gate
+ *   node bench/check.mjs --input results.json
+ */
+import { readFile } from "node:fs/promises";
+import { execFile } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { promisify } from "node:util";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const run = promisify(execFile);
+
+function parseArgs(argv) {
+  const args = { input: null, sizes: null };
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === "--input") args.input = argv[++i];
+    else if (argv[i] === "--sizes") args.sizes = argv[++i];
+  }
+  return args;
+}
+
+const { input, sizes } = parseArgs(process.argv.slice(2));
+const budget = JSON.parse(await readFile(join(here, "budget.json"), "utf-8"));
+
+let report;
+if (input) {
+  report = JSON.parse(await readFile(input, "utf-8"));
+} else {
+  const argv = [join(here, "run.mjs"), "--out", join(here, "results-ci.json")];
+  if (sizes) argv.push("--sizes", sizes);
+  // maxBuffer: a 10k run prints a lot of engine chatter on stderr.
+  await run(process.execPath, argv, { maxBuffer: 64 * 1024 * 1024 });
+  report = JSON.parse(await readFile(join(here, "results-ci.json"), "utf-8"));
+}
+
+/** Per-document cost in microseconds, the size-independent unit. */
+const perDoc = (entry, op) =>
+  entry.ops[op] ? (entry.ops[op].p95 / entry.size) * 1000 : null;
+
+const bySize = new Map(report.sizes.map((s) => [s.size, s]));
+const failures = [];
+const rows = [];
+const pad = (s, n) => String(s).padEnd(n);
+
+for (const rule of budget.scaling) {
+  const op = rule.op;
+  const from = bySize.get(rule.from);
+  const to = bySize.get(rule.to);
+  if (!from || !to) {
+    // Not every run covers every size (a PR run stops at 1,000). Skipping is
+    // correct; silently passing a rule that never ran is not — say so.
+    rows.push(`  ~ ${op} [${rule.from}→${rule.to}]: skipped (size not in this run)`);
+    continue;
+  }
+  const a = perDoc(from, op);
+  const b = perDoc(to, op);
+  if (a == null || b == null) {
+    rows.push(`  ~ ${op} [${rule.from}→${rule.to}]: skipped (not measured)`);
+    continue;
+  }
+  const growth = b / a;
+  const ok = growth <= rule.maxGrowth;
+  rows.push(
+    `  ${ok ? "✓" : "✗"} ${pad(`${op} [${rule.from}→${rule.to}]`, 44)}` +
+      `${a.toFixed(1)} → ${b.toFixed(1)} µs/doc  ` +
+      `(${growth.toFixed(2)}×, budget ${rule.maxGrowth}×)`,
+  );
+  if (!ok) {
+    failures.push(
+      `${op}: per-document cost grew ${growth.toFixed(2)}× from ${rule.from} to ${rule.to} ` +
+        `documents (budget ${rule.maxGrowth}×). The operation is scaling worse than linearly.`,
+    );
+  }
+}
+
+console.log(`\nPerformance budget — ${report.platform}, Node ${report.node}\n`);
+console.log(rows.join("\n"));
+
+if (failures.length) {
+  console.error(`\n${failures.length} budget breach(es):\n`);
+  for (const f of failures) console.error(`  - ${f}`);
+  console.error("");
+  process.exit(1);
+}
+console.log("\nAll operations within their scaling budget.\n");

--- a/packages/engine/bench/fixture.mjs
+++ b/packages/engine/bench/fixture.mjs
@@ -1,0 +1,120 @@
+/**
+ * Generate a synthetic vault of N documents for benchmarking.
+ *
+ * Written with plain `fs` rather than through the engine on purpose: a fixture
+ * built by the code under test would hide a regression in that code, and
+ * publishing N documents to lay down a baseline would take longer than the
+ * benchmark it feeds.
+ *
+ * The shape matters as much as the count. Real vaults are not a flat directory
+ * of identical files, and an engine that only ever sees one is not being
+ * measured on anything: documents are spread over a folder tree, bodies vary in
+ * length, tags repeat with a realistic skew (a few hot tags, a long tail), and
+ * a fraction carry wiki links to other documents so link resolution has real
+ * work to do.
+ *
+ * Deterministic: same `size` in, byte-identical vault out. A benchmark whose
+ * input drifts between runs measures the drift.
+ */
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+/** Bounded-parallel map — writing 10k files one await at a time is its own wait. */
+async function inBatches(items, fn, size = 64) {
+  for (let i = 0; i < items.length; i += size) {
+    await Promise.all(items.slice(i, i + size).map(fn));
+  }
+}
+
+/**
+ * Deterministic PRNG (mulberry32). `Math.random()` would make every run a
+ * different vault, so a result could never be compared to the run before it.
+ */
+function rng(seed) {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+const TAGS = [
+  "architecture", "api", "runbook", "decision", "onboarding",
+  "security", "billing", "infra", "frontend", "data",
+];
+
+const WORDS = [
+  "context", "vault", "document", "version", "checkpoint", "steward", "publish",
+  "retrieval", "governance", "index", "chain", "keyframe", "review", "approve",
+];
+
+/** A body of roughly `n` words, stable for a given rand stream. */
+function body(rand, n) {
+  const out = [];
+  for (let i = 0; i < n; i++) out.push(WORDS[Math.floor(rand() * WORDS.length)]);
+  return out.join(" ");
+}
+
+/**
+ * Write a vault of `size` documents under `root`.
+ *
+ * Returns the ids written, so a caller can drive per-document operations
+ * without re-scanning the vault it just built.
+ */
+export async function generateVault(root, size, { seed = 1 } = {}) {
+  const rand = rng(seed);
+  // Roughly 20 documents per folder, two levels deep — enough that discovery
+  // walks a real tree rather than one big readdir.
+  const folders = Math.max(1, Math.ceil(size / 20));
+  const ids = [];
+  const docs = [];
+
+  for (let i = 0; i < size; i++) {
+    const folder = i % folders;
+    const id = `nodes/area-${folder % 8}/topic-${folder}/doc-${i}`;
+    ids.push(id);
+
+    // Skewed tags: index 0 is on ~half the vault, the tail is rare. A uniform
+    // spread would make every tag query cost the same and hide the hot-tag case.
+    const tagCount = 1 + Math.floor(rand() * 3);
+    const tags = [];
+    for (let t = 0; t < tagCount; t++) {
+      const skewed = Math.floor(TAGS.length * rand() * rand());
+      const tag = TAGS[Math.min(skewed, TAGS.length - 1)];
+      if (!tags.includes(tag)) tags.push(tag);
+    }
+
+    // A fifth of the vault links to another document, so link resolution and
+    // the graph query engine have edges to actually traverse.
+    const linksTo = rand() < 0.2 ? `doc-${Math.floor(rand() * size)}` : null;
+
+    // Bodies vary: most short, some long. One fixed size would measure a single
+    // point on the curve and call it the curve.
+    const length = rand() < 0.1 ? 400 : 60;
+
+    docs.push({
+      id,
+      content:
+        `---\n` +
+        `title: Doc ${i}\n` +
+        `type: document\n` +
+        `status: published\n` +
+        `version: 1\n` +
+        `tags:\n${tags.map((t) => `  - "#${t}"`).join("\n")}\n` +
+        `---\n\n` +
+        `# Doc ${i}\n\n` +
+        `${body(rand, length)}\n` +
+        (linksTo ? `\nSee also [[${linksTo}]].\n` : ""),
+    });
+  }
+
+  // One mkdir per distinct folder, not per document.
+  const dirs = new Set(docs.map((d) => join(root, d.id.split("/").slice(0, -1).join("/"))));
+  await mkdir(root, { recursive: true });
+  await Promise.all([...dirs].map((d) => mkdir(d, { recursive: true })));
+  await inBatches(docs, (d) => writeFile(join(root, `${d.id}.md`), d.content, "utf-8"));
+
+  return ids;
+}

--- a/packages/engine/bench/run.mjs
+++ b/packages/engine/bench/run.mjs
@@ -1,0 +1,192 @@
+/**
+ * Engine benchmark harness — how the engine behaves as a vault grows.
+ *
+ * Answers the question a serious user actually asks before trusting a real
+ * vault to this: does it stay usable at 10k documents, or does something in
+ * here scale quadratically? Timings alone cannot answer that. A per-document
+ * cost that holds steady from 1k to 10k means the op is linear; one that
+ * doubles means it is not, and no absolute millisecond budget would tell them
+ * apart on unknown hardware.
+ *
+ * So this reports BOTH: absolute p50/p95 per operation, and the per-document
+ * cost at each size. `check.mjs` gates on the second.
+ *
+ * Runs against the built `dist`, not `src` — no TypeScript runner is in the
+ * dependency tree, and measuring the shipped bundle is the more honest target
+ * anyway.
+ *
+ * Usage:
+ *   node bench/run.mjs                        # default sizes
+ *   node bench/run.mjs --sizes 100,1000       # pick sizes
+ *   node bench/run.mjs --out results.json     # write results
+ */
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { performance } from "node:perf_hooks";
+import { NestStorage, GraphQueryEngine, VersionManager } from "../dist/index.js";
+import { createEngineApi } from "../dist/api/index.js";
+import { generateVault } from "./fixture.mjs";
+
+const DEFAULT_SIZES = [100, 1000, 10000];
+
+function parseArgs(argv) {
+  const args = { sizes: DEFAULT_SIZES, out: null };
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === "--sizes") {
+      args.sizes = argv[++i].split(",").map((s) => Number(s.trim())).filter(Boolean);
+    } else if (argv[i] === "--out") {
+      args.out = argv[++i];
+    }
+  }
+  return args;
+}
+
+/** p-th percentile of an unsorted sample, nearest-rank. */
+function percentile(samples, p) {
+  const sorted = [...samples].sort((a, b) => a - b);
+  const rank = Math.max(0, Math.ceil((p / 100) * sorted.length) - 1);
+  return sorted[rank];
+}
+
+/**
+ * Time `fn` over `reps` runs and return the distribution.
+ *
+ * One untimed warmup run first: the first call through any code path pays for
+ * lazy module init and a cold JIT, and folding that into a p95 measures Node
+ * warming up rather than the engine working.
+ */
+async function measure(fn, reps) {
+  await fn();
+  const samples = [];
+  for (let i = 0; i < reps; i++) {
+    const t0 = performance.now();
+    await fn();
+    samples.push(performance.now() - t0);
+  }
+  return {
+    p50: percentile(samples, 50),
+    p95: percentile(samples, 95),
+    runs: reps,
+  };
+}
+
+/** Time a single run of an operation that mutates the vault (so cannot repeat). */
+async function measureOnce(fn) {
+  const t0 = performance.now();
+  await fn();
+  return { p50: performance.now() - t0, p95: performance.now() - t0, runs: 1 };
+}
+
+function makeContext(root) {
+  const storage = new NestStorage(root);
+  return {
+    storage,
+    query: new GraphQueryEngine(storage),
+    versions: new VersionManager(storage),
+    actor: "bench@contextnest.dev",
+  };
+}
+
+async function benchSize(size) {
+  const api = createEngineApi();
+  const results = {};
+
+  // ── Read-only operations, on a vault that is already published ────────────
+  // Repeatable, so these get a real distribution. This is the path an agent
+  // hits on every retrieval, which makes its p95 the number users feel.
+  const readRoot = await mkdtemp(join(tmpdir(), `cn-bench-read-${size}-`));
+  try {
+    await generateVault(readRoot, size);
+    const ctx = makeContext(readRoot);
+
+    // Repetitions fall as the vault grows: at 10k a single crawl is already
+    // substantial, and 20 of them would dominate the run for no extra signal.
+    const reps = size >= 10000 ? 5 : size >= 1000 ? 10 : 20;
+
+    results.discoverDocuments = await measure(() => ctx.storage.discoverDocuments(), reps);
+    results.context_list = await measure(() => api.run("context_list", {}, ctx), reps);
+    results.context_search = await measure(
+      () => api.run("context_search", { query: "checkpoint" }, ctx),
+      reps,
+    );
+    results.context_query = await measure(
+      () => api.run("context_query", { query: "#architecture" }, ctx),
+      reps,
+    );
+  } finally {
+    await rm(readRoot, { recursive: true, force: true });
+  }
+
+  // ── Whole-vault write operations ──────────────────────────────────────────
+  // Each mutates the vault, so each gets a fresh fixture and a single timed
+  // run. These are the ops that made importing a large folder take minutes.
+  const importRoot = await mkdtemp(join(tmpdir(), `cn-bench-import-${size}-`));
+  try {
+    await generateVault(importRoot, size);
+    const ctx = makeContext(importRoot);
+    results.context_import_discover = await measureOnce(() =>
+      api.run("context_import", { discover: true, author: "bench@contextnest.dev" }, ctx),
+    );
+    // Index regeneration runs after the import above, on a published vault —
+    // which is when it actually runs in production.
+    results.regenerateIndex = await measureOnce(() => ctx.storage.regenerateIndex());
+  } finally {
+    await rm(importRoot, { recursive: true, force: true });
+  }
+
+  // Peak resident memory after the largest crawls. Reported per size so a
+  // memory regression shows up as growth that outpaces the document count.
+  const mem = process.memoryUsage();
+  return {
+    size,
+    ops: results,
+    memory: {
+      rssMb: +(mem.rss / 1024 / 1024).toFixed(1),
+      heapUsedMb: +(mem.heapUsed / 1024 / 1024).toFixed(1),
+    },
+  };
+}
+
+const { sizes, out } = parseArgs(process.argv.slice(2));
+
+const report = {
+  node: process.version,
+  platform: `${process.platform}-${process.arch}`,
+  // No timestamp: it would make every result file differ from the last even
+  // when nothing changed, which is noise in a committed baseline.
+  sizes: [],
+};
+
+for (const size of sizes) {
+  process.stderr.write(`benchmarking ${size} documents…\n`);
+  report.sizes.push(await benchSize(size));
+}
+
+// ── Report ──────────────────────────────────────────────────────────────────
+const opNames = [...new Set(report.sizes.flatMap((s) => Object.keys(s.ops)))];
+const pad = (s, n) => String(s).padEnd(n);
+const num = (v) => (v >= 100 ? v.toFixed(0) : v.toFixed(1));
+
+console.log(`\nContextNest engine benchmarks — ${report.platform}, Node ${report.node}\n`);
+console.log(
+  `${pad("operation", 26)}${report.sizes.map((s) => pad(`${s.size} docs`, 22)).join("")}`,
+);
+console.log("-".repeat(26 + report.sizes.length * 22));
+for (const op of opNames) {
+  const cells = report.sizes.map((s) => {
+    const r = s.ops[op];
+    if (!r) return pad("—", 22);
+    return pad(`${num(r.p95)}ms  ${num((r.p95 / s.size) * 1000)}µs/doc`, 22);
+  });
+  console.log(`${pad(op, 26)}${cells.join("")}`);
+}
+console.log(
+  `\n${pad("peak RSS", 26)}${report.sizes.map((s) => pad(`${s.memory.rssMb} MB`, 22)).join("")}`,
+);
+console.log("\np95 shown. µs/doc is the scaling signal: flat means linear.\n");
+
+if (out) {
+  await writeFile(out, `${JSON.stringify(report, null, 2)}\n`, "utf-8");
+  process.stderr.write(`wrote ${out}\n`);
+}

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -49,7 +49,10 @@
     "clean": "rm -rf dist",
     "test": "vitest run",
     "test:watch": "vitest",
-    "lint": "tsc --noEmit -p tsconfig.json"
+    "lint": "tsc --noEmit -p tsconfig.json",
+    "bench": "node bench/run.mjs",
+    "bench:check": "node bench/check.mjs",
+    "bench:profile": "node --cpu-prof --cpu-prof-dir=bench/profiles bench/run.mjs --sizes 1000"
   },
   "dependencies": {
     "diff": "^9.0.0",

--- a/packages/engine/src/__tests__/api-runtime.test.ts
+++ b/packages/engine/src/__tests__/api-runtime.test.ts
@@ -625,8 +625,16 @@ describe("createEngineApi — executable core operations", () => {
       "context_import",
       {
         files: [
-          // Status-less (a plain hand-authored note) → fair game to publish.
-          { path: "nodes/plain.md", content: "---\ntitle: Plain\ntype: document\n---\n\nbody\n" },
+          // Explicitly published by its author → the only thing that publishes.
+          {
+            path: "nodes/plain.md",
+            content: "---\ntitle: Plain\ntype: document\nstatus: published\n---\n\nbody\n",
+          },
+          // Status-less: saying nothing is not consent, so it is held.
+          {
+            path: "nodes/silent.md",
+            content: "---\ntitle: Silent\ntype: document\n---\n\nbody\n",
+          },
           // Explicitly not-yet-approved → must stay unpublished.
           {
             path: "nodes/wip.md",
@@ -649,18 +657,21 @@ describe("createEngineApi — executable core operations", () => {
       documents: Array<{ id: string; title: string; status: string; version: number }>;
     }>("context_import", { discover: true, author: "importer@test.com" }, ctx);
 
+    // Only the document whose author said "published" publishes.
     expect(out.published.map((p) => p.id)).toEqual(["nodes/plain"]);
     // Every scanned doc is reported, held ones included — the caller records
     // them all without re-reading the vault.
     expect(out.documents.map((d) => d.id).sort()).toEqual([
       "nodes/plain",
       "nodes/review",
+      "nodes/silent",
       "nodes/wip",
     ]);
     const byId = new Map(out.documents.map((d) => [d.id, d]));
     expect(byId.get("nodes/plain")!.status).toBe("published");
     expect(byId.get("nodes/wip")!.status).toBe("draft");
     expect(byId.get("nodes/review")!.status).toBe("draft");
+    expect(byId.get("nodes/silent")!.status).toBe("draft");
     // The author stamp rode along with the publish write — no second pass.
     const got = await api.run<{ frontmatter: { author?: string } }>(
       "context_get",
@@ -668,9 +679,115 @@ describe("createEngineApi — executable core operations", () => {
       ctx,
     );
     expect(got.frontmatter.author).toBe("importer@test.com");
+    // A held document is stamped too — it gets no publish write, so this pass
+    // is its only chance. A status-less file gets `draft` written down rather
+    // than left implied, and an author's own `pending_review` is not flattened.
+    const silent = await api.run<{ frontmatter: { author?: string; status?: string } }>(
+      "context_get",
+      { id: "nodes/silent" },
+      ctx,
+    );
+    expect(silent.frontmatter.author).toBe("importer@test.com");
+    expect(silent.frontmatter.status).toBe("draft");
+    const review = await api.run<{ frontmatter: { status?: string } }>(
+      "context_get",
+      { id: "nodes/review" },
+      ctx,
+    );
+    expect(review.frontmatter.status).toBe("pending_review");
     // One checkpoint for the whole discovered batch.
     const history = await ctx.storage.readCheckpointHistory();
     expect(history?.checkpoints).toHaveLength(1);
+  });
+
+  it("context_import discover honors an explicit status however it is written", async () => {
+    // The hold on not-yet-approved documents must survive ordinary frontmatter
+    // that is not the canonical one-value-per-line form. A trailing YAML
+    // comment used to defeat it: the document read as status-less and was
+    // published against its author's stated wishes.
+    const api = createEngineApi();
+    await api.run(
+      "context_import",
+      {
+        files: [
+          {
+            path: "nodes/commented.md",
+            content:
+              "---\ntitle: Commented\ntype: document\nstatus: draft  # not reviewed yet\n---\n\nbody\n",
+          },
+          {
+            path: "nodes/crlf.md",
+            content:
+              "---\r\ntitle: CRLF\r\ntype: document\r\nstatus: draft\r\n---\r\n\r\nbody\r\n",
+          },
+          {
+            path: "nodes/quoted.md",
+            content: `---\ntitle: Quoted\ntype: document\nstatus: 'pending_review'\n---\n\nbody\n`,
+          },
+          // Explicitly published, written with a trailing comment — the same
+          // parsing that must not lose a `draft` must not lose this either.
+          {
+            path: "nodes/live.md",
+            content:
+              "---\ntitle: Live\ntype: document\nstatus: published  # reviewed\n---\n\nbody\n",
+          },
+        ],
+        publish: false,
+      },
+      ctx,
+    );
+
+    const out = await api.run<{
+      published: Array<{ id: string }>;
+      documents: Array<{ id: string; status: string }>;
+    }>("context_import", { discover: true }, ctx);
+
+    expect(out.published.map((p) => p.id)).toEqual(["nodes/live"]);
+    const byId = new Map(out.documents.map((d) => [d.id, d.status]));
+    expect(byId.get("nodes/commented")).toBe("draft");
+    expect(byId.get("nodes/crlf")).toBe("draft");
+    expect(byId.get("nodes/quoted")).toBe("draft");
+    expect(byId.get("nodes/live")).toBe("published");
+  });
+
+  it("context_import discover does not stamp its author onto caller-staged documents", async () => {
+    // A single call may mix modes. Documents the caller staged itself carry
+    // frontmatter it chose deliberately, so the discover stamp must not reach
+    // them — only the ids the scan found.
+    const api = createEngineApi();
+    await ctx.storage.writeDocument(
+      "nodes/mine",
+      "---\ntitle: Mine\ntype: document\nauthor: original@author.com\nstatus: draft\n---\n\nbody\n",
+    );
+    await api.run(
+      "context_import",
+      {
+        files: [
+          { path: "nodes/found.md", content: "---\ntitle: Found\ntype: document\n---\n\nbody\n" },
+        ],
+        publish: false,
+      },
+      ctx,
+    );
+
+    await api.run(
+      "context_import",
+      { ids: ["nodes/mine"], discover: true, author: "importer@test.com" },
+      ctx,
+    );
+
+    const mine = await api.run<{ frontmatter: { author?: string } }>(
+      "context_get",
+      { id: "nodes/mine" },
+      ctx,
+    );
+    const found = await api.run<{ frontmatter: { author?: string } }>(
+      "context_get",
+      { id: "nodes/found" },
+      ctx,
+    );
+    expect(mine.frontmatter.author).toBe("original@author.com");
+    expect(found.frontmatter.author).toBe("importer@test.com");
   });
 
   it("context_import discover titles an untitled doc from its filename", async () => {

--- a/packages/engine/src/__tests__/api-runtime.test.ts
+++ b/packages/engine/src/__tests__/api-runtime.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { join } from "node:path";
-import { mkdtemp, rm } from "node:fs/promises";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtemp, rm, readFile } from "node:fs/promises";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { z } from "zod";
 import { NestStorage } from "../storage.js";
@@ -567,9 +567,156 @@ describe("createEngineApi — executable core operations", () => {
     expect(ticks.every(([, total]) => total === 4)).toBe(true);
   });
 
-  it("context_import rejects a call with neither documents nor ids", async () => {
+  it("context_import rejects a call with no input at all", async () => {
     const api = createEngineApi();
-    await expect(api.run("context_import", {}, ctx)).rejects.toThrow(/documents\[\] or ids\[\]/);
+    await expect(api.run("context_import", {}, ctx)).rejects.toThrow(
+      /documents\[\], ids\[\], files\[\] or discover/,
+    );
+  });
+
+  it("context_import writes files[] verbatim, version history and all", async () => {
+    const api = createEngineApi();
+    // A vault being imported carries its own frontmatter AND its version chain.
+    // Both must land byte-for-byte: a synthesized draft would drop the custom
+    // keys, and without .versions/ the chain can no longer reconstruct.
+    const doc =
+      "---\ntitle: Handbook\ntype: document\nversion: 3\ncustom_key: keep me\n---\n\nbody\n";
+    const history = "keyframe_interval: 10\nversions: []\n";
+    const out = await api.run<{
+      written: number;
+      published: unknown[];
+      checkpoint: number | null;
+    }>(
+      "context_import",
+      {
+        files: [
+          { path: "nodes/handbook.md", content: doc },
+          { path: "nodes/.versions/handbook/history.yaml", content: history },
+        ],
+        publish: false,
+      },
+      ctx,
+    );
+    expect(out.written).toBe(2);
+    // publish:false stages only — nothing published, no checkpoint sealed.
+    expect(out.published).toHaveLength(0);
+    expect(out.checkpoint).toBeNull();
+    expect(await readFile(join(dir, "nodes/handbook.md"), "utf-8")).toBe(doc);
+    expect(await readFile(join(dir, "nodes/.versions/handbook/history.yaml"), "utf-8")).toBe(
+      history,
+    );
+  });
+
+  it("context_import refuses a files[] path that escapes the vault", async () => {
+    const api = createEngineApi();
+    const out = await api.run<{ failed: Array<{ id?: string; error: string }> }>(
+      "context_import",
+      { files: [{ path: "../escaped.md", content: "nope" }], publish: false },
+      ctx,
+    );
+    expect(out.failed).toHaveLength(1);
+    expect(out.failed[0].id).toBe("../escaped.md");
+    expect(existsSync(join(dir, "..", "escaped.md"))).toBe(false);
+  });
+
+  it("context_import discover scans, stamps the author, and holds explicit drafts", async () => {
+    const api = createEngineApi();
+    await api.run(
+      "context_import",
+      {
+        files: [
+          // Status-less (a plain hand-authored note) → fair game to publish.
+          { path: "nodes/plain.md", content: "---\ntitle: Plain\ntype: document\n---\n\nbody\n" },
+          // Explicitly not-yet-approved → must stay unpublished.
+          {
+            path: "nodes/wip.md",
+            content: "---\ntitle: WIP\ntype: document\nstatus: draft\n---\n\nbody\n",
+          },
+          // An alias for pending_review — must not sneak past the hold either.
+          {
+            path: "nodes/review.md",
+            content: "---\ntitle: Review\ntype: document\nstatus: in_review\n---\n\nbody\n",
+          },
+        ],
+        publish: false,
+      },
+      ctx,
+    );
+
+    const out = await api.run<{
+      published: Array<{ id: string }>;
+      checkpoint: number | null;
+      documents: Array<{ id: string; title: string; status: string; version: number }>;
+    }>("context_import", { discover: true, author: "importer@test.com" }, ctx);
+
+    expect(out.published.map((p) => p.id)).toEqual(["nodes/plain"]);
+    // Every scanned doc is reported, held ones included — the caller records
+    // them all without re-reading the vault.
+    expect(out.documents.map((d) => d.id).sort()).toEqual([
+      "nodes/plain",
+      "nodes/review",
+      "nodes/wip",
+    ]);
+    const byId = new Map(out.documents.map((d) => [d.id, d]));
+    expect(byId.get("nodes/plain")!.status).toBe("published");
+    expect(byId.get("nodes/wip")!.status).toBe("draft");
+    expect(byId.get("nodes/review")!.status).toBe("draft");
+    // The author stamp rode along with the publish write — no second pass.
+    const got = await api.run<{ frontmatter: { author?: string } }>(
+      "context_get",
+      { id: "nodes/plain" },
+      ctx,
+    );
+    expect(got.frontmatter.author).toBe("importer@test.com");
+    // One checkpoint for the whole discovered batch.
+    const history = await ctx.storage.readCheckpointHistory();
+    expect(history?.checkpoints).toHaveLength(1);
+  });
+
+  it("context_import discover titles an untitled doc from its filename", async () => {
+    const api = createEngineApi();
+    await api.run(
+      "context_import",
+      {
+        files: [{ path: "nodes/no-title.md", content: "just a body, no frontmatter\n" }],
+        publish: false,
+      },
+      ctx,
+    );
+    const out = await api.run<{ documents: Array<{ id: string; title: string }> }>(
+      "context_import",
+      { discover: true },
+      ctx,
+    );
+    expect(out.documents.find((d) => d.id === "nodes/no-title")!.title).toBe("no-title");
+  });
+
+  it("context_import discover skips exclude_ids and no-ops on a re-run", async () => {
+    const api = createEngineApi();
+    await api.run(
+      "context_import",
+      {
+        files: [
+          { path: "nodes/a.md", content: "---\ntitle: A\ntype: document\n---\n\nbody\n" },
+          { path: "nodes/b.md", content: "---\ntitle: B\ntype: document\n---\n\nbody\n" },
+        ],
+        publish: false,
+      },
+      ctx,
+    );
+    const first = await api.run<{ documents: Array<{ id: string }> }>(
+      "context_import",
+      { discover: true, exclude_ids: ["nodes/a"] },
+      ctx,
+    );
+    expect(first.documents.map((d) => d.id)).toEqual(["nodes/b"]);
+    // Re-running with everything already imported is a no-op, not an error.
+    const second = await api.run<{
+      documents: Array<{ id: string }>;
+      checkpoint: number | null;
+    }>("context_import", { discover: true, exclude_ids: ["nodes/a", "nodes/b"] }, ctx);
+    expect(second.documents).toHaveLength(0);
+    expect(second.checkpoint).toBeNull();
   });
 
   it("normalizes tags to #-prefixed form on create (S7)", async () => {

--- a/packages/engine/src/api/core-executors.ts
+++ b/packages/engine/src/api/core-executors.ts
@@ -18,6 +18,7 @@ import {
   normalizeTags,
   normalizeStatus,
   isRejected,
+  explicitStatus,
 } from "../parser.js";
 import { normalizeDocumentId, assertSafeDocumentId } from "../storage.js";
 import { filterDocuments } from "../filters.js";
@@ -26,6 +27,7 @@ import { publishDocument, publishDocuments } from "../publish.js";
 import { VersionManager } from "../versioning.js";
 import { parseUri } from "../uri.js";
 import { ContextNestError, RejectedDocumentError } from "../errors.js";
+import { mapInBatches } from "../concurrency.js";
 import type { OperationContext, OperationExecutor } from "./context.js";
 
 /** Community/engine cap on graph traversal depth (community MAX_HOPS). */
@@ -607,6 +609,22 @@ const importDocs: OperationExecutor = async (ctx, input: any) => {
   // ids, and the caller owns their frontmatter. Nothing is rewritten here.
   const batch: string[] = [...(input.ids ?? [])];
 
+  // Stage 0: land an existing vault's files verbatim. Bounded-parallel because
+  // a vault may sit on a network mount where each write is a round trip, and a
+  // serial loop then costs one full latency per file.
+  const incoming: { path: string; content: string }[] = input.files ?? [];
+  let written = 0;
+  if (incoming.length > 0) {
+    await mapInBatches(incoming, async (f) => {
+      try {
+        await ctx.storage.writeVaultFile(f.path, f.content ?? "");
+        written++;
+      } catch (err) {
+        failed.push({ id: f.path, error: err instanceof Error ? err.message : String(err) });
+      }
+    });
+  }
+
   // Stage 1: write each new doc as a draft (exclusive → dup/invalid go to failed).
   for (const doc of input.documents ?? []) {
     try {
@@ -620,16 +638,43 @@ const importDocs: OperationExecutor = async (ctx, input: any) => {
     }
   }
 
+  // A staging call — files written, publishing deferred to the caller's final
+  // `discover` pass so a chunked upload seals ONE checkpoint, not one per chunk.
+  if (input.publish === false) {
+    return { published: [], failed, checkpoint: null, written };
+  }
+
+  // Stage 2 (discover): the vault itself is the input. The scan, the metadata
+  // stamp and the publish-vs-hold decision all live here so a folder importer
+  // does not have to walk the vault and rewrite every file before handing the
+  // ids back — that pass cost a second full round trip per document.
+  let held: ContextNode[] = [];
+  let scanned: ContextNode[] = [];
+  if (input.discover) {
+    const exclude = new Set<string>(input.exclude_ids ?? []);
+    for (const doc of await ctx.storage.discoverDocuments()) {
+      if (exclude.has(doc.id)) continue;
+      // Honor the source's own governance state: a file that EXPLICITLY says it
+      // is not published or approved stays unpublished. A status-less file (a
+      // plain Obsidian note) is fair game — see `explicitStatus`.
+      const status = explicitStatus(doc);
+      if (status && status !== "published" && status !== "approved") held.push(doc);
+      else scanned.push(doc);
+    }
+    batch.push(...scanned.map((d) => d.id));
+  }
+
   // An empty call is a caller bug, not an empty result — but a batch where every
-  // document failed to stage is a legitimate (fully-failed) result.
-  if (batch.length === 0 && failed.length === 0) {
+  // document failed to stage is a legitimate (fully-failed) result, and a
+  // `discover` over a folder with nothing new in it is simply done.
+  if (batch.length === 0 && failed.length === 0 && !input.discover && written === 0) {
     throw new ContextNestError(
-      "context_import requires documents[] or ids[]",
+      "context_import requires documents[], ids[], files[] or discover",
       "VALIDATION_FAILED",
     );
   }
 
-  // Stage 2: ONE bulk publish for both modes — one checkpoint + one index regen
+  // Stage 3: ONE bulk publish for every mode — one checkpoint + one index regen
   // for the whole batch (the O(N) path), instead of a checkpoint per document.
   let published: { id: string; version: number }[] = [];
   let checkpoint: number | null = null;
@@ -637,6 +682,16 @@ const importDocs: OperationExecutor = async (ctx, input: any) => {
     const result = await publishDocuments(ctx.storage, batch, {
       editedBy: ctx.actor ?? "engine",
       onProgress: ctx.onProgress,
+      // The importer's metadata rides along with the publish write instead of
+      // costing its own pass. Title falls back to the filename; the author is
+      // the importing user, since the source's own `author:` names someone who
+      // need not exist on this host.
+      frontmatter: input.discover
+        ? (node) => ({
+            title: node.frontmatter.title ?? node.id.split("/").pop() ?? node.id,
+            ...(input.author ? { author: input.author } : {}),
+          })
+        : undefined,
     });
     published = result.published.map((p) => ({ id: p.id, version: p.version }));
     checkpoint = result.checkpointNumber;
@@ -646,7 +701,34 @@ const importDocs: OperationExecutor = async (ctx, input: any) => {
     }
   }
 
-  return { published, failed, checkpoint };
+  if (!input.discover) {
+    return { published, failed, checkpoint, ...(incoming.length ? { written } : {}) };
+  }
+
+  // Stage 4 (discover): report every document the scan owned, published or not,
+  // so a governance layer can record the import without re-reading the vault.
+  // A doc that failed to publish is reported at its own version, not dropped —
+  // its imported history is intact and it simply stays a draft.
+  const publishedVersion = new Map(published.map((p) => [p.id, p.version]));
+  const asRecord = (doc: ContextNode) => {
+    const version = publishedVersion.get(doc.id);
+    const own = Number(doc.frontmatter.version);
+    return {
+      id: doc.id,
+      title: doc.frontmatter.title ?? doc.id.split("/").pop() ?? doc.id,
+      version: version ?? (Number.isInteger(own) && own > 0 ? own : 1),
+      status: version !== undefined ? ("published" as const) : ("draft" as const),
+      tags: normalizeTags(doc.frontmatter.tags) ?? [],
+      content: doc.body ?? "",
+    };
+  };
+  return {
+    published,
+    failed,
+    checkpoint,
+    ...(incoming.length ? { written } : {}),
+    documents: [...scanned, ...held].map(asRecord),
+  };
 };
 
 /** name → executor for the built-in `core` namespace. */

--- a/packages/engine/src/api/core-executors.ts
+++ b/packages/engine/src/api/core-executors.ts
@@ -652,17 +652,32 @@ const importDocs: OperationExecutor = async (ctx, input: any) => {
   let scanned: ContextNode[] = [];
   if (input.discover) {
     const exclude = new Set<string>(input.exclude_ids ?? []);
+    // Ids the caller supplied itself, via `ids` or staged from `documents`.
+    // The scan walks the whole vault, so it sees those documents too — but they
+    // are the caller's, already in the batch, and carry frontmatter it chose.
+    // Claiming them here would publish them under the scan's rules and stamp
+    // over the author it set.
+    const callerIds = new Set(batch);
     for (const doc of await ctx.storage.discoverDocuments()) {
-      if (exclude.has(doc.id)) continue;
-      // Honor the source's own governance state: a file that EXPLICITLY says it
-      // is not published or approved stays unpublished. A status-less file (a
-      // plain Obsidian note) is fair game — see `explicitStatus`.
+      if (exclude.has(doc.id) || callerIds.has(doc.id)) continue;
+      // Publishing is opt-in. Only a file that EXPLICITLY says it is published
+      // or approved gets published; everything else is held as a draft for a
+      // human to approve, including a file that states no status at all.
+      //
+      // Saying nothing is not consent. A vault of hand-authored notes carries
+      // no governance state, and importing it should not decide on the author's
+      // behalf that every note is fit to serve to an AI. Held is recoverable —
+      // approve what belongs — where published-by-default is not: the exposure
+      // has already happened by the time anyone reviews it.
       const status = explicitStatus(doc);
-      if (status && status !== "published" && status !== "approved") held.push(doc);
-      else scanned.push(doc);
+      if (status === "published" || status === "approved") scanned.push(doc);
+      else held.push(doc);
     }
     batch.push(...scanned.map((d) => d.id));
   }
+  // Which ids the scan claimed, so the metadata stamp below can leave a
+  // caller's own staged documents alone.
+  const discovered = new Set(scanned.map((d) => d.id));
 
   // An empty call is a caller bug, not an empty result — but a batch where every
   // document failed to stage is a legitimate (fully-failed) result, and a
@@ -686,11 +701,19 @@ const importDocs: OperationExecutor = async (ctx, input: any) => {
       // costing its own pass. Title falls back to the filename; the author is
       // the importing user, since the source's own `author:` names someone who
       // need not exist on this host.
-      frontmatter: input.discover
-        ? (node) => ({
-            title: node.frontmatter.title ?? node.id.split("/").pop() ?? node.id,
-            ...(input.author ? { author: input.author } : {}),
-          })
+      //
+      // Scoped to the ids the SCAN found. A single call may mix modes — nothing
+      // stops `discover` arriving alongside `ids`/`documents` — and a caller
+      // that staged its own documents chose their frontmatter deliberately.
+      // Stamping the whole batch would silently overwrite the author it set.
+      frontmatter: discovered.size
+        ? (node) =>
+            discovered.has(node.id)
+              ? {
+                  title: node.frontmatter.title ?? node.id.split("/").pop() ?? node.id,
+                  ...(input.author ? { author: input.author } : {}),
+                }
+              : null
         : undefined,
     });
     published = result.published.map((p) => ({ id: p.id, version: p.version }));
@@ -704,6 +727,43 @@ const importDocs: OperationExecutor = async (ctx, input: any) => {
   if (!input.discover) {
     return { published, failed, checkpoint, ...(incoming.length ? { written } : {}) };
   }
+
+  // Stage 3b: held documents never reach the publish write, so this is their
+  // only chance to be stamped. Two things must land.
+  //
+  // An explicit `status: draft` — a held document that states no status reads
+  // back as a draft in memory (the parser's default) but says nothing on disk,
+  // so anything reading the file itself, here or in another tool, is left to
+  // guess. Write the status down rather than leave it implied.
+  //
+  // And the importing user as `author`, for the same reason the publish path
+  // stamps it: the source vault's own `author:` names someone who need not
+  // exist on this host, and carrying it over invents a collaborator.
+  // This is the only write these documents get, so it is not extra work: it
+  // replaces the far heavier publish they used to receive. A document that
+  // already carries everything it needs is skipped outright, which makes a
+  // re-import of an already-stamped vault free.
+  await mapInBatches(held, async (doc) => {
+    const authored = explicitStatus(doc);
+    const stamp: Record<string, unknown> = {};
+
+    const title = doc.frontmatter.title ?? doc.id.split("/").pop() ?? doc.id;
+    if (doc.frontmatter.title !== title) stamp.title = title;
+    if (input.author && doc.frontmatter.author !== input.author) stamp.author = input.author;
+    // Only when the author stated nothing — an explicit `pending_review` or
+    // `rejected` is theirs to keep, not ours to flatten into `draft`.
+    if (authored === null) stamp.status = "draft";
+
+    if (Object.keys(stamp).length === 0) return;
+    try {
+      await ctx.storage.writeDocument(
+        doc.id,
+        serializeDocument({ ...doc, frontmatter: { ...doc.frontmatter, ...stamp } }),
+      );
+    } catch (err) {
+      failed.push({ id: doc.id, error: err instanceof Error ? err.message : String(err) });
+    }
+  });
 
   // Stage 4 (discover): report every document the scan owned, published or not,
   // so a governance layer can record the import without re-reading the vault.

--- a/packages/engine/src/api/core.ts
+++ b/packages/engine/src/api/core.ts
@@ -682,7 +682,7 @@ const importOp: OperationDescriptor = {
       .boolean()
       .optional()
       .describe(
-        "Import every document already in the vault: the engine scans, decides publish-vs-hold from each file's own frontmatter, and returns full per-document detail. For folder import, where the caller has written files in and does not want to scan or rewrite them itself.",
+        "Import every document already in the vault: the engine scans, decides publish-vs-hold from each file's own frontmatter, and returns full per-document detail. For folder import, where the caller has written files in and does not want to scan or rewrite them itself. Publishing is OPT-IN — only a document whose frontmatter explicitly says `published` or `approved` is published; everything else, including a document that states no status at all, is held as a draft for a human to approve.",
       ),
     exclude_ids: z
       .array(z.string())

--- a/packages/engine/src/api/core.ts
+++ b/packages/engine/src/api/core.ts
@@ -637,12 +637,21 @@ const importDoc = z.object({
   metadata: z.record(z.unknown()).optional().describe("Extra frontmatter metadata"),
 });
 
+/** One file from an existing vault, written in exactly as given. */
+const importFile = z.object({
+  path: z
+    .string()
+    .min(1)
+    .describe("Vault-relative path, e.g. `notes/api.md` or `notes/.versions/api/history.yaml`"),
+  content: z.string().describe("Full file contents, frontmatter included, written verbatim"),
+});
+
 const importOp: OperationDescriptor = {
   name: "context_import",
   namespace: "core",
   description:
-    "Bulk-publish many nodes in one pass (folder/batch import). Supply `documents` to create new nodes from title+content, and/or `ids` for nodes already written into the vault. Both modes share ONE checkpoint and ONE index regeneration for the whole batch; failures are reported per-document, never aborting the rest.",
-  // Both inputs are optional and validated in the executor rather than through
+    "Bulk-publish many nodes in one pass (folder/batch import). Supply `documents` to create new nodes from title+content, `ids` for nodes already written into the vault, `files` to write an existing vault's files in verbatim, and/or `discover` to let the engine find and publish everything already in the vault. Publishing modes share ONE checkpoint and ONE index regeneration for the whole batch; failures are reported per-document, never aborting the rest.",
+  // Every input is optional and validated in the executor rather than through
   // a refined union: `.refine()` produces a ZodEffects, which degrades to a
   // useless JSON Schema through zod-to-json-schema — and MCP publishes
   // `inputJsonSchema(op)` verbatim as the tool schema.
@@ -657,11 +666,39 @@ const importOp: OperationDescriptor = {
       .describe(
         "Ids of documents ALREADY written into the vault, published in the same batch. Ids are preserved as-is — use this when the files carry their own paths/frontmatter (folder import).",
       ),
+    files: z
+      .array(importFile)
+      .optional()
+      .describe(
+        "Files from an existing vault, written in verbatim at their own relative paths. Unlike `documents` nothing is synthesized: the source's frontmatter is preserved, and non-document files (`.versions/<doc>/history.yaml`) travel too, which is what lets an imported version chain still reconstruct.",
+      ),
+    publish: z
+      .boolean()
+      .optional()
+      .describe(
+        "Set false to write `files` without publishing them (default true). For an upload arriving in several batches: stage every batch, then make one final `discover` call so the whole import shares ONE checkpoint instead of one per batch.",
+      ),
+    discover: z
+      .boolean()
+      .optional()
+      .describe(
+        "Import every document already in the vault: the engine scans, decides publish-vs-hold from each file's own frontmatter, and returns full per-document detail. For folder import, where the caller has written files in and does not want to scan or rewrite them itself.",
+      ),
+    exclude_ids: z
+      .array(z.string())
+      .optional()
+      .describe("With `discover`: ids to leave alone (already imported on an earlier run)."),
+    author: z
+      .string()
+      .optional()
+      .describe(
+        "With `discover`: stamped as `author` on every imported document. The importing user, not the vault's own `author:` — which names someone who need not exist on this host.",
+      ),
   }),
   output: z.object({
     published: z.array(z.object({ id: z.string(), version: z.number().int().min(1) })),
-    // `title` identifies a failure from `documents`, `id` one from `ids` —
-    // exactly one is set per entry.
+    // `title` identifies a failure from `documents`, `id` one from `ids` or
+    // `files` — exactly one is set per entry.
     failed: z.array(
       z.object({
         id: z.string().optional(),
@@ -671,6 +708,25 @@ const importOp: OperationDescriptor = {
     ),
     /** The single checkpoint sealing the batch, or null if nothing published. */
     checkpoint: z.number().int().nullable(),
+    /** `files` only: how many were written in. */
+    written: z.number().int().optional(),
+    /**
+     * `discover` only: every document the scan took responsibility for,
+     * published or held back. Carries what a governance layer needs to record
+     * the import without re-reading the vault itself.
+     */
+    documents: z
+      .array(
+        z.object({
+          id: z.string(),
+          title: z.string(),
+          version: z.number().int().min(1),
+          status: z.enum(["published", "draft"]),
+          tags: z.array(z.string()),
+          content: z.string(),
+        }),
+      )
+      .optional(),
   }),
   errors: ["VALIDATION_FAILED"],
 };

--- a/packages/engine/src/parser.ts
+++ b/packages/engine/src/parser.ts
@@ -91,18 +91,28 @@ export function isRejected(node: ContextNode): boolean {
  *
  * `parseDocument` defaults a missing status to `draft`, so
  * `node.frontmatter.status` cannot tell an author's deliberate draft from a
- * status-less hand-authored file — the raw source is the only place that
- * distinction survives. Folder import needs it: a status-less file is fair game
- * to publish, an explicit `draft`/`pending_review` must stay unpublished.
- * Normalizing means aliases (`review`, `submitted`, `in_review`, …) collapse to
- * their canonical status, so an import cannot smuggle a not-yet-approved
- * document past that gate by spelling its status differently.
+ * status-less hand-authored file. Folder import needs that distinction: a
+ * status-less file is fair game to publish, an explicit `draft` or
+ * `pending_review` must stay unpublished. Aliases (`review`, `submitted`,
+ * `in_review`, …) are collapsed to their canonical status, so an import cannot
+ * smuggle a not-yet-approved document past the hold by spelling it differently.
+ *
+ * Reads what the YAML parser already produced (`authoredStatus`) rather than
+ * re-scanning the raw source. A second, hand-rolled frontmatter parse is a
+ * second thing to get wrong, and it was: `status: draft  # not reviewed` — an
+ * ordinary line js-yaml handles fine — did not match the pattern, so the
+ * document read as status-less and published against its author's wishes.
+ *
+ * A node built in memory has no `authoredStatus`, which reads as "not stated".
+ * That is the safe direction for every caller today: import only ever asks this
+ * about documents it parsed off disk.
  */
 export function explicitStatus(node: ContextNode): Status | null {
-  const fm = node.rawContent.match(/^---\r?\n([\s\S]*?)\r?\n---/);
-  if (!fm) return null;
-  const m = fm[1].match(/^status:[ \t]*["']?([A-Za-z_-]+)["']?[ \t]*$/m);
-  return m ? normalizeStatus(m[1]) : null;
+  const authored = node.authoredStatus;
+  if (authored === undefined || authored === null || authored.trim() === "") {
+    return null;
+  }
+  return normalizeStatus(authored);
 }
 
 /**
@@ -194,6 +204,15 @@ export function parseDocument(
     parsed.data.created_at = normalizeDateField(parsed.data.created_at);
   }
 
+  // Capture what the author wrote BEFORE the line below overwrites it. A
+  // missing status normalizes to `draft`, so this is the only point where an
+  // explicit draft and a status-less file are still distinguishable — see
+  // ContextNode.authoredStatus.
+  const authoredStatus =
+    parsed.data.status === undefined || parsed.data.status === null
+      ? null
+      : String(parsed.data.status);
+
   // Normalize status to canonical before downstream consumers see it.
   // Aliases (`cancelled`, `superseded`, `active`, …) and unknown values are
   // resolved here so zod validation, predicates, retrieval filters, and
@@ -214,6 +233,7 @@ export function parseDocument(
     frontmatter,
     body: parsed.content,
     rawContent: content,
+    authoredStatus,
   };
 }
 

--- a/packages/engine/src/parser.ts
+++ b/packages/engine/src/parser.ts
@@ -86,6 +86,26 @@ export function isRejected(node: ContextNode): boolean {
 }
 
 /**
+ * The EXPLICIT lifecycle status the source author wrote, canonicalized, or
+ * `null` when the frontmatter carried no `status:` at all.
+ *
+ * `parseDocument` defaults a missing status to `draft`, so
+ * `node.frontmatter.status` cannot tell an author's deliberate draft from a
+ * status-less hand-authored file — the raw source is the only place that
+ * distinction survives. Folder import needs it: a status-less file is fair game
+ * to publish, an explicit `draft`/`pending_review` must stay unpublished.
+ * Normalizing means aliases (`review`, `submitted`, `in_review`, …) collapse to
+ * their canonical status, so an import cannot smuggle a not-yet-approved
+ * document past that gate by spelling its status differently.
+ */
+export function explicitStatus(node: ContextNode): Status | null {
+  const fm = node.rawContent.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!fm) return null;
+  const m = fm[1].match(/^status:[ \t]*["']?([A-Za-z_-]+)["']?[ \t]*$/m);
+  return m ? normalizeStatus(m[1]) : null;
+}
+
+/**
  * @deprecated The `superseded` status was removed. `parseDocument` normalizes
  * legacy `superseded` values to `draft`, so this predicate always returns
  * `false` for parsed nodes. Use `isRejected` for the terminal-hide state.

--- a/packages/engine/src/publish.ts
+++ b/packages/engine/src/publish.ts
@@ -3,7 +3,7 @@
  * Ties together versioning, integrity, checkpoints, and index regeneration.
  */
 
-import type { ContextNode, VersionEntry } from "./types.js";
+import type { ContextNode, Frontmatter, VersionEntry } from "./types.js";
 import { NestStorage, assertSafeDocumentId } from "./storage.js";
 import { VersionManager } from "./versioning.js";
 import { CheckpointManager } from "./checkpoint.js";
@@ -118,6 +118,20 @@ export interface BulkPublishOptions extends PublishOptions {
    * concurrency > 1 docs finish out of input order, so only the count is
    * monotonic — it drives progress bars, not per-doc reporting. */
   onProgress?: (done: number, total: number) => void;
+  /**
+   * Frontmatter to merge into each document just before it is published.
+   *
+   * For importers that must stamp their own metadata (an `author` that is the
+   * importing user, a `title` fallback from the filename) onto every incoming
+   * file. Doing it here folds the stamp into the publish write; a caller doing
+   * it beforehand pays a SECOND full write pass over the vault, which on a
+   * network-backed mount is one extra round trip per document.
+   *
+   * Returning `null`/`undefined` leaves the document's frontmatter alone. The
+   * publish fields (`version`, `status`, `updated_at`, `checksum`) are applied
+   * after this and always win.
+   */
+  frontmatter?: (node: ContextNode) => Partial<Frontmatter> | null | undefined;
 }
 
 export interface BulkPublishResult {
@@ -177,6 +191,12 @@ export async function publishDocuments(
     try {
       let node = await storage.readDocument(docId);
       if (isRejected(node)) throw new RejectedDocumentError(docId);
+
+      // Importer metadata rides along with the publish write below rather than
+      // costing its own pass over the vault. Applied before the version bump so
+      // the publish fields still win.
+      const stamp = options.frontmatter?.(node);
+      if (stamp) node = { ...node, frontmatter: { ...node.frontmatter, ...stamp } };
 
       const versionManager = new VersionManager(storage);
       const existingHistory = await storage.readHistory(docId);

--- a/packages/engine/src/storage.ts
+++ b/packages/engine/src/storage.ts
@@ -4,7 +4,7 @@
  */
 
 import { readFile, writeFile, mkdir, open, stat, unlink, rm, rename } from "node:fs/promises";
-import { join, dirname, basename } from "node:path";
+import { join, dirname, basename, isAbsolute } from "node:path";
 import yaml from "js-yaml";
 import { globFiles } from "./glob.js";
 import { parseDocument } from "./parser.js";
@@ -558,6 +558,39 @@ export class NestStorage {
       }
       throw err;
     }
+  }
+
+  /**
+   * Write a file into the vault VERBATIM at a caller-given relative path.
+   *
+   * For ingesting an existing vault — a folder or archive a user is importing.
+   * Those bytes must land exactly as they arrived: the frontmatter is the
+   * source's own (`version`, `checksum`, custom keys a synthesized draft would
+   * drop), and not every file is a document — `.versions/<doc>/history.yaml`
+   * is what makes an imported version chain reconstruct at all. So this writes
+   * what it is given and parses nothing.
+   *
+   * Path safety is the whole risk surface here, since the path comes from
+   * outside: `..` and absolute paths are rejected so an import cannot write
+   * outside the vault root.
+   */
+  async writeVaultFile(relPath: string, content: string): Promise<void> {
+    const segments = String(relPath ?? "")
+      .split(/[/\\]/)
+      .filter(Boolean);
+    if (
+      segments.length === 0 ||
+      isAbsolute(relPath) ||
+      segments.some((seg) => seg === "..")
+    ) {
+      throw new ContextNestError(
+        `Invalid vault file path "${relPath}": must be a relative path inside the vault.`,
+        "INVALID_DOCUMENT_ID",
+      );
+    }
+    const filePath = join(this.root, ...segments);
+    await mkdir(dirname(filePath), { recursive: true });
+    await writeFile(filePath, content, "utf-8");
   }
 
   /**

--- a/packages/engine/src/types.ts
+++ b/packages/engine/src/types.ts
@@ -163,6 +163,22 @@ export interface ContextNode {
   /** Full raw file content */
   rawContent: string;
   /**
+   * The `status` the author actually wrote, before normalization, or `null`
+   * when the frontmatter carried no `status:` key at all.
+   *
+   * `frontmatter.status` cannot answer that question: a missing status is
+   * normalized to `draft`, so an author's deliberate draft is indistinguishable
+   * from a status-less hand-authored note once parsed. Folder import needs the
+   * distinction — a status-less file is fair game to publish, an explicit
+   * `draft`/`pending_review` must be held back. Read it through
+   * `explicitStatus()`, which canonicalizes aliases.
+   *
+   * Taken from the same YAML load that produces `frontmatter`, so it sees
+   * whatever the author wrote, however they wrote it. Only `parseDocument` sets
+   * it; nodes built in memory leave it undefined.
+   */
+  authoredStatus?: string | null;
+  /**
    * Set when live file bytes differ from the last-approved canonical content
    * (bridge-function-spec Story 3.1, hootie-inbox-spec §4.2). When present,
    * `frontmatter` and `body` reflect the approved state, NOT live bytes.


### PR DESCRIPTION
## Summary

Two pieces of Q2 hardening. The engine now performs a folder import end to end instead of leaving half of it to whoever calls it, and the engine's scaling behaviour is measured, published, and enforced in CI rather than being a matter of opinion.

## What changed

Bulk import gained three inputs: write an existing vault's files in verbatim, stage them without publishing, and let the engine discover and publish everything it finds. Together these mean a caller hands over files and gets back a finished import — it no longer scans the vault itself, rewrites every document to stamp its own metadata, or decides which documents are allowed to publish.

Verbatim means verbatim. A source vault's own frontmatter survives, and files that are not documents travel with it, so an imported version history still reconstructs. Documents an author marked as not-yet-approved stay unpublished, with status aliases resolved first so the distinction cannot be spelled around.

Alongside that, a benchmark suite over synthetic vaults of 100, 1,000 and 10,000 documents, with the results published in the README and a performance budget enforced on every pull request.

## Impact

Importing a folder previously cost two full passes over every document before publishing even began — on a network-backed vault that is two extra round trips per document. That is now one pass, with the metadata stamp folded into the publish write.

Measured result: **every operation scales linearly.** Per-document cost between 1,000 and 10,000 documents lands within 0.45×–1.15×, and memory tracks document count. The concern that the engine degrades as a vault grows does not survive measurement.

The one number worth attention is bulk import at roughly 108 seconds for 10,000 documents. Linear, but a heavy constant factor, since every document is published, versioned and hash-chained on the way in. That is the next optimisation target — constant factor, not scaling shape.

The CI budget asserts scaling shape rather than millisecond ceilings, because runners vary several-fold in speed: absolute ceilings tight enough to catch a real regression would flake constantly on a slow runner, and loose enough to survive one they would catch nothing. Every pull request runs the cheap sizes; the full sweep runs nightly.