### PR TITLE
feat(engine): read one folder instead of the whole vault

### DIFF
--- a/.changeset/folder-scoped-discovery.md
+++ b/.changeset/folder-scoped-discovery.md
@@ -1,0 +1,13 @@
+---
+"@promptowl/contextnest-engine": minor
+---
+
+Folder-scoped discovery and folder listing.
+
+`context_list` and `NestStorage.discoverDocuments` accept `folder` (a path relative to the vault root, i.e. the id prefix) and `recursive`.
+
+New `context_folders` operation and `NestStorage.listFolders`: the vault's folders and their document counts, read from directory entries without opening a single document. Discovery's cost is parsing every markdown file it finds, so a caller that only needs the vault's shape — a navigable tree, a folder picker, per-folder counts — now pays none of it. Folders are read rather than inferred from the documents inside them, so a folder holding only subfolders still appears.
+
+This narrows the crawl rather than the result. Previously the only way to browse one folder was to read and parse every document in the vault and filter afterwards, which costs the same as not filtering — painful on a large vault, and worse on a network-backed mount where each document is a round trip. With `recursive: false` a folder's subfolders are never opened either, so a lazily-expanded document tree pays only for the level it is showing.
+
+The vault walk now also stops descending once no pattern can match any deeper, so existing callers with non-recursive patterns (e.g. `listSuggestionIds`) stop reading subtrees they were already discarding.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,9 +69,9 @@ Binaries `ctx` and `contextnest`, both from a single ~2k-line `src/index.ts` (co
 
 ### MCP Server (`@promptowl/contextnest-mcp-server`)
 
-35 tools over stdio, in three groups:
+36 tools over stdio, in three groups:
 
-- **Catalog-driven** (16, registered by looping over `listOperations("core")` — name, description and schema all come from the engine's operation catalog, so this surface cannot drift, and a new core op appears here automatically): `context_init`, `context_nests`, `context_get`, `context_list`, `context_search`, `context_query`, `context_resolve`, `context_versions`, `context_reconstruct`, `context_packs`, `context_verify`, `context_create`, `context_update`, `context_publish`, `context_delete`, `context_import`. **Add new tools here, not by hand.**
+- **Catalog-driven** (17, registered by looping over `listOperations("core")` — name, description and schema all come from the engine's operation catalog, so this surface cannot drift, and a new core op appears here automatically): `context_init`, `context_nests`, `context_get`, `context_list`, `context_folders`, `context_search`, `context_query`, `context_resolve`, `context_versions`, `context_reconstruct`, `context_packs`, `context_verify`, `context_create`, `context_update`, `context_publish`, `context_delete`, `context_import`. **Add new tools here, not by hand.**
 - **Hand-written, still current** (8): `document_format`, `read_index`, `read_pack`, `list_checkpoints`, `stage_drift_suggestion`, `list_suggestions`, `approve_suggestion`, `reject_suggestion`.
 - **Deprecated** (11, kept byte-identical for existing clients, removed in a future major): `vault_info`, `resolve`, `read_document`, `list_documents`, `search`, `verify_integrity`, `read_version`, `create_document`, `update_document`, `delete_document`, `publish_document`.
 

--- a/packages/engine/src/__tests__/folder-scoped-discovery.test.ts
+++ b/packages/engine/src/__tests__/folder-scoped-discovery.test.ts
@@ -89,6 +89,19 @@ describe("folder-scoped discovery", () => {
     expect(normalizeFolder("/nodes/gtm/")).toBe("nodes/gtm");
     expect(normalizeFolder("nodes\\gtm")).toBe("nodes/gtm");
     expect(normalizeFolder("")).toBe("");
+    // Empty segments collapse — an interior "//" would otherwise survive into
+    // the glob prefix and match nothing.
+    expect(normalizeFolder("nodes//gtm")).toBe("nodes/gtm");
+    expect(normalizeFolder("///")).toBe("");
+  });
+
+  it("normalizes a hostile run of separators in linear time", () => {
+    // Trimming with an anchored `\/+` retried at every position of the run,
+    // which is quadratic — a path like this is the cheap way to notice.
+    const hostile = "/".repeat(200_000) + "x";
+    const started = performance.now();
+    expect(normalizeFolder(hostile)).toBe("x");
+    expect(performance.now() - started).toBeLessThan(1000);
   });
 
   it("lists folders without opening a single document", async () => {

--- a/packages/engine/src/__tests__/folder-scoped-discovery.test.ts
+++ b/packages/engine/src/__tests__/folder-scoped-discovery.test.ts
@@ -158,6 +158,23 @@ describe("folder-scoped discovery", () => {
     expect(folders.find((f) => f.path === "nodes/gtm")!.count).toBe(1);
   });
 
+  it("declares the error code a rejected folder actually raises", async () => {
+    const api = createEngineApi();
+    // `folder` is a plain string to zod, so a traversal clears validation and
+    // is thrown by the normalizer instead. A consumer generating handling from
+    // `op.errors` only learns that if the descriptor says so.
+    for (const name of ["context_list", "context_folders"]) {
+      const raised = await api
+        .run(name, { folder: "../../etc" }, { storage } as any)
+        .then(() => null, (e: any) => e.code);
+      expect(raised, `${name} should reject a traversal`).toBe("INVALID_DOCUMENT_ID");
+      expect(
+        api.getOperation(name)!.errors,
+        `${name} does not declare the code it raises`,
+      ).toContain(raised);
+    }
+  });
+
   it("exposes folder listing through context_folders", async () => {
     const api = createEngineApi();
     const res = await api.run<{ folders: { path: string; count: number }[] }>(

--- a/packages/engine/src/__tests__/folder-scoped-discovery.test.ts
+++ b/packages/engine/src/__tests__/folder-scoped-discovery.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { NestStorage, normalizeFolder } from "../storage.js";
+import { maxMatchDepth } from "../glob.js";
+import { createEngineApi } from "../api/index.js";
+import { ContextNestError } from "../errors.js";
+
+/**
+ * Folder-scoped discovery narrows the CRAWL, not just the returned list — a
+ * caller browsing one folder of a large vault must not read the rest of it.
+ * Filtering a whole-vault listing afterwards costs exactly as much as not
+ * filtering it, which is the reason this option exists at all.
+ */
+describe("folder-scoped discovery", () => {
+  let root: string;
+  let storage: NestStorage;
+
+  const doc = (title: string) =>
+    `---\ntitle: ${title}\ntype: document\nstatus: published\n---\n\nbody\n`;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "ctxnest-folderscope-"));
+    for (const [path, title] of [
+      ["nodes/root-one.md", "Root One"],
+      ["nodes/gtm/gtm-one.md", "Gtm One"],
+      ["nodes/gtm/deals/deal-one.md", "Deal One"],
+      ["nodes/gtm/deals/deal-two.md", "Deal Two"],
+      ["nodes/eng/eng-one.md", "Eng One"],
+    ] as [string, string][]) {
+      await mkdir(join(root, path, ".."), { recursive: true });
+      await writeFile(join(root, path), doc(title), "utf-8");
+    }
+    storage = new NestStorage(root);
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  const ids = (nodes: { id: string }[]) => nodes.map((n) => n.id).sort();
+
+  it("reads one folder's subtree and nothing outside it", async () => {
+    expect(ids(await storage.discoverDocuments({ folder: "nodes/gtm" }))).toEqual([
+      "nodes/gtm/deals/deal-one",
+      "nodes/gtm/deals/deal-two",
+      "nodes/gtm/gtm-one",
+    ]);
+  });
+
+  it("reads one level only when recursive is false", async () => {
+    expect(
+      ids(await storage.discoverDocuments({ folder: "nodes/gtm", recursive: false })),
+    ).toEqual(["nodes/gtm/gtm-one"]);
+
+    // The nest root as a level of its own: its own documents, no subfolders.
+    expect(
+      ids(await storage.discoverDocuments({ folder: "nodes", recursive: false })),
+    ).toEqual(["nodes/root-one"]);
+  });
+
+  it("stops descending when no pattern can match deeper", () => {
+    // The actual saving: `nodes/gtm/*.md` cannot match anything below
+    // nodes/gtm, so the walk must not open nodes/gtm/deals to find that out.
+    expect(maxMatchDepth(["nodes/gtm/*.md"])).toBe(3);
+    expect(maxMatchDepth(["*.md"])).toBe(1);
+    // A `**` anywhere spans arbitrarily many directories, so the walk is full.
+    expect(maxMatchDepth(["nodes/gtm/**/*.md"])).toBe(Infinity);
+    expect(maxMatchDepth(["*.md", "nodes/**/*.md"])).toBe(Infinity);
+  });
+
+  it("leaves an unscoped crawl exactly as it was", async () => {
+    expect(ids(await storage.discoverDocuments())).toEqual([
+      "nodes/eng/eng-one",
+      "nodes/gtm/deals/deal-one",
+      "nodes/gtm/deals/deal-two",
+      "nodes/gtm/gtm-one",
+      "nodes/root-one",
+    ]);
+  });
+
+  it("refuses a folder that would escape the vault root", () => {
+    // The folder is joined against the root to start the crawl, so traversal
+    // would read outside the vault entirely.
+    expect(() => normalizeFolder("../../etc")).toThrow(ContextNestError);
+    expect(() => normalizeFolder("nodes/../../etc")).toThrow(/traversal/);
+    // Surrounding slashes and either separator are just noise, not an escape.
+    expect(normalizeFolder("/nodes/gtm/")).toBe("nodes/gtm");
+    expect(normalizeFolder("nodes\\gtm")).toBe("nodes/gtm");
+    expect(normalizeFolder("")).toBe("");
+  });
+
+  it("lists folders without opening a single document", async () => {
+    // A folder holding nothing but subfolders, and one holding nothing at all.
+    await mkdir(join(root, "nodes/empty/deep"), { recursive: true });
+    await writeFile(join(root, "nodes/empty/deep/x.md"), doc("X"), "utf-8");
+
+    const opened: string[] = [];
+    const readDocument = storage.readDocument.bind(storage);
+    storage.readDocument = async (id: string, o?: any) => {
+      opened.push(id);
+      return readDocument(id, o);
+    };
+
+    expect(await storage.listFolders()).toEqual([
+      { path: "nodes", count: 1 },
+      { path: "nodes/empty", count: 0 },
+      { path: "nodes/empty/deep", count: 1 },
+      { path: "nodes/eng", count: 1 },
+      { path: "nodes/gtm", count: 1 },
+      { path: "nodes/gtm/deals", count: 2 },
+    ]);
+    expect(opened).toEqual([]);
+  });
+
+  it("lists immediate children only when recursive is false", async () => {
+    await mkdir(join(root, "nodes/empty/deep"), { recursive: true });
+    await writeFile(join(root, "nodes/empty/deep/x.md"), doc("X"), "utf-8");
+
+    // `nodes/empty` holds no document of its own, but inferring folders from
+    // the documents inside them would drop it and leave the tree unnavigable.
+    expect(await storage.listFolders({ folder: "nodes", recursive: false })).toEqual([
+      { path: "nodes/empty", count: 0 },
+      { path: "nodes/eng", count: 1 },
+      { path: "nodes/gtm", count: 1 },
+    ]);
+  });
+
+  it("skips version, suggestion and scaffold directories", async () => {
+    await mkdir(join(root, "nodes/.versions/root-one"), { recursive: true });
+    await writeFile(join(root, "nodes/.versions/root-one/v1.md"), "x", "utf-8");
+    await mkdir(join(root, "nodes/_suggestions/root-one"), { recursive: true });
+    await writeFile(join(root, "nodes/_suggestions/root-one/s.md"), "x", "utf-8");
+    // Generated indexes are not documents, so they must not inflate a count.
+    await writeFile(join(root, "nodes/gtm/INDEX.md"), "x", "utf-8");
+
+    const folders = await storage.listFolders();
+    expect(folders.map((f) => f.path)).toEqual([
+      "nodes",
+      "nodes/eng",
+      "nodes/gtm",
+      "nodes/gtm/deals",
+    ]);
+    expect(folders.find((f) => f.path === "nodes/gtm")!.count).toBe(1);
+  });
+
+  it("exposes folder listing through context_folders", async () => {
+    const api = createEngineApi();
+    const res = await api.run<{ folders: { path: string; count: number }[] }>(
+      "context_folders",
+      { folder: "nodes/gtm" },
+      { storage } as any,
+    );
+    expect(res.folders).toEqual([{ path: "nodes/gtm/deals", count: 2 }]);
+  });
+
+  it("exposes the scope through context_list", async () => {
+    const api = createEngineApi();
+    const ctx = { storage } as any;
+
+    const level = await api.run<{ documents: { id: string }[] }>(
+      "context_list",
+      { folder: "nodes/gtm", recursive: false },
+      ctx,
+    );
+    expect(ids(level.documents)).toEqual(["nodes/gtm/gtm-one"]);
+
+    // Still composes with the ordinary filters.
+    const subtree = await api.run<{ documents: { id: string }[] }>(
+      "context_list",
+      { folder: "nodes/gtm", limit: 2 },
+      ctx,
+    );
+    expect(subtree.documents.length).toBe(2);
+  });
+});

--- a/packages/engine/src/api/core-executors.ts
+++ b/packages/engine/src/api/core-executors.ts
@@ -264,9 +264,26 @@ const list: OperationExecutor = async (ctx, input: any) => {
   // includeRetired, or `status: "rejected"` matches nothing: discovery drops
   // retired documents before the filter ever sees them. filterDocuments hides
   // them again whenever no status was asked for.
-  const docs = await ctx.storage.discoverDocuments({ includeRetired: true });
+  // `folder` goes to discovery, not to filterDocuments: it decides which files
+  // are read at all, so narrowing afterwards would save nothing.
+  const docs = await ctx.storage.discoverDocuments({
+    includeRetired: true,
+    ...(input.folder !== undefined ? { folder: input.folder } : {}),
+    ...(input.recursive !== undefined ? { recursive: input.recursive } : {}),
+  });
   const kept = filterDocuments(docs, { ...input, includeRetired: input.include_retired });
   return { documents: kept.map((d) => toSummary(d, input.full === true, input.full === true)) };
+};
+
+const folders: OperationExecutor = async (ctx, input: any) => {
+  // Reads directory entries only — the shape of the vault is answerable
+  // without opening a single document.
+  return {
+    folders: await ctx.storage.listFolders({
+      ...(input?.folder !== undefined ? { folder: input.folder } : {}),
+      ...(input?.recursive !== undefined ? { recursive: input.recursive } : {}),
+    }),
+  };
 };
 
 /**
@@ -802,6 +819,7 @@ export const CORE_EXECUTORS: Readonly<Record<string, OperationExecutor>> = Objec
   context_search: search,
   context_get: get,
   context_list: list,
+  context_folders: folders,
   context_create: create,
   context_update: update,
   context_publish: publish,

--- a/packages/engine/src/api/core.ts
+++ b/packages/engine/src/api/core.ts
@@ -220,7 +220,8 @@ const getOp: OperationDescriptor = {
 const listOp: OperationDescriptor = {
   name: "context_list",
   namespace: "core",
-  description: "Browse vault contents with optional type, tag, status, or limit filters.",
+  description:
+    "Browse vault contents with optional folder, type, tag, status, or limit filters.",
   input: z.object({
     // An array as well as a single value: callers that browse a family of types
     // (every runnable type, say) would otherwise have to list, then re-filter.
@@ -236,6 +237,20 @@ const listOp: OperationDescriptor = {
       .optional()
       .describe("Filter by status (aliases normalized). Retired nodes are hidden unless asked for."),
     limit: z.number().int().positive().optional().describe("Max nodes to return"),
+    // Narrows the CRAWL, not just the result. Filtering a whole-vault listing
+    // down to one folder costs exactly as much as not filtering it.
+    folder: z
+      .string()
+      .optional()
+      .describe(
+        'Read only this folder, as a path relative to the vault root — the id prefix ("nodes/gtm", not "gtm"). Empty string means the vault root itself.',
+      ),
+    recursive: z
+      .boolean()
+      .optional()
+      .describe(
+        "With `folder`: include subfolders (default true). Pass false for one level only, so nested folders are never read.",
+      ),
     include_retired: z
       .boolean()
       .optional()
@@ -254,6 +269,42 @@ const listOp: OperationDescriptor = {
   }),
   errors: ["VALIDATION_FAILED"],
   aliases: ["list_documents"],
+};
+
+// ─── context_folders ─────────────────────────────────────────────────────────
+
+const foldersOp: OperationDescriptor = {
+  name: "context_folders",
+  namespace: "core",
+  description:
+    "List the vault's folders and their document counts, without reading any document.",
+  input: z.object({
+    folder: z
+      .string()
+      .optional()
+      .describe(
+        'List folders under this one, as a path relative to the vault root — the id prefix ("nodes/gtm", not "gtm"). Omit for the whole vault.',
+      ),
+    recursive: z
+      .boolean()
+      .optional()
+      .describe(
+        "Include nested folders (default true). Pass false for the immediate children only.",
+      ),
+  }),
+  output: z.object({
+    folders: z.array(
+      z.object({
+        path: z.string().describe("Path relative to the vault root"),
+        count: z
+          .number()
+          .int()
+          .describe("Documents directly in this folder, excluding its subfolders"),
+      }),
+    ),
+  }),
+  errors: ["VALIDATION_FAILED"],
+  aliases: ["list_folders"],
 };
 
 // ─── context_create ──────────────────────────────────────────────────────────
@@ -750,6 +801,7 @@ export const CORE_OPERATIONS: readonly OperationDescriptor[] = [
   queryOp,
   resolveOp,
   listOp,
+  foldersOp,
   searchOp,
   createOp,
   updateOp,

--- a/packages/engine/src/api/core.ts
+++ b/packages/engine/src/api/core.ts
@@ -303,8 +303,9 @@ const foldersOp: OperationDescriptor = {
       }),
     ),
   }),
+  // No alias: aliases are a migration path off tool names that already
+  // existed in the wild, and nothing ever called this one.
   errors: ["VALIDATION_FAILED"],
-  aliases: ["list_folders"],
 };
 
 // ─── context_create ──────────────────────────────────────────────────────────

--- a/packages/engine/src/api/core.ts
+++ b/packages/engine/src/api/core.ts
@@ -267,7 +267,10 @@ const listOp: OperationDescriptor = {
   output: z.object({
     documents: z.array(nodeSummary),
   }),
-  errors: ["VALIDATION_FAILED"],
+  // `folder` is a free-form string to zod, so a `..` in it clears validation
+  // and is rejected by the folder normalizer instead — a consumer generating
+  // handling from this list has to know that code can arrive.
+  errors: ["VALIDATION_FAILED", "INVALID_DOCUMENT_ID"],
   aliases: ["list_documents"],
 };
 
@@ -305,7 +308,8 @@ const foldersOp: OperationDescriptor = {
   }),
   // No alias: aliases are a migration path off tool names that already
   // existed in the wild, and nothing ever called this one.
-  errors: ["VALIDATION_FAILED"],
+  // INVALID_DOCUMENT_ID for the same reason as context_list — see there.
+  errors: ["VALIDATION_FAILED", "INVALID_DOCUMENT_ID"],
 };
 
 // ─── context_create ──────────────────────────────────────────────────────────

--- a/packages/engine/src/glob.ts
+++ b/packages/engine/src/glob.ts
@@ -45,10 +45,14 @@ function globToRegExp(pattern: string, dot: boolean): RegExp {
  * must survive a single permission-denied subdirectory (this is what
  * fast-glob's `suppressErrors` bought us).
  */
-async function walkFiles(root: string, base: string): Promise<string[]> {
+async function walkFiles(
+  root: string,
+  base: string,
+  maxDepth = Infinity,
+): Promise<string[]> {
   const files: string[] = [];
 
-  async function walk(dir: string, prefix: string): Promise<void> {
+  async function walk(dir: string, prefix: string, depth: number): Promise<void> {
     let entries;
     try {
       entries = await readdir(dir, { withFileTypes: true });
@@ -60,15 +64,37 @@ async function walkFiles(root: string, base: string): Promise<string[]> {
       if (entry.isDirectory()) {
         // Never a knowledge node, and descending is pure cost.
         if (entry.name === "node_modules") continue;
-        await walk(join(dir, entry.name), rel);
+        // Files inside this directory sit at depth + 2; if no pattern can
+        // match that deep, reading it is pure cost too.
+        if (depth + 1 < maxDepth) await walk(join(dir, entry.name), rel, depth + 1);
       } else if (entry.isFile()) {
         files.push(rel);
       }
     }
   }
 
-  await walk(base ? join(root, base) : root, base);
+  const baseDepth = base ? base.split("/").length : 0;
+  await walk(base ? join(root, base) : root, base, baseDepth);
   return files;
+}
+
+/**
+ * How many path segments the deepest match can have, or Infinity when any
+ * pattern contains `**` and so spans arbitrarily many directories.
+ *
+ * A pattern without `**` matches a fixed number of segments, so the walk can
+ * stop descending instead of reading a subtree it must then throw away —
+ * which is what makes a single-folder listing cheap rather than merely
+ * narrow. Exported for tests: like sharedBase, the pruning is observable
+ * only in how much of the tree was read.
+ */
+export function maxMatchDepth(patterns: string[]): number {
+  let deepest = 0;
+  for (const pattern of patterns) {
+    if (pattern.includes("**")) return Infinity;
+    deepest = Math.max(deepest, pattern.split("/").length);
+  }
+  return deepest;
 }
 
 /**
@@ -122,9 +148,10 @@ export async function globFiles(
   // Ignores always see dotted paths, so an exclusion cannot be dodged by one.
   const exclude = ignore.map((p) => globToRegExp(p, true));
 
-  // Descend only into the subtree the patterns can match. Paths still come back
-  // relative to `cwd`, so patterns and ignores are unaffected by the narrowing.
-  const files = await walkFiles(cwd, sharedBase(list));
+  // Descend only into the subtree the patterns can match, and no deeper than
+  // they can reach. Paths still come back relative to `cwd`, so patterns and
+  // ignores are unaffected by the narrowing.
+  const files = await walkFiles(cwd, sharedBase(list), maxMatchDepth(list));
   return files.filter(
     (file) =>
       include.some((re) => re.test(file)) && !exclude.some((re) => re.test(file)),

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -222,8 +222,13 @@ export {
 export type { RemoteNestConnection } from "./remote-nest.js";
 
 // Storage
-export { NestStorage, UNSTAGED_DRIFT_SENTINEL, normalizeDocumentId } from "./storage.js";
-export type { LayoutMode, ReadDocumentOptions } from "./storage.js";
+export {
+  NestStorage,
+  UNSTAGED_DRIFT_SENTINEL,
+  normalizeDocumentId,
+  normalizeFolder,
+} from "./storage.js";
+export type { LayoutMode, ReadDocumentOptions, FolderEntry } from "./storage.js";
 
 // Document filtering — shared by context_list and by surfaces that filter a
 // document list they already hold.

--- a/packages/engine/src/storage.ts
+++ b/packages/engine/src/storage.ts
@@ -3,7 +3,17 @@
  * Supports both structured and Obsidian-compatible layouts (§1.1).
  */
 
-import { readFile, writeFile, mkdir, open, stat, unlink, rm, rename } from "node:fs/promises";
+import {
+  readFile,
+  readdir,
+  writeFile,
+  mkdir,
+  open,
+  stat,
+  unlink,
+  rm,
+  rename,
+} from "node:fs/promises";
 import { join, dirname, basename, isAbsolute } from "node:path";
 import yaml from "js-yaml";
 import { globFiles } from "./glob.js";
@@ -99,6 +109,59 @@ export function assertSafeDocumentId(raw: string): void {
       "INVALID_DOCUMENT_ID",
     );
   }
+}
+
+/**
+ * Normalize a folder path used to scope discovery: strips surrounding slashes,
+ * accepts either separator, and rejects `..` — the path is joined against the
+ * vault root to start the crawl, so a traversal sequence would read outside it.
+ *
+ * `""` is the vault root, which is why this cannot reuse `assertSafeDocumentId`
+ * (that requires every segment to name something).
+ */
+export function normalizeFolder(raw: string): string {
+  const trimmed = raw.replace(/\\/g, "/").replace(/^\/+|\/+$/g, "");
+  if (trimmed.split("/").some((seg) => seg === "..")) {
+    throw new ContextNestError(
+      `Invalid folder "${raw}": path traversal ("..") is not allowed.`,
+      "INVALID_DOCUMENT_ID",
+    );
+  }
+  return trimmed;
+}
+
+/**
+ * Markdown that lives in the vault but is not a knowledge node: version
+ * artifacts, generated indexes, agent-config scaffold. Shared by document
+ * discovery and folder listing so the two can never disagree about which files
+ * count — a folder holding only these is not a folder of documents.
+ */
+const NON_DOCUMENT_BASENAMES = new Set([
+  "INDEX.md",
+  // Agent-config / scaffold files are not knowledge nodes.
+  "CLAUDE.md",
+  "GEMINI.md",
+  "AGENTS.md",
+  "README.md",
+]);
+
+const NON_DOCUMENT_FILES = [
+  "**/node_modules/**",
+  "**/.versions/**",
+  "**/.context/**",
+  // Root-only, unlike the basenames below: a CONTEXT.md nested in a folder is
+  // an authored document, the one at the vault root is the vault's preamble.
+  "CONTEXT.md",
+  "context.yaml",
+  ...[...NON_DOCUMENT_BASENAMES].map((name) => `**/${name}`),
+];
+
+/** A folder of documents, and how many sit directly in it. */
+export interface FolderEntry {
+  /** Path relative to the vault root — the id prefix, e.g. `nodes/gtm`. */
+  path: string;
+  /** Documents directly in this folder, not counting its subfolders. */
+  count: number;
 }
 
 /** Options for `NestStorage.readDocument`. */
@@ -217,14 +280,33 @@ export class NestStorage {
    *
    * Back-compat: `includeSuperseded` is accepted as a deprecated alias for
    * `includeRetired`. Either flag opens the filter.
+   *
+   * `folder` scopes the crawl to one directory (a path relative to the vault
+   * root, i.e. the id prefix — `nodes/gtm`, not `gtm`). This narrows the READ,
+   * not just the result: a caller browsing one folder of a large vault never
+   * opens the rest of it. With `recursive: false` only that folder's own
+   * documents are read, so its subfolders cost nothing either.
    */
   async discoverDocuments(
-    options: { includeRetired?: boolean; includeSuperseded?: boolean } = {},
+    options: {
+      includeRetired?: boolean;
+      includeSuperseded?: boolean;
+      folder?: string;
+      recursive?: boolean;
+    } = {},
   ): Promise<ContextNode[]> {
     const layout = await this.detectLayout();
     let patterns: string[];
 
-    if (layout === "structured") {
+    const folder = options.folder === undefined ? undefined : normalizeFolder(options.folder);
+    if (folder !== undefined) {
+      // One directory. An empty folder means the vault root itself, whose
+      // own *.md files are the root-level nodes.
+      const prefix = folder ? `${folder}/` : "";
+      patterns = options.recursive === false
+        ? [`${prefix}*.md`]
+        : [`${prefix}**/*.md`];
+    } else if (layout === "structured") {
       // Include root-level *.md so a node is discoverable wherever it lives,
       // not only under nodes/ or sources/. Agent-config and scaffold files at
       // the root are excluded via the ignore list below.
@@ -233,19 +315,7 @@ export class NestStorage {
       patterns = ["**/*.md"];
     }
 
-    const files = await globFiles(this.root, patterns, [
-      "**/node_modules/**",
-      "**/.versions/**",
-      "**/.context/**",
-      "**/INDEX.md",
-      "CONTEXT.md",
-      "context.yaml",
-      // Agent-config / scaffold files are not knowledge nodes.
-      "**/CLAUDE.md",
-      "**/GEMINI.md",
-      "**/AGENTS.md",
-      "**/README.md",
-    ]);
+    const files = await globFiles(this.root, patterns, NON_DOCUMENT_FILES);
 
     const parsed = await mapInBatches(files.sort(), async (file) => {
       const filePath = join(this.root, file);
@@ -273,6 +343,59 @@ export class NestStorage {
     const includeRetired = options.includeRetired || options.includeSuperseded;
     if (includeRetired) return nodes;
     return nodes.filter((n) => n.frontmatter.status !== "rejected");
+  }
+
+  /**
+   * The vault's folders, WITHOUT reading a single document.
+   *
+   * Discovery's cost is not the directory walk, it is opening and parsing every
+   * markdown file it finds. A caller that only needs the shape of the vault — a
+   * navigable tree, a folder picker, per-folder counts — pays none of that here:
+   * the walk yields paths, and paths alone answer the question.
+   *
+   * Counts are of files, so they include retired documents; a status is only
+   * knowable by reading the file, which is the thing this avoids. Ancestors are
+   * included even when they hold no document of their own, so a tree built from
+   * this is fully navigable. `folder` and `recursive` scope it exactly as they
+   * scope `discoverDocuments`.
+   */
+  async listFolders(
+    options: { folder?: string; recursive?: boolean } = {},
+  ): Promise<FolderEntry[]> {
+    const base = options.folder === undefined ? "" : normalizeFolder(options.folder);
+    const found: FolderEntry[] = [];
+
+    // Directories are read, not inferred from the documents inside them: a
+    // folder holding nothing but subfolders is still a folder, and inferring
+    // from files would silently drop it.
+    const scan = async (rel: string, depth: number): Promise<void> => {
+      let entries;
+      try {
+        entries = await readdir(join(this.root, rel), { withFileTypes: true });
+      } catch {
+        return; // unreadable subtree — same tolerance as the vault crawl
+      }
+      let count = 0;
+      const children: string[] = [];
+      for (const entry of entries) {
+        if (entry.isDirectory()) {
+          // Dot-directories (.versions, .context, .git, .obsidian), package
+          // installs, and staged-suggestion stores hold no knowledge nodes.
+          if (entry.name.startsWith(".")) continue;
+          if (entry.name === "node_modules" || entry.name === "_suggestions") continue;
+          children.push(rel ? `${rel}/${entry.name}` : entry.name);
+        } else if (entry.isFile() && entry.name.endsWith(".md")) {
+          if (!NON_DOCUMENT_BASENAMES.has(entry.name)) count++;
+        }
+      }
+      if (rel !== base) found.push({ path: rel, count });
+      if (depth > 0) {
+        for (const child of children) await scan(child, depth - 1);
+      }
+    };
+
+    await scan(base, options.recursive === false ? 1 : Infinity);
+    return found.sort((a, b) => a.path.localeCompare(b.path));
   }
 
   /**

--- a/packages/engine/src/storage.ts
+++ b/packages/engine/src/storage.ts
@@ -432,8 +432,12 @@ export class NestStorage {
         }
       }
       if (rel !== base) found.push({ path: rel, count });
+      // Sibling directories are independent reads, and on a network mount each
+      // one is a round trip — the very cost this function exists to avoid.
+      // Batched rather than unbounded so a wide vault can't exhaust file
+      // handles. Push order stops being deterministic; the caller sorts.
       if (depth > 0) {
-        for (const child of children) await scan(child, depth - 1);
+        await mapInBatches(children, (child) => scan(child, depth - 1));
       }
     };
 

--- a/packages/engine/src/storage.ts
+++ b/packages/engine/src/storage.ts
@@ -133,22 +133,26 @@ export function assertSafeDocumentId(raw: string): void {
 }
 
 /**
- * Normalize a folder path used to scope discovery: strips surrounding slashes,
+ * Normalize a folder path used to scope discovery: drops empty segments,
  * accepts either separator, and rejects `..` — the path is joined against the
  * vault root to start the crawl, so a traversal sequence would read outside it.
  *
  * `""` is the vault root, which is why this cannot reuse `assertSafeDocumentId`
  * (that requires every segment to name something).
+ *
+ * Splitting on the separator rather than trimming with an anchored `\/+` also
+ * keeps this linear: that pattern retries at every position of a long run of
+ * slashes, which is quadratic on a hostile path (CodeQL js/polynomial-redos).
  */
 export function normalizeFolder(raw: string): string {
-  const trimmed = raw.replace(/\\/g, "/").replace(/^\/+|\/+$/g, "");
-  if (trimmed.split("/").some((seg) => seg === "..")) {
+  const segments = raw.split(/[/\\]/).filter(Boolean);
+  if (segments.includes("..")) {
     throw new ContextNestError(
       `Invalid folder "${raw}": path traversal ("..") is not allowed.`,
       "INVALID_DOCUMENT_ID",
     );
   }
-  return trimmed;
+  return segments.join("/");
 }
 
 /**

--- a/packages/mcp-server/src/__tests__/mcp-server.regression.test.ts
+++ b/packages/mcp-server/src/__tests__/mcp-server.regression.test.ts
@@ -35,6 +35,7 @@ const EXPECTED_TOOLS = [
   "context_query",
   "context_resolve",
   "context_list",
+  "context_folders",
   "context_search",
   "context_create",
   "context_update",


### PR DESCRIPTION
Refs [CU-wdqcq007pc](https://app.clickup.com/t/wdqcq007pc)

## Summary

Browsing one folder of a vault meant reading and parsing every document in it, then discarding what didn't match. Filtering a whole-vault listing costs exactly as much as not filtering it, so a consumer showing one folder paid for all of them. This makes the scope narrow the read itself.

## What changed

- Listing and discovery accept a folder scope, optionally one level deep. The crawl is narrowed, not its output — the rest of the vault is never opened.
- New operation returns a vault's folders and their document counts without opening a single document. Folders are read from the directory tree rather than inferred from the documents inside them, so a folder holding only subfolders still appears and stays navigable.
- The vault walk stops descending once no pattern can match any deeper.

## Impact

- A consumer browsing one folder pays for that folder. Cost tracks what is shown, not how large the vault is.
- Asking only for a vault's shape is now near-free — no document is read.
- Existing callers with non-recursive patterns get faster for free: they stop walking subtrees they were already discarding.
- Additive and backward compatible. Omitting the new options behaves exactly as before.

Minor version bump via changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)