### PR TITLE
fix(engine): separate remote timeout and auth failures from unreachability

### DIFF
--- a/packages/cli/src/remote.ts
+++ b/packages/cli/src/remote.ts
@@ -230,6 +230,13 @@ export async function remoteRead(
   });
 }
 
+/**
+ * NOT AVAILABLE against a Community-hosted nest (contextnest-community):
+ * that server registers no `context_verify` tool and has no equivalent to
+ * route to, so this fails with "Tool context_verify not found". Works against
+ * a catalog-bound OSS server (@promptowl/contextnest-mcp-server), which does
+ * expose the op.
+ */
 export async function remoteVerify(
   target: RemoteTarget,
   opts: { json?: boolean },
@@ -279,7 +286,13 @@ export async function remoteHistory(
     console.log(chalk.bold(`Version history for ${out.id}:\n`));
     for (const entry of out.versions) {
       const keyframe = entry.keyframe ? chalk.blue(" [keyframe]") : "";
-      const published = entry.published_at ? chalk.green(" published") : chalk.yellow(" draft");
+      // published_at is our own server's field; contextnest-community reports
+      // the same fact as `status`. Without the fallback every version of a
+      // Community-hosted node renders "draft".
+      const published =
+        entry.published_at || entry.status === "published"
+          ? chalk.green(" published")
+          : chalk.yellow(" draft");
       console.log(`  v${entry.version}${keyframe}${published}`);
       console.log(`    By: ${entry.edited_by} at ${entry.edited_at}`);
       if (entry.note) console.log(`    Note: ${entry.note}`);
@@ -374,6 +387,13 @@ export async function remoteUpdate(
   });
 }
 
+/**
+ * NOT AVAILABLE against a Community-hosted nest (contextnest-community):
+ * that server registers no `context_publish` tool — it publishes through
+ * steward review (`context_submit_review` → `context_approve`, which calls the
+ * engine's publish op server-side), so this fails with "Tool context_publish
+ * not found". Works against a catalog-bound OSS server, which exposes the op.
+ */
 export async function remotePublish(
   target: RemoteTarget,
   path: string | undefined,

--- a/packages/engine/src/__tests__/fixtures/stub-mcp-server.mjs
+++ b/packages/engine/src/__tests__/fixtures/stub-mcp-server.mjs
@@ -44,6 +44,31 @@ server.tool("context_list", "stub list — malformed error", {}, async () => ({
   isError: true,
 }));
 
+// Structured output in structuredContent only, with no text mirror.
+server.tool("context_resolve", "stub resolve — structuredContent only", {}, async () => ({
+  content: [],
+  structuredContent: { id: "nodes/a", title: "A" },
+}));
+
+// Nothing at all — no text, no structuredContent.
+server.tool("context_versions", "stub versions — empty payload", {}, async () => ({
+  content: [],
+}));
+
+// The contextnest-community shape: human-readable PROSE in the text block,
+// catalog payload in structuredContent. Parsing text first fails here.
+server.tool("context_import", "stub import — prose text + structuredContent", {}, async () => ({
+  content: [{ type: "text", text: "1 node(s):\n\n1. **A** [document]" }],
+  structuredContent: { documents: [{ id: "nodes/a", title: "A" }] },
+}));
+
+// Same shape on the error path: prose sentence + structured {code, message}.
+server.tool("context_reconstruct", "stub reconstruct — prose error + structured code", {}, async () => ({
+  content: [{ type: "text", text: "Node not found: nodes/ghost" }],
+  structuredContent: { code: "DOCUMENT_NOT_FOUND", message: "Node not found: nodes/ghost" },
+  isError: true,
+}));
+
 // Echo the received arguments back, to pin input passthrough.
 server.tool(
   "context_search",

--- a/packages/engine/src/__tests__/remote-nest.test.ts
+++ b/packages/engine/src/__tests__/remote-nest.test.ts
@@ -16,6 +16,8 @@ import { fileURLToPath } from "node:url";
 import {
   connectRemoteNest,
   RemoteUnreachableError,
+  RemoteTimeoutError,
+  RemoteAuthError,
   type RemoteNestConnection,
 } from "../remote-nest.js";
 import { ContextNestError } from "../errors.js";
@@ -207,6 +209,33 @@ describe("connectRemoteNest — against a live stub server", () => {
     expect((err as Error).message).toMatch(/non-JSON/i);
   });
 
+  it("quotes the offending payload so the error is diagnosable", async () => {
+    const err = await conn.run("context_query", { query: "#x" }).catch((e) => e);
+    expect((err as Error).message).toContain("this is not json");
+  });
+
+  it("prefers structuredContent over a prose text block (community shape)", async () => {
+    const out = await conn.run<{ documents: Array<{ id: string }> }>("context_import", {});
+    expect(out.documents[0].id).toBe("nodes/a");
+  });
+
+  it("reads the error code from structuredContent when the text is prose", async () => {
+    const err = await conn.run("context_reconstruct", {}).catch((e) => e);
+    expect((err as ContextNestError).code).toBe("DOCUMENT_NOT_FOUND");
+    expect((err as Error).message).toContain("nodes/ghost");
+  });
+
+  it("accepts structuredContent when the server sends no text mirror", async () => {
+    const out = await conn.run<{ id: string }>("context_resolve", {});
+    expect(out.id).toBe("nodes/a");
+  });
+
+  it("reports an empty payload as empty, not as unparseable text", async () => {
+    const err = await conn.run("context_versions", {}).catch((e) => e);
+    expect((err as ContextNestError).code).toBe("INTERNAL");
+    expect((err as Error).message).toContain("empty");
+  });
+
   it("an unknown tool surfaces as an error, not a hang", async () => {
     const err = await conn.run("context_never_registered", {}).catch((e) => e);
     expect(err).toBeInstanceOf(ContextNestError);
@@ -238,14 +267,77 @@ describe("connectRemoteNest — against a live stub server", () => {
   }, 30_000);
 });
 
+describe("connectRemoteNest — HTTP auth rejection", () => {
+  // 401/403 mean the server ANSWERED. Reporting that as "unreachable" sent
+  // people hunting for a network fault while the body already said why.
+  for (const status of [401, 403]) {
+    it(`an HTTP ${status} is an auth failure, not unreachability`, async () => {
+      const srv = createHttpServer((_req, res) => {
+        res.statusCode = status;
+        res.end(JSON.stringify({ error: "Missing or invalid credentials" }));
+      });
+      await new Promise<void>((resolve) => srv.listen(0, "127.0.0.1", resolve));
+      const port = (srv.address() as AddressInfo).port;
+      try {
+        const err = await connectRemoteNest(
+          "team",
+          {
+            transport: "http",
+            url: `http://127.0.0.1:${port}/mcp`,
+            auth: { bearer_env: "CN_TOK" },
+          },
+          { CN_TOK: "expired-token" },
+        ).catch((e) => e);
+
+        expect(err).toBeInstanceOf(RemoteAuthError);
+        expect(err).not.toBeInstanceOf(RemoteUnreachableError);
+        expect((err as ContextNestError).code).toBe("REMOTE_AUTH_FAILED");
+        // Names the env var to re-export, and keeps the server's own words.
+        expect((err as Error).message).toContain("CN_TOK");
+        expect((err as Error).message).toContain("Missing or invalid credentials");
+      } finally {
+        await new Promise<void>((resolve) => srv.close(() => resolve()));
+      }
+    }, 20_000);
+  }
+
+  it("a non-auth HTTP status stays unreachable (exit-3 contract unchanged)", async () => {
+    const srv = createHttpServer((_req, res) => {
+      res.statusCode = 503;
+      res.end();
+    });
+    await new Promise<void>((resolve) => srv.listen(0, "127.0.0.1", resolve));
+    const port = (srv.address() as AddressInfo).port;
+    try {
+      const err = await connectRemoteNest(
+        "team",
+        { transport: "http", url: `http://127.0.0.1:${port}/mcp` },
+        {},
+      ).catch((e) => e);
+      expect(err).toBeInstanceOf(RemoteUnreachableError);
+      expect((err as ContextNestError).code).toBe("REMOTE_UNREACHABLE");
+    } finally {
+      await new Promise<void>((resolve) => srv.close(() => resolve()));
+    }
+  }, 20_000);
+});
+
 describe("connectRemoteNest — per-call timeout", () => {
-  it("a call exceeding timeout_ms fails as RemoteUnreachableError", async () => {
+  it("a call exceeding timeout_ms is a timeout, NOT unreachability", async () => {
     // Generous connect budget (the same timeout guards connect), tiny enough
     // that the stub's 60s-sleeping tool trips it well within the test timeout.
     const conn = await connectRemoteNest("slow", stubSpec({ timeout_ms: 4000 }), process.env);
     try {
       const err = await conn.run("context_verify", {}).catch((e) => e);
-      expect(err).toBeInstanceOf(RemoteUnreachableError);
+      // The distinction the CLI's exit-code contract rides on: connect
+      // succeeded, so the request WAS delivered — a write may have landed.
+      // Calling this "unreachable" is what made a timed-out `ctx add` look
+      // like a no-op and collide with itself on retry.
+      expect(err).toBeInstanceOf(RemoteTimeoutError);
+      expect(err).not.toBeInstanceOf(RemoteUnreachableError);
+      expect((err as ContextNestError).code).toBe("REMOTE_TIMEOUT");
+      expect((err as Error).message).toMatch(/may already have been applied/i);
+      expect((err as Error).message).toContain("context_verify");
     } finally {
       await conn.close();
     }

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -214,7 +214,10 @@ export type {
 export {
   connectRemoteNest,
   RemoteUnreachableError,
+  RemoteTimeoutError,
+  RemoteAuthError,
   REMOTE_DEFAULT_TIMEOUT_MS,
+  REMOTE_HTTP_DEFAULT_TIMEOUT_MS,
 } from "./remote-nest.js";
 export type { RemoteNestConnection } from "./remote-nest.js";
 

--- a/packages/engine/src/remote-nest.ts
+++ b/packages/engine/src/remote-nest.ts
@@ -13,8 +13,28 @@
 import { ContextNestError } from "./errors.js";
 import type { RemoteNestSpec } from "./types.js";
 
-/** Default per-call timeout when the registry entry sets no timeout_ms. */
+/** Default per-call timeout for a stdio remote (a local spawn — fast or dead). */
 export const REMOTE_DEFAULT_TIMEOUT_MS = 10_000;
+
+/**
+ * Default for an HTTP remote. Higher than stdio because a scale-to-zero host
+ * (Cloud Run, Lambda, Fly) cold-starts on the first request: the nest is up and
+ * the write lands, but the response can take well past 10s. Under the stdio
+ * default that surfaced as a bogus "unreachable" on a write that had already
+ * been applied. Override per entry with `timeout_ms` in the registry.
+ */
+export const REMOTE_HTTP_DEFAULT_TIMEOUT_MS = 30_000;
+
+/** JSON-RPC code the MCP SDK raises when a request outlives its timeout. */
+const MCP_REQUEST_TIMEOUT_CODE = -32001;
+
+/**
+ * HTTP statuses meaning "the server answered, and rejected your credential".
+ * StreamableHTTPError carries the status in `.code`, colliding namespaces with
+ * the JSON-RPC codes above — both are read off `.code`, so order the checks by
+ * the negative/positive split rather than assuming one shape.
+ */
+const HTTP_AUTH_STATUSES = new Set([401, 403]);
 
 /**
  * Thrown when the remote endpoint cannot be reached (spawn failure, dead
@@ -30,6 +50,66 @@ export class RemoteUnreachableError extends ContextNestError {
     super(`Remote nest "${alias}" is unreachable — ${detail}`, "REMOTE_UNREACHABLE");
     this.name = "RemoteUnreachableError";
   }
+}
+
+/**
+ * Thrown when a call times out AFTER the connection was established.
+ *
+ * Deliberately NOT a RemoteUnreachableError: the handshake succeeded, so the
+ * request reached the nest and the client simply stopped waiting for the
+ * reply. For a write that means the outcome is UNKNOWN, not "nothing
+ * happened" — the nest may well have applied it. Carrying its own code keeps
+ * it off the CLI's exit-3 path, so plugin hooks skip an offline remote but
+ * never silently swallow a write that might have landed.
+ */
+export class RemoteTimeoutError extends ContextNestError {
+  constructor(
+    public readonly alias: string,
+    public readonly operation: string,
+    timeoutMs: number,
+  ) {
+    super(
+      `Remote nest "${alias}" did not answer ${operation} within ${timeoutMs}ms. ` +
+        `The request reached the nest, so if this was a write it may already have been applied — ` +
+        `check before retrying. Raise timeout_ms for "${alias}" in ~/.contextnest/config.yaml if this recurs.`,
+      "REMOTE_TIMEOUT",
+    );
+    this.name = "RemoteTimeoutError";
+  }
+}
+
+/**
+ * Thrown when the remote answers an HTTP 401/403 — the credential was missing,
+ * expired or wrong.
+ *
+ * NOT a RemoteUnreachableError: the server responded, promptly and on purpose.
+ * Filing an auth rejection under "unreachable" sent people hunting for a
+ * network fault while the server had already said "Missing or invalid
+ * credentials" in the detail string. It also keeps a dead key off the CLI's
+ * exit-3 path — a plugin hook that silently skips an expired credential would
+ * quietly stop syncing and never say so.
+ */
+export class RemoteAuthError extends ContextNestError {
+  constructor(
+    public readonly alias: string,
+    envVar: string | undefined,
+    detail: string,
+  ) {
+    const fix = envVar
+      ? `Check that ${envVar} is exported and still valid`
+      : `Remote "${alias}" has no auth configured — add an auth entry`;
+    super(
+      `Remote nest "${alias}" rejected the credential — ${detail}. ${fix} in ~/.contextnest/config.yaml.`,
+      "REMOTE_AUTH_FAILED",
+    );
+    this.name = "RemoteAuthError";
+  }
+}
+
+/** The env var a spec draws its credential from, for error messages. */
+function authEnvVar(spec: RemoteNestSpec): string | undefined {
+  if (spec.transport !== "http") return undefined;
+  return spec.auth?.bearer_env ?? spec.auth?.header_env;
 }
 
 /** A connected remote nest: run catalog operations, then close. */
@@ -81,7 +161,9 @@ export async function connectRemoteNest(
 ): Promise<RemoteNestConnection> {
   const { Client } = await import("@modelcontextprotocol/sdk/client/index.js");
   const client = new Client({ name: "contextnest-remote-client", version: "1.0.0" });
-  const timeout = spec.timeout_ms ?? REMOTE_DEFAULT_TIMEOUT_MS;
+  const timeout =
+    spec.timeout_ms ??
+    (spec.transport === "http" ? REMOTE_HTTP_DEFAULT_TIMEOUT_MS : REMOTE_DEFAULT_TIMEOUT_MS);
 
   try {
     if (spec.transport === "stdio") {
@@ -122,12 +204,20 @@ export async function connectRemoteNest(
     // A ContextNestError raised before any I/O (e.g. missing auth env var) is
     // a config problem, not connectivity — let it through untranslated.
     if (err instanceof ContextNestError) throw err;
+    // An HTTP 401/403 is the server answering, not failing to answer.
+    if (HTTP_AUTH_STATUSES.has((err as { code?: number })?.code as number)) {
+      throw new RemoteAuthError(alias, authEnvVar(spec), (err as Error)?.message ?? String(err));
+    }
     throw new RemoteUnreachableError(alias, (err as Error)?.message ?? String(err));
   }
 
   return {
     async run<T>(operation: string, input: Record<string, unknown>): Promise<T> {
-      let result: { content?: Array<{ type: string; text?: string }>; isError?: boolean };
+      let result: {
+        content?: Array<{ type: string; text?: string }>;
+        structuredContent?: unknown;
+        isError?: boolean;
+      };
       try {
         result = (await client.callTool(
           { name: operation, arguments: input },
@@ -135,34 +225,59 @@ export async function connectRemoteNest(
           { timeout },
         )) as typeof result;
       } catch (err) {
-        // A protocol-level failure mid-call (transport died, request timed
-        // out) is a connectivity problem, same as a failed connect.
+        // A timeout is NOT unreachability. Connect already succeeded, so the
+        // request was delivered and executed; only the reply went missing.
+        // Reporting it as "unreachable" told users nothing had happened when a
+        // node had in fact been created, and the retry then collided with it.
+        if ((err as { code?: number })?.code === MCP_REQUEST_TIMEOUT_CODE) {
+          throw new RemoteTimeoutError(alias, operation, timeout);
+        }
+        // A credential can expire mid-session, or a nest can scope a single op
+        // — same reasoning as on connect: the server answered.
+        if (HTTP_AUTH_STATUSES.has((err as { code?: number })?.code as number)) {
+          throw new RemoteAuthError(alias, authEnvVar(spec), (err as Error)?.message ?? String(err));
+        }
+        // Anything else mid-call (transport died, socket reset) is genuine
+        // connectivity loss, same as a failed connect.
         throw new RemoteUnreachableError(alias, (err as Error)?.message ?? String(err));
       }
       const text = (result.content ?? [])
         .map((c) => (c.type === "text" ? (c.text ?? "") : ""))
         .join("");
-      if (result.isError) {
-        // Catalog-bound servers return structured {code, message} JSON; map it
-        // back to a typed engine error. Anything else becomes INTERNAL.
+      // The catalog payload is `structuredContent` (MCP 2025-06-18). The text
+      // block is prose for chat clients and is NOT required to mirror it —
+      // contextnest-community sends a human-readable sentence there ("3
+      // node(s): …") next to the catalog JSON here, so parsing text first
+      // fails on every op against a Community-hosted nest. Prefer
+      // structuredContent whenever the server sends it; fall back to the text
+      // for servers that are text-only (our own MCP server still is).
+      let payload = result.structuredContent;
+      if (payload === undefined) {
         try {
-          const parsed = JSON.parse(text) as { code?: string; message?: string };
-          if (parsed && typeof parsed.message === "string") {
-            throw new ContextNestError(parsed.message, parsed.code ?? "INTERNAL");
-          }
-        } catch (err) {
-          if (err instanceof ContextNestError) throw err;
+          payload = JSON.parse(text) as unknown;
+        } catch {
+          payload = undefined;
+        }
+      }
+
+      if (result.isError) {
+        // Catalog-bound servers return a structured {code, message}; map it
+        // back to a typed engine error. Anything else becomes INTERNAL.
+        const structured = payload as { code?: string; message?: string } | undefined;
+        if (structured && typeof structured.message === "string") {
+          throw new ContextNestError(structured.message, structured.code ?? "INTERNAL");
         }
         throw new ContextNestError(text || `Remote operation ${operation} failed`, "INTERNAL");
       }
-      try {
-        return JSON.parse(text) as T;
-      } catch {
-        throw new ContextNestError(
-          `Remote operation ${operation} returned a non-JSON payload — is "${alias}" a ContextNest MCP endpoint?`,
-          "INTERNAL",
-        );
-      }
+
+      if (payload !== undefined) return payload as T;
+      // Quote what actually came back — without it this error is a dead end:
+      // prose, an HTML error page and an empty payload all look identical.
+      const got = text.trim() ? `got: ${text.trim().slice(0, 200)}` : "the payload was empty";
+      throw new ContextNestError(
+        `Remote operation ${operation} returned a non-JSON payload — is "${alias}" a ContextNest MCP endpoint? (${got})`,
+        "INTERNAL",
+      );
     },
     async close(): Promise<void> {
       try {


### PR DESCRIPTION
ClickUp: [wdqcpzzmdw](https://app.clickup.com/t/wdqcpzzmdw)

## Problem

`connectRemoteNest` collapsed three distinct failure modes into `RemoteUnreachableError`, and read tool results from the wrong field.

1. **Timeouts reported as unreachable.** A call that times out *after* a successful handshake was delivered and may have executed. Reporting it as "unreachable" told users nothing had happened when a node had in fact been created — the retry then collided with it.
2. **HTTP 401/403 reported as unreachable.** The server answered, promptly and on purpose. Filing it under "unreachable" sent people hunting for a network fault while the body already said `Missing or invalid credentials`. It also put a dead credential on the CLI's exit-3 path, where a plugin hook silently skips the remote and stops syncing without saying so.
3. **`structuredContent` ignored.** The catalog payload lives in `structuredContent` (MCP 2025-06-18); the text block is prose for chat clients and is not required to mirror it. `contextnest-community` sends a human-readable sentence there, so parsing text first failed on **every** op against a Community-hosted nest.
4. **10s default too low for HTTP.** A scale-to-zero host (Cloud Run, Lambda, Fly) cold-starts on the first request — the write lands, the reply arrives well past 10s.

## Changes

**`packages/engine/src/remote-nest.ts`**
- `RemoteTimeoutError` (`REMOTE_TIMEOUT`), deliberately *not* a subclass of `RemoteUnreachableError`. The message states the write may already have been applied and points at `timeout_ms`.
- `RemoteAuthError` (`REMOTE_AUTH_FAILED`) on HTTP 401/403, at both connect and mid-call (a credential can expire mid-session, or a nest can scope a single op). Names the env var to re-export and keeps the server's own detail string.
- `REMOTE_HTTP_DEFAULT_TIMEOUT_MS = 30_000` for HTTP transports; stdio keeps 10s.
- Prefer `structuredContent`, falling back to parsing the text block for text-only servers (our own MCP server still is). Same preference on the error path, so `{code, message}` maps back to a typed engine error even when the text is prose.
- The non-JSON payload error now quotes up to 200 chars of what came back, or says the payload was empty. Previously prose, an HTML error page and an empty response all produced the same dead-end message.

**`packages/engine/src/index.ts`** — export `RemoteTimeoutError`, `RemoteAuthError`, `REMOTE_HTTP_DEFAULT_TIMEOUT_MS`.

**`packages/cli/src/remote.ts`**
- `remoteHistory` falls back to `entry.status === "published"`; Community reports the same fact under `status`, so without it every version of a Community-hosted node rendered "draft".
- Doc comments on `remoteVerify` / `remotePublish` recording that neither op exists on a Community-hosted nest (Community publishes through steward review: `context_submit_review` → `context_approve`), so the failure is expected rather than a bug to re-diagnose.

## Exit-code contract

Unchanged. `packages/cli/src/index.ts:2794` exits 3 on the `REMOTE_UNREACHABLE` code string, so the two new codes fall through to the default error path — an offline remote is still skipped by plugin hooks, but a timed-out write or a dead credential now surfaces.

## Tests

`packages/engine/src/__tests__/remote-nest.test.ts` (25 passing) plus new tools on the stub server fixture:

- 401 and 403 → `RemoteAuthError`, asserted *not* `RemoteUnreachableError`
- 503 stays `RemoteUnreachableError` — pins the exit-3 contract
- Per-call timeout → `RemoteTimeoutError`, asserted *not* `RemoteUnreachableError`
- `structuredContent` preferred over a prose text block (the Community shape)
- Error code read from `structuredContent` when the text is prose
- `structuredContent` accepted with no text mirror at all
- Empty payload reported as empty rather than as unparseable text
- Non-JSON error quotes the offending payload

`pnpm lint` clean across all three packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
