### PR TITLE
feat(engine): stable error code for VaultLockTimeoutError + api catalog registration

### DIFF
--- a/packages/engine/src/__tests__/vault-lock.test.ts
+++ b/packages/engine/src/__tests__/vault-lock.test.ts
@@ -100,4 +100,10 @@ describe("withVaultLock", () => {
     // message names the remedy — the full 20s wait is not worth a test's time.
     expect(new VaultLockTimeoutError("/x").message).toMatch(/stale/i);
   });
+
+  it("carries a stable code for cross-package matching", () => {
+    // Consumers on the other side of a dual CJS/ESM build can't rely on
+    // instanceof; `code` (mirrored in api ERROR_CODES) is the contract.
+    expect(new VaultLockTimeoutError("/x").code).toBe("VAULT_LOCK_TIMEOUT");
+  });
 });

--- a/packages/engine/src/api/core.ts
+++ b/packages/engine/src/api/core.ts
@@ -321,7 +321,12 @@ const createOp: OperationDescriptor = {
       .nullable()
       .describe("Checkpoint sealing the publish, or null when created as a draft"),
   }),
-  errors: ["VALIDATION_FAILED", "INVALID_DOCUMENT_ID", "DOCUMENT_ALREADY_EXISTS"],
+  errors: [
+    "VALIDATION_FAILED",
+    "INVALID_DOCUMENT_ID",
+    "DOCUMENT_ALREADY_EXISTS",
+    "VAULT_LOCK_TIMEOUT",
+  ],
   aliases: ["create_document"],
 };
 
@@ -390,6 +395,7 @@ const updateOp: OperationDescriptor = {
     "DOCUMENT_NOT_FOUND",
     "INVALID_DOCUMENT_ID",
     "REJECTED_DOCUMENT",
+    "VAULT_LOCK_TIMEOUT",
   ],
   aliases: ["update_document"],
 };
@@ -420,6 +426,7 @@ const publishOp: OperationDescriptor = {
     "INVALID_DOCUMENT_ID",
     "INVALID_URI",
     "REJECTED_DOCUMENT",
+    "VAULT_LOCK_TIMEOUT",
   ],
   aliases: ["publish_document"],
 };
@@ -436,7 +443,13 @@ const deleteOp: OperationDescriptor = {
     title: z.string().describe("Title of the deleted node, read before removal"),
     deleted: z.literal(true),
   }),
-  errors: ["VALIDATION_FAILED", "DOCUMENT_NOT_FOUND", "INVALID_DOCUMENT_ID", "INVALID_URI"],
+  errors: [
+    "VALIDATION_FAILED",
+    "DOCUMENT_NOT_FOUND",
+    "INVALID_DOCUMENT_ID",
+    "INVALID_URI",
+    "VAULT_LOCK_TIMEOUT",
+  ],
   aliases: ["delete_document"],
 };
 
@@ -741,7 +754,7 @@ const importOp: OperationDescriptor = {
       )
       .optional(),
   }),
-  errors: ["VALIDATION_FAILED"],
+  errors: ["VALIDATION_FAILED", "VAULT_LOCK_TIMEOUT"],
 };
 
 /** All `core` namespace operations, in catalog order. */

--- a/packages/engine/src/api/types.ts
+++ b/packages/engine/src/api/types.ts
@@ -51,6 +51,9 @@ export const ERROR_CODES = [
   "REJECTED_DOCUMENT",
   "SUPERSEDED_DOCUMENT",
   "CONFIG_ERROR",
+  // vault write lock (vault-lock.ts) — retryable: a concurrent writer held
+  // the lock past the acquire timeout; the operation was not performed
+  "VAULT_LOCK_TIMEOUT",
   // operation-runtime codes
   "UNKNOWN_OPERATION",
   "NOT_IMPLEMENTED",

--- a/packages/engine/src/vault-lock.ts
+++ b/packages/engine/src/vault-lock.ts
@@ -49,6 +49,13 @@ const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
 /** Thrown when the lock cannot be acquired within ACQUIRE_TIMEOUT_MS. */
 export class VaultLockTimeoutError extends Error {
+  /**
+   * Stable discriminator for consumers matching across package boundaries
+   * (dual CJS/ESM builds break `instanceof`). Mirrored in the api module's
+   * ERROR_CODES so bindings can surface it as a typed, retryable error.
+   */
+  readonly code = "VAULT_LOCK_TIMEOUT";
+
   constructor(root: string) {
     super(
       `Could not acquire the write lock for vault at ${root} within ${ACQUIRE_TIMEOUT_MS}ms — ` +


### PR DESCRIPTION
Stacked on #78 (targets its branch so the error-code contract ships with the lock).

## Why

Community (and any other binding) must map the lock timeout to a **retryable** wire error — HTTP 503 + Retry-After on REST, a typed `structuredContent` code on MCP. Today `VaultLockTimeoutError` carries only a `name`, and `instanceof` is unreliable across a dual CJS/ESM package boundary. There is also no way for consumers to generate retry handling from the catalog: the lock's failure mode isn't declared anywhere in the api module.

## What

- `vault-lock.ts`: `VaultLockTimeoutError` gains `readonly code = "VAULT_LOCK_TIMEOUT"` — a stable discriminator for cross-package matching.
- `api/types.ts`: `VAULT_LOCK_TIMEOUT` registered in `ERROR_CODES` (own group, documented as retryable).
- `api/core.ts`: the code declared in `errors` on exactly the five mutating descriptors the lock wraps (`context_create/update/publish/delete/import`) — consumers can now generate typed retry handling from `op.errors`.
- `__tests__/vault-lock.test.ts`: pins the `code` property.

## Verification

- `packages/engine`: `tsc --noEmit` clean
- `vitest run src/__tests__/vault-lock.test.ts` — 7 passed
- `vitest run src/__tests__/api` — 96 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)