### PR TITLE
feat: vault-hosted skills, safer writes, and reliable remote nests

### DIFF
--- a/.changeset/serialize-concurrent-vault-writes.md
+++ b/.changeset/serialize-concurrent-vault-writes.md
@@ -1,0 +1,33 @@
+---
+"@promptowl/contextnest-engine": minor
+---
+
+Serialize concurrent vault writes behind a per-vault lock.
+
+Every mutating operation read-modify-writes the nest-level
+`.versions/context_history.yaml` hash chain. With nothing serializing that,
+concurrent writers corrupted it *silently* — measured with 6 parallel
+`ctx update` processes on one vault: all bodies landed, 3 checkpoint seals were
+lost, and `ctx verify` then reported `cross_chain_mismatch`. Reachable with two
+terminals today; guaranteed once parallel agents write the same vault.
+
+- New `vault-lock.ts`, exported as `withVaultLock`, `VaultLockTimeoutError` and
+  `LOCK_DIRNAME`. The mechanism is `mkdir` of `<root>/.versions/.lock` — atomic
+  on POSIX and Windows alike, no open file handle. Writers acquire with jittered
+  bounded backoff; reads never lock.
+- A holder heartbeats while its critical section runs, so a live writer is never
+  judged stale however long the write takes. Only a holder that stops
+  heartbeating (a crashed process) goes stale and is stolen, and each
+  acquisition writes an owner token so a stolen holder cannot delete the next
+  writer's live lock on its way out.
+- Every mutating core executor and the four approval-path entry points
+  (`approveSuggestion`, `rejectSuggestion`, `rollbackDocument`,
+  `czarDirectEdit`) run inside the lock.
+- New `VAULT_LOCK_TIMEOUT` error code on the affected core operations, returned
+  when the lock cannot be acquired within the bound. **Callers that map engine
+  error codes need an entry for it.**
+
+Out of scope, so the boundary stays explicit: several server *instances* over
+shared object storage (a filesystem lock cannot span that; the upgrade path is
+optimistic concurrency on the chain's parent `chain_hash`), and a vault inside a
+Dropbox/iCloud-synced folder edited from two machines.

--- a/.changeset/thick-jars-invite.md
+++ b/.changeset/thick-jars-invite.md
@@ -1,0 +1,30 @@
+---
+"@promptowl/contextnest-engine": minor
+"@promptowl/contextnest-mcp-server": minor
+"@promptowl/contextnest-cli": minor
+---
+
+Vault-hosted skills: install a `type: skill` node into an agent harness
+
+A skill node can now be rendered as a Claude Code `SKILL.md`, a Cursor rule, a
+Codex skill, or raw markdown, and installed into the caller's project or home
+directory. `skill.trigger` becomes the harness's local matcher — the one field
+that must exist locally, since matching happens before anything can be fetched,
+so a skill node without a trigger is refused rather than given a guessed one.
+
+The default install writes a **loader**: the trigger plus an instruction to fetch
+the procedure from the vault at runtime. A loader cannot go stale because it
+never holds a copy. `mode: "full"` embeds an offline snapshot instead, and says
+out loud that the copy will drift.
+
+- New engine module `skills.ts` (`renderSkill`, `buildInstallManifest`).
+- New catalog operations `context_skill` and `context_skill_install`, which the
+  MCP server registers automatically — 38 tools now.
+- New CLI commands `ctx skill <path>` and `ctx skill install <path> [--write]`.
+  Writes land outside the vault, so they go through the same never-clobber guard
+  and dry-run accounting as `ctx read --out`.
+- New `skills.bootstrap` key in `.context/config.yaml`, naming the skill that
+  teaches an agent to use this vault. `context_init` returns it as
+  `config.skill_bootstrap`.
+- Node bodies can write `{{server_alias}}` / `{{vault_id}}` / `{{node_path}}`
+  instead of hardcoding an `mcp__…__` prefix that is only correct on one client.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,9 +69,9 @@ Binaries `ctx` and `contextnest`, both from a single ~2k-line `src/index.ts` (co
 
 ### MCP Server (`@promptowl/contextnest-mcp-server`)
 
-36 tools over stdio, in three groups:
+38 tools over stdio, in three groups:
 
-- **Catalog-driven** (17, registered by looping over `listOperations("core")` — name, description and schema all come from the engine's operation catalog, so this surface cannot drift, and a new core op appears here automatically): `context_init`, `context_nests`, `context_get`, `context_list`, `context_folders`, `context_search`, `context_query`, `context_resolve`, `context_versions`, `context_reconstruct`, `context_packs`, `context_verify`, `context_create`, `context_update`, `context_publish`, `context_delete`, `context_import`. **Add new tools here, not by hand.**
+- **Catalog-driven** (19, registered by looping over `listOperations("core")` — name, description and schema all come from the engine's operation catalog, so this surface cannot drift, and a new core op appears here automatically): `context_init`, `context_nests`, `context_get`, `context_list`, `context_folders`, `context_search`, `context_query`, `context_resolve`, `context_versions`, `context_reconstruct`, `context_packs`, `context_verify`, `context_create`, `context_update`, `context_publish`, `context_delete`, `context_import`, `context_skill`, `context_skill_install`. **Add new tools here, not by hand.**
 - **Hand-written, still current** (8): `document_format`, `read_index`, `read_pack`, `list_checkpoints`, `stage_drift_suggestion`, `list_suggestions`, `approve_suggestion`, `reject_suggestion`.
 - **Deprecated** (11, backward-compatible for existing clients, removed in a future major): `vault_info`, `resolve`, `read_document`, `list_documents`, `search`, `verify_integrity`, `read_version`, `create_document`, `update_document`, `delete_document`, `publish_document`. Additive parity fixes are allowed here — `list_documents` takes `path` (the `folder` filter of `context_list`), `create_document`/`update_document` take `description` and accept `content` as an alias for `body` — but nothing already accepted may change meaning.
 

--- a/README.md
+++ b/README.md
@@ -226,6 +226,10 @@ folders:
     description: "Project documents"
   sources:
     description: "Live data sources"
+skills:
+  # The type: skill node that teaches an agent how to use this vault.
+  # A pointer, not content — the node stays the source of truth.
+  bootstrap: "nodes/skills/onboarding"
 servers:
   jira:
     url: "https://mcp.atlassian.com/sse"
@@ -352,6 +356,42 @@ skill:
 
 Skills are queryable like any other node: `ctx query "type:skill + #engineering"`
 
+#### Installing a skill into an agent harness
+
+A skill node is not just documentation — it can be **installed** into Claude Code,
+Cursor, or Codex, where the harness matches on it and runs it:
+
+```bash
+ctx skill nodes/review-pr                          # render it and look at it
+ctx skill install nodes/review-pr --write          # install for Claude Code, user scope
+ctx skill install nodes/review-pr --harness cursor --scope project --write
+```
+
+`skill.trigger` becomes the harness's local matcher (Claude Code's `description`
+frontmatter, a Cursor rule description). It is the one field that must exist
+locally, because matching happens before anything can be fetched — which is why a
+skill node without a trigger is refused rather than given a guessed one.
+
+The default install writes a **loader**: a small file carrying the trigger and an
+instruction to fetch the procedure from the vault at runtime. A loader cannot go
+stale, because it never holds a copy of the procedure. `--mode full` embeds an
+offline snapshot instead — useful when the agent cannot reach the vault, and a
+deliberate trade: that copy *will* drift as the node changes, silently, while the
+agent keeps working confidently from superseded rules.
+
+Node bodies should write `{{server_alias}}`, `{{vault_id}}`, and `{{node_path}}`
+rather than hardcoding a tool prefix: the same vault is `mcp__contextnest__*` on
+one machine and `mcp__team-ctx__*` on another, so the prefix is resolved per
+caller at render time.
+
+Point `skills.bootstrap` at the skill that teaches an agent to use *this* vault,
+and `context_init` will hand it to every agent that opens the vault:
+
+```yaml
+skills:
+  bootstrap: nodes/skills/onboarding
+```
+
 ### 7. Add context packs
 
 Packs are saved queries in `packs/` as YAML files:
@@ -461,6 +501,8 @@ export CONTEXTNEST_VAULT_PATH=/path/to/your/vault
 | `ctx delete <path>` | Delete a document and its version history |
 | `ctx read <path>` | Read and display a document in the terminal |
 | `ctx read <path> --html` | Render a document as styled HTML and open in browser |
+| `ctx skill <path>` | Render a `type: skill` node for an agent harness and print it |
+| `ctx skill install <path>` | Install a vault skill into Claude Code / Cursor / Codex (`--write` to actually write) |
 | `ctx validate [path]` | Validate documents against the spec |
 | `ctx publish <path>` | Publish a document (creates version + checkpoint) |
 | `ctx publish --all` | Publish every unpublished document in one batch — one checkpoint, one index pass |
@@ -517,7 +559,7 @@ full stack trace back.
 
 ## MCP Server
 
-The MCP server exposes vault operations as 36 tools for AI agents over stdio transport.
+The MCP server exposes vault operations as 38 tools for AI agents over stdio transport.
 
 ### Running the server
 
@@ -584,6 +626,8 @@ cloud:
 |---|---|
 | `context_init` | Open a vault: instructions, configuration, path, and what it holds (`include_nodes` to also list nodes) |
 | `context_nests` | List every nest in the central registry |
+| `context_skill` | Render a `type: skill` node as a harness-ready skill file |
+| `context_skill_install` | Build the file manifest that installs a vault skill locally |
 | `context_get` | Read one node (`include_raw`, `verify_checksum`, `allow_rejected`) |
 | `context_list` | List nodes with folder / type / status / tag filters (`folder`, `recursive`, `include_retired`, `full`, `limit`) |
 | `context_folders` | List the vault's folders and their document counts, without reading a single document (`folder`, `recursive`) |

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -93,6 +93,8 @@ After `ctx init`, the CLI prints a starter-specific instruction block to stdout.
 - `ctx read <path>` — Read and display a document in the terminal
 - `ctx read <path> --html` — Render as styled HTML and open in browser
 - `ctx read <path> --html --out file.html` — Save rendered HTML to file
+- `ctx skill <path>` — Render a `type: skill` node for an agent harness (`--harness claude-code|cursor|codex|raw`)
+- `ctx skill install <path> --write` — Install a vault skill locally. Defaults to `--mode loader` (fetches the procedure at runtime, cannot drift); `--mode full` embeds an offline copy that will
 - `ctx update <path>` — Update a document
 - `ctx delete <path>` — Delete a document
 - `ctx publish <path>` — Publish (bump version, create checkpoint)
@@ -258,7 +260,7 @@ Your hand-written content in these files is preserved — only the Context Nest 
 
 ## MCP Server
 
-For direct AI agent access via the Model Context Protocol — **36 tools** over stdio (the canonical `context_*` operation set — read/create/update/publish/import documents, selector queries, version history, drift governance, integrity verification):
+For direct AI agent access via the Model Context Protocol — **38 tools** over stdio (the canonical `context_*` operation set — read/create/update/publish/import documents, selector queries, version history, drift governance, integrity verification):
 
 ```bash
 # Run it directly, no install
@@ -277,7 +279,7 @@ Four ways into the same vault — same file format, same governed history:
 | | What it is | Get it |
 |---|---|---|
 | **CLI** (`ctx`) | Build and query the vault from the terminal (this package) | [@promptowl/contextnest-cli](https://www.npmjs.com/package/@promptowl/contextnest-cli) |
-| **MCP server** | Agent access over the Model Context Protocol — 36 tools | [@promptowl/contextnest-mcp-server](https://www.npmjs.com/package/@promptowl/contextnest-mcp-server) |
+| **MCP server** | Agent access over the Model Context Protocol — 38 tools | [@promptowl/contextnest-mcp-server](https://www.npmjs.com/package/@promptowl/contextnest-mcp-server) |
 | **Engine** | Core library — parsing, storage, versioning, graph traversal | [@promptowl/contextnest-engine](https://www.npmjs.com/package/@promptowl/contextnest-engine) |
 | **PromptOwl cloud** | Hosted packs, marketplace, SSO, approvals, role-scoped publishing | [promptowl.ai](https://promptowl.ai) |
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,6 +6,7 @@ import fs from "node:fs";
 import { readFile, writeFile, mkdir } from "node:fs/promises";
 import pathMod from "node:path";
 import readline from "node:readline";
+import { homedir } from "node:os";
 import { createRequire } from "node:module";
 import { Command, Help } from "commander";
 
@@ -56,6 +57,7 @@ import {
   normalizeDocumentId,
   isPublished,
   isRejected,
+  HARNESSES,
 } from "@promptowl/contextnest-engine";
 import type { RemoteNestSpec } from "@promptowl/contextnest-engine";
 import {
@@ -1142,6 +1144,103 @@ program
 
     console.log(chalk.dim("─".repeat(60)));
     console.log(doc.body.trim());
+  });
+
+// ─── ctx skill ─────────────────────────────────────────────────────────────────
+
+const HARNESS_CHOICES = HARNESSES.join(" | ");
+
+/** Resolve a manifest entry's `base` to a real directory on this machine. */
+function resolveInstallBase(base: "project_root" | "home"): string {
+  return base === "home" ? homedir() : process.cwd();
+}
+
+async function runSkillOp<T>(op: string, input: Record<string, unknown>): Promise<T> {
+  const storage = getStorage();
+  return createEngineApi().run<T>(op, input, opContext(storage, "cli@contextnest.local"));
+}
+
+const skillCmd = program
+  .command("skill")
+  .description("Render and install vault-hosted skills (type: skill nodes)");
+
+skillCmd
+  .command("show <path>", { isDefault: true })
+  .description("Render a skill node for an agent harness and print it")
+  .option(`--harness <name>`, `Target harness (${HARNESS_CHOICES})`, "claude-code")
+  .option("--server-alias <name>", "What your MCP client calls this server (default: vault name)")
+  .option("--scope <scope>", "user | project — decides the install path only", "user")
+  .action(async (path, opts) => {
+    const rendered = await runSkillOp<{
+      name: string;
+      description: string;
+      content: string;
+      relative_path: string;
+      base: "project_root" | "home";
+    }>("context_skill", {
+      id: normalizeDocumentId(path),
+      harness: opts.harness,
+      scope: opts.scope,
+      ...(opts.serverAlias ? { server_alias: opts.serverAlias } : {}),
+    });
+
+    console.log(chalk.dim(`# ${pathMod.join(resolveInstallBase(rendered.base), rendered.relative_path)}`));
+    console.log(rendered.content);
+  });
+
+skillCmd
+  .command("install <path>")
+  .description("Build (and optionally write) the files that install a vault skill locally")
+  .option(`--harness <name>`, `Target harness (${HARNESS_CHOICES})`, "claude-code")
+  .option("--server-alias <name>", "What your MCP client calls this server (default: vault name)")
+  .option("--scope <scope>", "user (home directory) | project (cwd)", "user")
+  .option(
+    "--mode <mode>",
+    "loader — fetch the procedure at runtime, cannot drift; full — offline snapshot that will",
+    "loader",
+  )
+  .option("--write", "Actually write the files (otherwise they are only printed)")
+  .action(async (path, opts) => {
+    const manifest = await runSkillOp<{
+      files: { relative_path: string; base: "project_root" | "home"; content: string }[];
+      post_install: string;
+      notes: string;
+      skill: { name: string; source_path: string; version: number | null };
+    }>("context_skill_install", {
+      id: normalizeDocumentId(path),
+      harness: opts.harness,
+      scope: opts.scope,
+      mode: opts.mode,
+      ...(opts.serverAlias ? { server_alias: opts.serverAlias } : {}),
+    });
+
+    for (const file of manifest.files) {
+      const target = pathMod.join(resolveInstallBase(file.base), file.relative_path);
+
+      if (!opts.write) {
+        console.log(chalk.dim(`# ${target}`));
+        console.log(file.content);
+        continue;
+      }
+
+      // These land outside the vault, in the user's project or home directory,
+      // so they get the same never-clobber-without-consent guard as `read --out`.
+      await ensureOverwritable(target, "Skill file");
+      noteExternalWrite(target);
+      if (isDryRun()) continue;
+
+      await mkdir(pathMod.dirname(target), { recursive: true });
+      await writeFile(target, file.content, "utf-8");
+      console.log(chalk.green(`Written to ${target}`));
+    }
+
+    if (!opts.write) {
+      console.log();
+      console.log(chalk.dim("Re-run with --write to install these files."));
+    }
+    console.log();
+    console.log(chalk.dim(manifest.notes));
+    if (opts.write && !isDryRun()) console.log(chalk.yellow(manifest.post_install));
   });
 
 // ─── ctx add ───────────────────────────────────────────────────────────────────

--- a/packages/engine/README.md
+++ b/packages/engine/README.md
@@ -73,7 +73,7 @@ console.log(report.valid ? "Integrity OK" : `Tampering: ${report.errors}`);
 - **Graph Traversal** — Hop-based BFS over `context.yaml` as a lightweight graph index, with priority-weighted edges
 - **Skill Nodes** — First-class `type: skill` nodes with trigger, inputs, tools_required, output_format, and guard_rails
 - **Versioning** — Hash-chained version history with keyframe + diff reconstruction; each non-keyframe version's change log is a standalone `v{N}.diff` unified diff beside the keyframes
-- **Operation Catalog** — `@promptowl/contextnest-engine/api`: one canonical, schema-described set of 17 operations (`context_get`, `context_query`, `context_create`, …) that CLI, MCP, and REST surfaces bind to instead of hand-rolling their own. As of 2.0 the `core` namespace is complete and every surface actually runs on it
+- **Operation Catalog** — `@promptowl/contextnest-engine/api`: one canonical, schema-described set of 19 operations (`context_get`, `context_query`, `context_create`, …) that CLI, MCP, and REST surfaces bind to instead of hand-rolling their own. As of 2.0 the `core` namespace is complete and every surface actually runs on it
 - **Integrity** — SHA-256 content hashes, chain hashes, and checkpoint verification down to the byte
 - **URI Resolution** — Resolve `contextnest://` URIs to documents, tags, folders, or search results
 - **Storage** — Read/write documents, version histories, checkpoints, and config from the vault file system; discovery is folder-scoped, and `listFolders` returns the vault's shape from directory entries without parsing a document

--- a/packages/engine/src/__tests__/skills.test.ts
+++ b/packages/engine/src/__tests__/skills.test.ts
@@ -15,6 +15,7 @@ import {
   type SkillSource,
 } from "../skills.js";
 import { createEngineApi, type OperationContext } from "../api/index.js";
+import { parseDocument } from "../parser.js";
 
 function skillDoc(overrides: Partial<SkillSource> = {}): SkillSource {
   return {
@@ -267,6 +268,74 @@ describe("context_skill / context_skill_install", () => {
     await expect(
       createEngineApi().run("context_skill", { id: "nodes/notes" }, ctx),
     ).rejects.toThrow(/not "skill"/);
+  });
+
+  it("refuses a rejected skill node with nothing approved behind it", async () => {
+    await writeFile(
+      join(dir, "nodes", "skills", "retired.md"),
+      [
+        "---",
+        "title: Retired",
+        "type: skill",
+        "status: rejected",
+        "skill:",
+        '  trigger: "When deploying to production"',
+        "---",
+        "",
+        "Steps a steward turned down.",
+      ].join("\n"),
+      "utf-8",
+    );
+    const api = createEngineApi();
+    for (const op of ["context_skill", "context_skill_install"]) {
+      await expect(api.run(op, { id: "nodes/skills/retired" }, ctx)).rejects.toMatchObject({
+        code: "REJECTED_DOCUMENT",
+      });
+    }
+  });
+
+  it("serves the last approved version when the live node is rejected", async () => {
+    const id = "nodes/skills/deploy";
+    const file = join(dir, "nodes", "skills", "deploy.md");
+    const node = (status: string, step: string) =>
+      [
+        "---",
+        "title: Deploy",
+        "type: skill",
+        `status: ${status}`,
+        "skill:",
+        '  trigger: "When deploying"',
+        "---",
+        "",
+        step,
+      ].join("\n");
+
+    // v1 approved and published, then a rejected edit on top of it.
+    await writeFile(file, node("approved", "Approved step."), "utf-8");
+    await ctx.versions.createVersion(
+      parseDocument(file, node("approved", "Approved step."), id),
+      "steward@example.com",
+      { publishedAt: "1970-01-01T00:00:00.000Z" },
+    );
+    await writeFile(file, node("rejected", "Steps a steward turned down."), "utf-8");
+
+    const rendered = await createEngineApi().run<{
+      content: string;
+      served_version?: number;
+      notes?: string;
+    }>("context_skill", { id }, ctx);
+    expect(rendered.served_version).toBe(1);
+    expect(rendered.content).toContain("Approved step.");
+    expect(rendered.content).not.toContain("turned down");
+    expect(rendered.notes).toContain("serving approved version 1");
+
+    const manifest = await createEngineApi().run<{ served_version?: number; notes: string }>(
+      "context_skill_install",
+      { id, mode: "full" },
+      ctx,
+    );
+    expect(manifest.served_version).toBe(1);
+    expect(manifest.notes).toContain("serving approved version 1");
   });
 
   it("builds a loader manifest by default", async () => {

--- a/packages/engine/src/__tests__/skills.test.ts
+++ b/packages/engine/src/__tests__/skills.test.ts
@@ -117,6 +117,26 @@ describe("renderSkill", () => {
     expect(rendered.content).not.toContain("{{");
   });
 
+  it("substitutes placeholders in the guard rails, inputs and output format", () => {
+    const doc = skillDoc();
+    doc.frontmatter.skill!.guard_rails = ["Call mcp__{{server_alias}}__context_get before editing"];
+    doc.frontmatter.skill!.inputs = [
+      { name: "version", type: "string", required: true, description: "Tag in {{vault_id}}" },
+    ];
+    doc.frontmatter.skill!.output_format = "Cite {{node_path}} in the summary.";
+    const opts = { serverAlias: "team-ctx", vaultId: "team" } as const;
+
+    for (const content of [
+      renderSkill(doc, { ...opts, harness: "raw" }).content,
+      buildInstallManifest(doc, { ...opts, harness: "raw", mode: "loader" }).files[0].content,
+    ]) {
+      expect(content).toContain("Call mcp__team-ctx__context_get before editing");
+      expect(content).toContain("Tag in team");
+      expect(content).toContain("Cite nodes/skills/release-checklist in the summary.");
+      expect(content).not.toContain("{{");
+    }
+  });
+
   it("puts each harness's file where that harness looks for it", () => {
     const opts = { serverAlias: "team-ctx", vaultId: "team" } as const;
     expect(renderSkill(skillDoc(), { ...opts, harness: "claude-code", scope: "project" })).toMatchObject(

--- a/packages/engine/src/__tests__/skills.test.ts
+++ b/packages/engine/src/__tests__/skills.test.ts
@@ -1,0 +1,274 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { join } from "node:path";
+import { mkdtemp, rm, mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { NestStorage } from "../storage.js";
+import { GraphQueryEngine } from "../graph-query-engine.js";
+import { VersionManager } from "../versioning.js";
+import {
+  assertSkillNode,
+  buildInstallManifest,
+  NotASkillNodeError,
+  renderSkill,
+  skillNameFromPath,
+  substitutePlaceholders,
+  type SkillSource,
+} from "../skills.js";
+import { createEngineApi, type OperationContext } from "../api/index.js";
+
+function skillDoc(overrides: Partial<SkillSource> = {}): SkillSource {
+  return {
+    id: "nodes/skills/release-checklist",
+    frontmatter: {
+      title: "Release Checklist",
+      type: "skill",
+      version: 3,
+      skill: {
+        trigger: "Use when cutting a release: tags, changelog # and announcements",
+        tools_required: ["context_get", "mcp__other__thing"],
+        inputs: [{ name: "version", type: "string", required: true, description: "Semver tag" }],
+        guard_rails: ["Never publish without a changeset"],
+        output_format: "markdown",
+      },
+    },
+    body: "1. Run `{{server_alias}}` checks against {{node_path}}.",
+    ...overrides,
+  };
+}
+
+describe("assertSkillNode", () => {
+  it("rejects a node that is not type: skill", () => {
+    const doc = skillDoc({ frontmatter: { title: "Notes", type: "document" } });
+    expect(() => assertSkillNode(doc)).toThrow(NotASkillNodeError);
+    expect(() => assertSkillNode(doc)).toThrow(/has type "document"/);
+  });
+
+  it("rejects a skill node with no trigger rather than defaulting one", () => {
+    const doc = skillDoc({
+      frontmatter: { title: "Half a skill", type: "skill", skill: { trigger: "   " } },
+    });
+    expect(() => assertSkillNode(doc)).toThrow(/carries no skill.trigger/);
+  });
+});
+
+describe("skillNameFromPath", () => {
+  it("slugifies the last segment", () => {
+    expect(skillNameFromPath("nodes/skills/Release Checklist.md")).toBe("release-checklist");
+    expect(skillNameFromPath("nodes/skills/ci_cd")).toBe("ci-cd");
+  });
+
+  it("falls back rather than producing an empty name", () => {
+    expect(skillNameFromPath("nodes/skills/---")).toBe("skill");
+  });
+});
+
+describe("substitutePlaceholders", () => {
+  const values = { serverAlias: "team-ctx", vaultId: "team", nodePath: "nodes/skills/x" };
+
+  it("resolves the vault placeholders", () => {
+    expect(substitutePlaceholders("mcp__{{server_alias}}__context_get", values)).toBe(
+      "mcp__team-ctx__context_get",
+    );
+    expect(substitutePlaceholders("{{ vault_id }} / {{NODE_PATH}}", values)).toBe(
+      "team / nodes/skills/x",
+    );
+  });
+
+  it("leaves existing mcp__ prefixes alone — they may name a different server", () => {
+    expect(substitutePlaceholders("mcp__github__search", values)).toBe("mcp__github__search");
+  });
+});
+
+describe("renderSkill", () => {
+  it("maps skill.trigger onto the harness's local matcher, YAML-quoted", () => {
+    const rendered = renderSkill(skillDoc(), {
+      harness: "claude-code",
+      serverAlias: "team-ctx",
+      vaultId: "team",
+    });
+    expect(rendered.name).toBe("release-checklist");
+    expect(rendered.description).toMatch(/^Use when cutting a release/);
+    // The trigger contains `:` and `#`, both of which change an unquoted scalar.
+    expect(rendered.content).toContain(
+      'description: "Use when cutting a release: tags, changelog # and announcements"',
+    );
+    expect(rendered.content).toContain("name: release-checklist");
+  });
+
+  it("qualifies bare required tools with the caller's alias and leaves qualified ones", () => {
+    const rendered = renderSkill(skillDoc(), {
+      harness: "claude-code",
+      serverAlias: "team-ctx",
+      vaultId: "team",
+    });
+    expect(rendered.content).toContain("- mcp__team-ctx__context_get");
+    expect(rendered.content).toContain("- mcp__other__thing");
+  });
+
+  it("substitutes placeholders in the node body", () => {
+    const rendered = renderSkill(skillDoc(), {
+      harness: "raw",
+      serverAlias: "team-ctx",
+      vaultId: "team",
+    });
+    expect(rendered.content).toContain(
+      "Run `team-ctx` checks against nodes/skills/release-checklist.",
+    );
+    expect(rendered.content).not.toContain("{{");
+  });
+
+  it("puts each harness's file where that harness looks for it", () => {
+    const opts = { serverAlias: "team-ctx", vaultId: "team" } as const;
+    expect(renderSkill(skillDoc(), { ...opts, harness: "claude-code", scope: "project" })).toMatchObject(
+      { relativePath: ".claude/skills/release-checklist/SKILL.md", base: "project_root" },
+    );
+    expect(renderSkill(skillDoc(), { ...opts, harness: "cursor", scope: "user" })).toMatchObject({
+      relativePath: ".cursor/rules/release-checklist.mdc",
+      base: "home",
+    });
+    expect(renderSkill(skillDoc(), { ...opts, harness: "codex", scope: "user" })).toMatchObject({
+      relativePath: ".codex/skills/release-checklist/SKILL.md",
+      base: "home",
+    });
+    // raw is the unwrapped body — no harness frontmatter at all.
+    expect(
+      renderSkill(skillDoc(), { ...opts, harness: "raw" }).content.startsWith("---"),
+    ).toBe(false);
+  });
+});
+
+describe("buildInstallManifest", () => {
+  const opts = { harness: "claude-code", serverAlias: "team-ctx", vaultId: "team" } as const;
+
+  it("defaults to a loader that carries the trigger, not the procedure", () => {
+    const manifest = buildInstallManifest(skillDoc(), { ...opts, scope: "user", mode: "loader" });
+    const content = manifest.files[0]!.content;
+    expect(content).toContain("This is a **loader**");
+    expect(content).toContain('mcp__team-ctx__context_skill({ id: "nodes/skills/release-checklist"');
+    // The procedure itself must NOT be inlined — that is the whole point.
+    expect(content).not.toContain("Run `team-ctx` checks");
+    expect(content).toContain("## If the vault is unreachable");
+    expect(manifest.notes).toContain("cannot drift");
+  });
+
+  it("full mode embeds the body and says out loud that it will drift", () => {
+    const manifest = buildInstallManifest(skillDoc(), { ...opts, scope: "user", mode: "full" });
+    const content = manifest.files[0]!.content;
+    expect(content).toContain("Run `team-ctx` checks");
+    expect(content).toContain("Offline snapshot");
+    expect(content).toContain("at version 3");
+    expect(manifest.notes).toContain("WILL drift");
+  });
+
+  it("reports what was installed, including the version pinned into a full copy", () => {
+    const manifest = buildInstallManifest(skillDoc(), { ...opts, scope: "project", mode: "full" });
+    expect(manifest.skill).toEqual({
+      name: "release-checklist",
+      source_path: "nodes/skills/release-checklist",
+      version: 3,
+      harness: "claude-code",
+      scope: "project",
+      mode: "full",
+      server_alias: "team-ctx",
+    });
+    expect(manifest.post_install).toContain("/release-checklist");
+  });
+});
+
+// ─── Catalog operations ───────────────────────────────────────────────────────
+
+describe("context_skill / context_skill_install", () => {
+  let ctx: OperationContext;
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "contextnest-skills-"));
+    await mkdir(join(dir, "nodes", "skills"), { recursive: true });
+    await mkdir(join(dir, ".context"), { recursive: true });
+    await writeFile(
+      join(dir, ".context", "config.yaml"),
+      ["version: 1", "name: team", "skills:", "  bootstrap: nodes/skills/onboarding"].join("\n"),
+      "utf-8",
+    );
+    await writeFile(
+      join(dir, "nodes", "skills", "onboarding.md"),
+      [
+        "---",
+        "title: Onboarding",
+        "type: skill",
+        "status: published",
+        "version: 2",
+        "skill:",
+        '  trigger: "Use when starting a session with this vault"',
+        "  tools_required:",
+        "    - context_search",
+        "---",
+        "",
+        "Ask {{server_alias}} for the index first.",
+      ].join("\n"),
+      "utf-8",
+    );
+    await writeFile(
+      join(dir, "nodes", "notes.md"),
+      ["---", "title: Notes", "type: document", "---", "", "Not a skill."].join("\n"),
+      "utf-8",
+    );
+    const storage = new NestStorage(dir);
+    ctx = {
+      storage,
+      query: new GraphQueryEngine(storage),
+      versions: new VersionManager(storage),
+      actor: "tester@example.com",
+    };
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("renders a vault skill, defaulting the tool prefix to the vault name", async () => {
+    const rendered = await createEngineApi().run<{ name: string; content: string }>(
+      "context_skill",
+      { id: "nodes/skills/onboarding" },
+      ctx,
+    );
+    expect(rendered.name).toBe("onboarding");
+    expect(rendered.content).toContain("- mcp__team__context_search");
+    expect(rendered.content).toContain("Ask team for the index first.");
+  });
+
+  it("honors the caller's own server alias over the vault name", async () => {
+    const rendered = await createEngineApi().run<{ content: string }>(
+      "context_skill",
+      { id: "nodes/skills/onboarding", server_alias: "my-nest" },
+      ctx,
+    );
+    expect(rendered.content).toContain("- mcp__my-nest__context_search");
+  });
+
+  it("refuses a node that is not a skill, with a validation error", async () => {
+    await expect(
+      createEngineApi().run("context_skill", { id: "nodes/notes" }, ctx),
+    ).rejects.toThrow(/not "skill"/);
+  });
+
+  it("builds a loader manifest by default", async () => {
+    const manifest = await createEngineApi().run<{
+      files: { relative_path: string; base: string; content: string }[];
+      skill: { mode: string };
+    }>("context_skill_install", { id: "nodes/skills/onboarding" }, ctx);
+
+    expect(manifest.skill.mode).toBe("loader");
+    expect(manifest.files[0]!.base).toBe("home");
+    expect(manifest.files[0]!.relative_path).toBe(".claude/skills/onboarding/SKILL.md");
+    expect(manifest.files[0]!.content).toContain("This is a **loader**");
+  });
+
+  it("context_init points at the vault's bootstrap skill", async () => {
+    const info = await createEngineApi().run<{ config: { skill_bootstrap?: string } }>(
+      "context_init",
+      {},
+      ctx,
+    );
+    expect(info.config.skill_bootstrap).toBe("nodes/skills/onboarding");
+  });
+});

--- a/packages/engine/src/__tests__/skills.test.ts
+++ b/packages/engine/src/__tests__/skills.test.ts
@@ -117,22 +117,20 @@ describe("renderSkill", () => {
     expect(rendered.content).not.toContain("{{");
   });
 
-  it("substitutes placeholders in the guard rails, inputs and output format", () => {
+  it("substitutes placeholders in the guard rails and input descriptions", () => {
     const doc = skillDoc();
     doc.frontmatter.skill!.guard_rails = ["Call mcp__{{server_alias}}__context_get before editing"];
     doc.frontmatter.skill!.inputs = [
       { name: "version", type: "string", required: true, description: "Tag in {{vault_id}}" },
     ];
-    doc.frontmatter.skill!.output_format = "Cite {{node_path}} in the summary.";
     const opts = { serverAlias: "team-ctx", vaultId: "team" } as const;
 
     for (const content of [
       renderSkill(doc, { ...opts, harness: "raw" }).content,
-      buildInstallManifest(doc, { ...opts, harness: "raw", mode: "loader" }).files[0].content,
+      buildInstallManifest(doc, { ...opts, harness: "raw", mode: "loader", scope: "project" }).files[0].content,
     ]) {
       expect(content).toContain("Call mcp__team-ctx__context_get before editing");
       expect(content).toContain("Tag in team");
-      expect(content).toContain("Cite nodes/skills/release-checklist in the summary.");
       expect(content).not.toContain("{{");
     }
   });

--- a/packages/engine/src/api/README.md
+++ b/packages/engine/src/api/README.md
@@ -32,6 +32,7 @@ Write/lifecycle: `context_create` · `context_update` · `context_publish` ·
 `context_delete` · `context_import` (bulk create+publish, one checkpoint)
 History/audit: `context_versions` · `context_reconstruct` · `context_verify`
 Registry: `context_nests` (list every registered nest)
+Skills: `context_skill`, `context_skill_install` (render/install a vault-hosted skill)
 
 These cover the operations all three surfaces (OSS MCP, CLI, Community MCP)
 expose, so Phase 2 bindings import them instead of hand-rolling. `governance`,

--- a/packages/engine/src/api/core-executors.ts
+++ b/packages/engine/src/api/core-executors.ts
@@ -19,6 +19,7 @@ import {
   normalizeStatus,
   isRejected,
   explicitStatus,
+  parseDocument,
 } from "../parser.js";
 import { normalizeDocumentId, assertSafeDocumentId } from "../storage.js";
 import { filterDocuments } from "../filters.js";
@@ -679,10 +680,29 @@ const init: OperationExecutor = async (ctx, input: any) => {
 async function loadSkillNode(ctx: OperationContext, input: any) {
   const id = normalizeDocumentId(String(input.id ?? ""));
   assertSafeDocumentId(id);
-  const [node, config] = await Promise.all([ctx.storage.readDocument(id), ctx.storage.readConfig()]);
+  const [live, config] = await Promise.all([ctx.storage.readDocument(id), ctx.storage.readConfig()]);
+
+  // A rejected node does not dead-end: it falls back to the last APPROVED version,
+  // so an agent keeps working from the last steps a steward signed off on while the
+  // author fixes the live file (which update/publish still accept — being rejected
+  // is what you edit your way out of). Rendering the rejected text itself is what
+  // is refused: an installed skill is matched on and executed, not just displayed.
+  // Only a rejected node with nothing approved behind it has nothing safe to serve.
+  let node = live;
+  let servedVersion: number | null = null;
+  if (isRejected(live)) {
+    const history = await ctx.versions.getHistory(id);
+    // published_at is the local marker of an approved version — the approval
+    // publish path is the only writer. Highest wins; history is append-only.
+    const approved = [...(history?.versions ?? [])].reverse().find((v) => v.published_at);
+    if (!approved) throw new RejectedDocumentError(id);
+    node = parseDocument(id, await ctx.versions.reconstructVersion(id, approved.version), id);
+    servedVersion = approved.version;
+  }
   const vaultName = config?.name;
   return {
     doc: { id: node.id, frontmatter: node.frontmatter, body: node.body },
+    servedVersion,
     vaultName,
     serverAlias: String(input.server_alias ?? vaultName ?? "contextnest"),
     harness: (input.harness ?? "claude-code") as Harness,
@@ -704,7 +724,10 @@ function asValidationError<T>(fn: () => T): T {
 }
 
 const skill: OperationExecutor = async (ctx, input: any) => {
-  const { doc, vaultName, serverAlias, harness, scope } = await loadSkillNode(ctx, input);
+  const { doc, servedVersion, vaultName, serverAlias, harness, scope } = await loadSkillNode(
+    ctx,
+    input,
+  );
   const rendered = asValidationError(() =>
     renderSkill(doc, { harness, serverAlias, vaultName, vaultId: vaultName ?? serverAlias, scope }),
   );
@@ -717,12 +740,21 @@ const skill: OperationExecutor = async (ctx, input: any) => {
     harness,
     source_path: doc.id,
     version: doc.frontmatter.version ?? null,
+    ...(servedVersion === null ? {} : { served_version: servedVersion, notes: rejectedNote(doc.id, servedVersion) }),
   };
 };
 
+/** Said out loud on both ops: what you got is not what is on disk right now. */
+function rejectedNote(id: string, version: number): string {
+  return `${id} is rejected; serving approved version ${version}.`;
+}
+
 const skillInstall: OperationExecutor = async (ctx, input: any) => {
-  const { doc, vaultName, serverAlias, harness, scope, mode } = await loadSkillNode(ctx, input);
-  return asValidationError(() =>
+  const { doc, servedVersion, vaultName, serverAlias, harness, scope, mode } = await loadSkillNode(
+    ctx,
+    input,
+  );
+  const manifest = asValidationError(() =>
     buildInstallManifest(doc, {
       harness,
       serverAlias,
@@ -732,6 +764,12 @@ const skillInstall: OperationExecutor = async (ctx, input: any) => {
       mode,
     }),
   );
+  if (servedVersion === null) return manifest;
+  return {
+    ...manifest,
+    served_version: servedVersion,
+    notes: `${rejectedNote(doc.id, servedVersion)} ${manifest.notes}`,
+  };
 };
 
 const packs: OperationExecutor = async (ctx) => {

--- a/packages/engine/src/api/core-executors.ts
+++ b/packages/engine/src/api/core-executors.ts
@@ -27,6 +27,14 @@ import { publishDocument, publishDocuments } from "../publish.js";
 import { VersionManager } from "../versioning.js";
 import { parseUri } from "../uri.js";
 import { ContextNestError, RejectedDocumentError } from "../errors.js";
+import {
+  buildInstallManifest,
+  renderSkill,
+  NotASkillNodeError,
+  type Harness,
+  type InstallMode,
+  type InstallScope,
+} from "../skills.js";
 import { applyTypedBlocks } from "../typed-blocks.js";
 import { mapInBatches } from "../concurrency.js";
 import { withVaultLock } from "../vault-lock.js";
@@ -648,6 +656,7 @@ const init: OperationExecutor = async (ctx, input: any) => {
           name: config.name,
           ...(config.description ? { description: config.description } : {}),
           servers: config.servers ? Object.keys(config.servers) : [],
+          ...(config.skills?.bootstrap ? { skill_bootstrap: config.skills.bootstrap } : {}),
         }
       : null,
     total: docs.length,
@@ -658,6 +667,71 @@ const init: OperationExecutor = async (ctx, input: any) => {
     // dwarfs them, so it is opt-in.
     ...(input?.include_nodes ? { nodes: listed.map((d) => toSummary(d)) } : {}),
   };
+};
+
+/**
+ * Shared preamble for the two skill operations: load the node, and settle the
+ * caller-supplied names. `server_alias` falls back to the vault's own name
+ * because a caller that omits it usually configured the server under that name;
+ * a wrong-but-plausible prefix is at least recognizable, where an empty one
+ * renders `mcp____context_skill`.
+ */
+async function loadSkillNode(ctx: OperationContext, input: any) {
+  const id = normalizeDocumentId(String(input.id ?? ""));
+  assertSafeDocumentId(id);
+  const [node, config] = await Promise.all([ctx.storage.readDocument(id), ctx.storage.readConfig()]);
+  const vaultName = config?.name;
+  return {
+    doc: { id: node.id, frontmatter: node.frontmatter, body: node.body },
+    vaultName,
+    serverAlias: String(input.server_alias ?? vaultName ?? "contextnest"),
+    harness: (input.harness ?? "claude-code") as Harness,
+    scope: (input.scope ?? "user") as InstallScope,
+    mode: (input.mode ?? "loader") as InstallMode,
+  };
+}
+
+/** NotASkillNodeError carries a caller-actionable message; keep it, drop the class. */
+function asValidationError<T>(fn: () => T): T {
+  try {
+    return fn();
+  } catch (err) {
+    if (err instanceof NotASkillNodeError) {
+      throw new ContextNestError(err.message, "VALIDATION_FAILED");
+    }
+    throw err;
+  }
+}
+
+const skill: OperationExecutor = async (ctx, input: any) => {
+  const { doc, vaultName, serverAlias, harness, scope } = await loadSkillNode(ctx, input);
+  const rendered = asValidationError(() =>
+    renderSkill(doc, { harness, serverAlias, vaultName, vaultId: vaultName ?? serverAlias, scope }),
+  );
+  return {
+    name: rendered.name,
+    description: rendered.description,
+    content: rendered.content,
+    relative_path: rendered.relativePath,
+    base: rendered.base,
+    harness,
+    source_path: doc.id,
+    version: doc.frontmatter.version ?? null,
+  };
+};
+
+const skillInstall: OperationExecutor = async (ctx, input: any) => {
+  const { doc, vaultName, serverAlias, harness, scope, mode } = await loadSkillNode(ctx, input);
+  return asValidationError(() =>
+    buildInstallManifest(doc, {
+      harness,
+      serverAlias,
+      vaultName,
+      vaultId: vaultName ?? serverAlias,
+      scope,
+      mode,
+    }),
+  );
 };
 
 const packs: OperationExecutor = async (ctx) => {
@@ -899,4 +973,6 @@ export const CORE_EXECUTORS: Readonly<Record<string, OperationExecutor>> = Objec
   context_packs: packs,
   context_nests: nests,
   context_import: locked(importDocs),
+  context_skill: skill,
+  context_skill_install: skillInstall,
 });

--- a/packages/engine/src/api/core.ts
+++ b/packages/engine/src/api/core.ts
@@ -971,8 +971,16 @@ const skillOp: OperationDescriptor = {
     harness: z.enum(HARNESSES),
     source_path: z.string(),
     version: z.number().int().nullable(),
+    served_version: z
+      .number()
+      .int()
+      .optional()
+      .describe(
+        "Present only when the node is rejected: the approved version served in its place. The live file is NOT what you got.",
+      ),
+    notes: z.string().optional().describe("Only set when an approved version stood in for a rejected node"),
   }),
-  errors: ["VALIDATION_FAILED", "DOCUMENT_NOT_FOUND", "INVALID_DOCUMENT_ID"],
+  errors: ["VALIDATION_FAILED", "DOCUMENT_NOT_FOUND", "INVALID_DOCUMENT_ID", "REJECTED_DOCUMENT"],
 };
 
 const skillInstallOp: OperationDescriptor = {
@@ -1008,6 +1016,14 @@ const skillInstallOp: OperationDescriptor = {
     ),
     post_install: z.string().describe("What the user must do for the harness to pick it up"),
     notes: z.string(),
+    served_version: z
+      .number()
+      .int()
+      .optional()
+      .describe(
+        "Present only when the node is rejected: the approved version served in its place. The live file is NOT what you got.",
+      ),
+
     skill: z.object({
       name: z.string(),
       source_path: z.string(),
@@ -1018,7 +1034,7 @@ const skillInstallOp: OperationDescriptor = {
       server_alias: z.string(),
     }),
   }),
-  errors: ["VALIDATION_FAILED", "DOCUMENT_NOT_FOUND", "INVALID_DOCUMENT_ID"],
+  errors: ["VALIDATION_FAILED", "DOCUMENT_NOT_FOUND", "INVALID_DOCUMENT_ID", "REJECTED_DOCUMENT"],
 };
 
 /** All `core` namespace operations, in catalog order. */

--- a/packages/engine/src/api/core.ts
+++ b/packages/engine/src/api/core.ts
@@ -20,6 +20,7 @@ import {
   frontmatterSchema,
   sourceMetaSchema,
 } from "../schemas.js";
+import { HARNESSES, INSTALL_MODES, INSTALL_SCOPES } from "../skills.js";
 import type { OperationDescriptor } from "./types.js";
 
 const tag = z.string().regex(TAG_PATTERN);
@@ -707,6 +708,12 @@ const initOp: OperationDescriptor = {
         name: z.string(),
         description: z.string().optional(),
         servers: z.array(z.string()).describe("Names of the MCP servers the vault declares"),
+        skill_bootstrap: z
+          .string()
+          .optional()
+          .describe(
+            "The vault's entry-point skill node (config `skills.bootstrap`), if it designates one. Render it with context_skill and install it with context_skill_install — it is how this vault teaches an agent to use it.",
+          ),
       })
       .nullable(),
     total: z.number().int(),
@@ -930,6 +937,90 @@ const importOp: OperationDescriptor = {
   errors: ["VALIDATION_FAILED", "VAULT_LOCK_TIMEOUT"],
 };
 
+
+// ─── context_skill / context_skill_install ───────────────────────────────────
+
+const skillOp: OperationDescriptor = {
+  name: "context_skill",
+  namespace: "core",
+  description:
+    "Render a `type: skill` node as a harness-ready skill file (Claude Code SKILL.md, a Cursor rule, and so on). The node's `skill.trigger` becomes the harness's matcher, and `{{server_alias}}` / `{{vault_id}}` / `{{node_path}}` placeholders in the node resolve to this caller's names. Returns the file content and where it belongs; it writes nothing.",
+  input: z.object({
+    id: z.string().describe("Node path of the skill, e.g. `nodes/skills/release-checklist`"),
+    harness: z
+      .enum(HARNESSES)
+      .optional()
+      .describe("Target agent harness. Default `claude-code`."),
+    server_alias: z
+      .string()
+      .optional()
+      .describe(
+        "What YOUR client calls this MCP server — the `mcp__<alias>__*` prefix baked into the rendered file. The prefix is client configuration, not a server fact, so pass your own. Defaults to the vault name.",
+      ),
+    scope: z
+      .enum(INSTALL_SCOPES)
+      .optional()
+      .describe("`user` (home directory, default) or `project` (repo root). Decides the path only."),
+  }),
+  output: z.object({
+    name: z.string().describe("Slugified skill / rule name"),
+    description: z.string().describe("The harness's local matcher text, from `skill.trigger`"),
+    content: z.string().describe("Complete file content, harness frontmatter included"),
+    relative_path: z.string().describe("Path relative to `base`"),
+    base: z.enum(["project_root", "home"]),
+    harness: z.enum(HARNESSES),
+    source_path: z.string(),
+    version: z.number().int().nullable(),
+  }),
+  errors: ["VALIDATION_FAILED", "DOCUMENT_NOT_FOUND", "INVALID_DOCUMENT_ID"],
+};
+
+const skillInstallOp: OperationDescriptor = {
+  name: "context_skill_install",
+  namespace: "core",
+  description:
+    "Build the file manifest that installs a vault skill into an agent harness. Defaults to `mode: \"loader\"` — a small file carrying the trigger and a fetch instruction back to the vault, so it CANNOT drift from the node. Use `mode: \"full\"` only when the agent must work offline; that copy will go stale silently. Returns files and paths; the caller writes them (`ctx skill install --write`, or your own file tools).",
+  input: z.object({
+    id: z.string().describe("Node path of the skill"),
+    harness: z.enum(HARNESSES).optional().describe("Target agent harness. Default `claude-code`."),
+    server_alias: z
+      .string()
+      .optional()
+      .describe("What YOUR client calls this MCP server. Defaults to the vault name."),
+    scope: z
+      .enum(INSTALL_SCOPES)
+      .optional()
+      .describe("`user` (home directory, default) or `project` (repo root)."),
+    mode: z
+      .enum(INSTALL_MODES)
+      .optional()
+      .describe(
+        "`loader` (default) fetches the procedure at runtime and never drifts. `full` embeds an offline snapshot that will.",
+      ),
+  }),
+  output: z.object({
+    files: z.array(
+      z.object({
+        relative_path: z.string(),
+        base: z.enum(["project_root", "home"]),
+        content: z.string(),
+      }),
+    ),
+    post_install: z.string().describe("What the user must do for the harness to pick it up"),
+    notes: z.string(),
+    skill: z.object({
+      name: z.string(),
+      source_path: z.string(),
+      version: z.number().int().nullable(),
+      harness: z.enum(HARNESSES),
+      scope: z.enum(INSTALL_SCOPES),
+      mode: z.enum(INSTALL_MODES),
+      server_alias: z.string(),
+    }),
+  }),
+  errors: ["VALIDATION_FAILED", "DOCUMENT_NOT_FOUND", "INVALID_DOCUMENT_ID"],
+};
+
 /** All `core` namespace operations, in catalog order. */
 export const CORE_OPERATIONS: readonly OperationDescriptor[] = [
   getOp,
@@ -949,4 +1040,6 @@ export const CORE_OPERATIONS: readonly OperationDescriptor[] = [
   packsOp,
   nestsOp,
   importOp,
+  skillOp,
+  skillInstallOp,
 ];

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -370,4 +370,27 @@ export { TraceLogger } from "./tracing.js";
 
 // Chain event log (persistent governance audit trail)
 export { ChainEventLog } from "./chain-log.js";
+
+// Vault-hosted skills
+export {
+  HARNESSES,
+  INSTALL_SCOPES,
+  INSTALL_MODES,
+  NotASkillNodeError,
+  assertSkillNode,
+  skillNameFromPath,
+  substitutePlaceholders,
+  renderSkill,
+  buildInstallManifest,
+} from "./skills.js";
+export type {
+  Harness,
+  InstallScope,
+  InstallMode,
+  SkillSource,
+  RenderOptions,
+  RenderedSkill,
+  ManifestFile,
+  InstallManifest,
+} from "./skills.js";
 export { withVaultLock, VaultLockTimeoutError, LOCK_DIRNAME } from "./vault-lock.js";

--- a/packages/engine/src/schemas.ts
+++ b/packages/engine/src/schemas.ts
@@ -292,6 +292,11 @@ export const nestConfigSchema = z.object({
       auto_index: z.boolean().optional(),
     })
     .optional(),
+  skills: z
+    .object({
+      bootstrap: z.string().optional(),
+    })
+    .optional(),
   agent_maintenance_directive: z.string().optional(),
   agent_tools: z.array(z.string()).optional(),
 });

--- a/packages/engine/src/skills.ts
+++ b/packages/engine/src/skills.ts
@@ -133,7 +133,10 @@ export function skillNameFromPath(nodePath: string): string {
   const slug = segment
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "");
+    // The line above collapses every run of non-alphanumerics to ONE dash, so a
+    // single-character trim is enough here. `^-+|-+$` would be equivalent but is
+    // quadratic on a long run of dashes (CodeQL js/polynomial-redos).
+    .replace(/^-|-$/g, "");
   return slug || "skill";
 }
 

--- a/packages/engine/src/skills.ts
+++ b/packages/engine/src/skills.ts
@@ -1,0 +1,450 @@
+/**
+ * Vault-hosted skills: rendering a `type: skill` node for an agent harness, and
+ * building the file manifest that installs it.
+ *
+ * Two things shape everything here:
+ *
+ *  1. **Install files do not belong to the vault.** A rendered skill lands in the
+ *     caller's project or home directory — `.claude/skills/…`, `.cursor/rules/…` —
+ *     which is not the vault and, for a remote or containerized server, not even
+ *     the same filesystem. So this module returns file contents and intended
+ *     paths; whoever holds the filesystem (`ctx skill install`, or the calling
+ *     agent's own file tools) does the writing.
+ *
+ *  2. **Loader beats copy.** The default install writes a small file carrying only
+ *     the trigger and a fetch instruction pointing back at the vault node — not the
+ *     procedure. A local copy of a procedure drifts the moment the node is updated,
+ *     and the drift is invisible: the agent keeps working, confidently, from
+ *     superseded rules. `mode: "full"` exists for offline use and is a deliberate
+ *     choice, never the default.
+ */
+
+import type { Frontmatter, SkillMeta } from "./types.js";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export const HARNESSES = ["claude-code", "cursor", "codex", "raw"] as const;
+export type Harness = (typeof HARNESSES)[number];
+
+export const INSTALL_SCOPES = ["project", "user"] as const;
+export type InstallScope = (typeof INSTALL_SCOPES)[number];
+
+export const INSTALL_MODES = ["loader", "full"] as const;
+export type InstallMode = (typeof INSTALL_MODES)[number];
+
+/** The subset of a ContextNode this module needs. */
+export interface SkillSource {
+  id: string;
+  frontmatter: Frontmatter;
+  body: string;
+}
+
+export interface RenderOptions {
+  harness: Harness;
+  /**
+   * The MCP server name as configured on the *client*. The tool prefix in
+   * generated content is client-side configuration, not a server fact: the same
+   * vault is `mcp__contextnest__*` on one machine and `mcp__team-ctx__*` on
+   * another. Defaults to the vault id.
+   */
+  serverAlias: string;
+  vaultName?: string;
+}
+
+export interface RenderedSkill {
+  /** Skill directory / rule name — the node path's last segment, slugified. */
+  name: string;
+  /**
+   * The harness's local matcher text. For Claude Code this is the `description`
+   * frontmatter, derived from `skill.trigger` — the one field that must exist
+   * locally, because matching happens before any fetch can.
+   */
+  description: string;
+  /** The complete file content, harness frontmatter included. */
+  content: string;
+  /** Where a harness of this kind expects the file, relative to `base`. */
+  relativePath: string;
+  base: "project_root" | "home";
+}
+
+export interface ManifestFile {
+  relative_path: string;
+  base: "project_root" | "home";
+  content: string;
+}
+
+export interface InstallManifest {
+  files: ManifestFile[];
+  post_install: string;
+  notes: string;
+  skill: {
+    name: string;
+    source_path: string;
+    version: number | null;
+    harness: Harness;
+    scope: InstallScope;
+    mode: InstallMode;
+    server_alias: string;
+  };
+}
+
+/** Thrown when the requested node is not a usable `type: skill` node. */
+export class NotASkillNodeError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "NotASkillNodeError";
+  }
+}
+
+// ─── Node validation ──────────────────────────────────────────────────────────
+
+/**
+ * Confirm the node is a skill and return its skill block.
+ *
+ * A `type: skill` node with no `skill.trigger` is rejected rather than defaulted:
+ * the trigger is what the harness matches on, so a guessed one silently produces
+ * a skill that never fires (or fires on everything).
+ */
+export function assertSkillNode(doc: SkillSource): SkillMeta {
+  const type = doc.frontmatter.type ?? "document";
+  if (type !== "skill") {
+    throw new NotASkillNodeError(
+      `Node "${doc.id}" has type "${type}", not "skill". ` +
+        `Only type: skill nodes can be rendered as a skill. ` +
+        `List the vault's skills with context_list({ type: "skill" }).`,
+    );
+  }
+  const skill = doc.frontmatter.skill;
+  if (!skill || !skill.trigger || !skill.trigger.trim()) {
+    throw new NotASkillNodeError(
+      `Node "${doc.id}" is type "skill" but carries no skill.trigger. ` +
+        `The trigger is what the harness matches on locally, so it cannot be defaulted. ` +
+        `Set it on the node before rendering.`,
+    );
+  }
+  return skill;
+}
+
+// ─── Naming and placeholders ──────────────────────────────────────────────────
+
+/** Slugify a node path's last segment into a harness-safe skill name. */
+export function skillNameFromPath(nodePath: string): string {
+  const segment = nodePath.replace(/\.md$/, "").split("/").filter(Boolean).pop() ?? "";
+  const slug = segment
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return slug || "skill";
+}
+
+/**
+ * Substitute vault placeholders in node-authored text.
+ *
+ * A node body cannot hardcode a tool prefix — `mcp__contextnest__context_get` is
+ * wrong on any client that named the server something else. Node authors write
+ * `{{server_alias}}` instead and it is resolved per caller here. Existing
+ * `mcp__…__` strings are left alone: they may legitimately reference a *different*
+ * MCP server, and rewriting them would break those references.
+ */
+export function substitutePlaceholders(
+  text: string,
+  values: { serverAlias: string; vaultId: string; nodePath: string },
+): string {
+  return text
+    .replace(/\{\{\s*server_alias\s*\}\}/gi, values.serverAlias)
+    .replace(/\{\{\s*vault_id\s*\}\}/gi, values.vaultId)
+    .replace(/\{\{\s*node_path\s*\}\}/gi, values.nodePath);
+}
+
+/** Qualify a bare tool name with the caller's alias; leave already-qualified names alone. */
+function qualifyTool(tool: string, serverAlias: string): string {
+  const trimmed = tool.trim();
+  if (!trimmed) return trimmed;
+  if (trimmed.includes("__") || /\s/.test(trimmed)) return trimmed;
+  return `mcp__${serverAlias}__${trimmed}`;
+}
+
+/**
+ * YAML-quote a scalar. Triggers are free text and routinely contain `:` and `#`,
+ * both of which change the meaning of an unquoted YAML scalar.
+ */
+function yamlScalar(value: string): string {
+  const flat = value.replace(/\s+/g, " ").trim();
+  return `"${flat.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}
+
+// ─── Body construction ────────────────────────────────────────────────────────
+
+function bulletList(items: string[] | undefined): string | null {
+  const clean = (items ?? []).map((i) => i.trim()).filter(Boolean);
+  if (clean.length === 0) return null;
+  return clean.map((i) => `- ${i}`).join("\n");
+}
+
+function contextBlocks(skill: SkillMeta, serverAlias: string): string {
+  const parts: string[] = [];
+
+  const tools = bulletList((skill.tools_required ?? []).map((t) => qualifyTool(t, serverAlias)));
+  if (tools) parts.push(`## Tools required\n\n${tools}`);
+
+  const inputs = bulletList(
+    (skill.inputs ?? []).map((i) => {
+      const req = i.required ? " (required)" : "";
+      const desc = i.description ? ` — ${i.description}` : "";
+      return `\`${i.name}\` (${i.type})${req}${desc}`;
+    }),
+  );
+  if (inputs) parts.push(`## Inputs\n\n${inputs}`);
+
+  const rails = bulletList(skill.guard_rails);
+  if (rails) parts.push(`## Guard rails\n\n${rails}`);
+
+  if (skill.output_format) parts.push(`## Output format\n\n${skill.output_format}`);
+
+  return parts.join("\n\n");
+}
+
+/**
+ * The loader body: trigger context plus a fetch instruction, and explicitly *not*
+ * the procedure. The degraded-mode section matters — an agent that cannot reach
+ * the vault must know this file is not a usable substitute for the node.
+ */
+function loaderBody(
+  doc: SkillSource,
+  skill: SkillMeta,
+  opts: RenderOptions & { vaultId: string },
+): string {
+  const alias = opts.serverAlias;
+  const where = opts.vaultName
+    ? `the **${opts.vaultName}** Context Nest vault`
+    : "the Context Nest vault";
+
+  return [
+    `# ${doc.frontmatter.title}`,
+    "",
+    `This is a **loader**. The procedure lives in ${where} at \`${doc.id}\` and is`,
+    `fetched at runtime, so it is always the current version. Do not paste the`,
+    `procedure into this file — a local copy drifts silently the moment the node changes.`,
+    "",
+    "## Load the procedure",
+    "",
+    "1. Fetch the skill:",
+    "",
+    "   ```",
+    `   mcp__${alias}__context_skill({ id: "${doc.id}", server_alias: "${alias}" })`,
+    "   ```",
+    "",
+    `   If that tool is unavailable, \`mcp__${alias}__context_get({ id: "${doc.id}" })\``,
+    `   returns the same node unrendered, and \`ctx skill ${doc.id}\` does the same from a shell.`,
+    "",
+    "2. Follow the returned body exactly. It supersedes anything in this file.",
+    "",
+    contextBlocks(skill, alias),
+    "",
+    "## If the vault is unreachable",
+    "",
+    `Say plainly that \`${doc.id}\` could not be loaded from the \`${alias}\` vault and that`,
+    "you are proceeding without it. Do not reconstruct the procedure from this file —",
+    "it carries the trigger, not the steps.",
+    "",
+  ]
+    .join("\n")
+    .replace(/\n{3,}/g, "\n\n");
+}
+
+/** The full body: the node's own content, plus a staleness warning and refresh path. */
+function fullBody(
+  doc: SkillSource,
+  skill: SkillMeta,
+  opts: RenderOptions & { vaultId: string },
+): string {
+  const alias = opts.serverAlias;
+  const version = doc.frontmatter.version;
+  const body = substitutePlaceholders(doc.body, {
+    serverAlias: alias,
+    vaultId: opts.vaultId,
+    nodePath: doc.id,
+  }).trim();
+
+  return [
+    `# ${doc.frontmatter.title}`,
+    "",
+    `> **Offline snapshot** of \`${doc.id}\`${version ? ` at version ${version}` : ""}.`,
+    `> The vault node is the source of truth and this copy will drift from it.`,
+    `> Refresh with \`mcp__${alias}__context_skill({ id: "${doc.id}" })\` whenever the vault`,
+    "> is reachable, and prefer the fetched version over this one.",
+    "",
+    contextBlocks(skill, alias),
+    "",
+    "---",
+    "",
+    body,
+    "",
+  ]
+    .join("\n")
+    .replace(/\n{3,}/g, "\n\n");
+}
+
+// ─── Harness formatters ───────────────────────────────────────────────────────
+
+/**
+ * Each formatter is a thin wrapper over the shared body: frontmatter in the
+ * harness's dialect and the path that harness looks in. Adding a harness is
+ * adding an entry here, not a refactor.
+ */
+interface HarnessFormat {
+  wrap(args: { name: string; description: string; title: string; body: string }): string;
+  path(name: string, scope: InstallScope): { relativePath: string; base: "project_root" | "home" };
+  postInstall: string;
+}
+
+const HARNESS_FORMATS: Record<Harness, HarnessFormat> = {
+  "claude-code": {
+    wrap: ({ name, description, body }) =>
+      ["---", `name: ${name}`, `description: ${yamlScalar(description)}`, "---", "", body].join(
+        "\n",
+      ),
+    path: (name, scope) => ({
+      relativePath: `.claude/skills/${name}/SKILL.md`,
+      base: scope === "user" ? "home" : "project_root",
+    }),
+    postInstall:
+      "Restart Claude Code (or start a new session) so the skill is picked up. Invoke it with /<name> or let the description match automatically.",
+  },
+
+  cursor: {
+    wrap: ({ description, body }) =>
+      [
+        "---",
+        `description: ${yamlScalar(description)}`,
+        "globs:",
+        "alwaysApply: false",
+        "---",
+        "",
+        body,
+      ].join("\n"),
+    path: (name, scope) => ({
+      relativePath: `.cursor/rules/${name}.mdc`,
+      base: scope === "user" ? "home" : "project_root",
+    }),
+    postInstall: "Reload the Cursor window so the rule is picked up.",
+  },
+
+  codex: {
+    wrap: ({ name, description, body }) =>
+      ["---", `name: ${name}`, `description: ${yamlScalar(description)}`, "---", "", body].join(
+        "\n",
+      ),
+    path: (name, scope) => ({
+      relativePath: `.codex/skills/${name}/SKILL.md`,
+      base: scope === "user" ? "home" : "project_root",
+    }),
+    postInstall:
+      "Restart Codex so the skill is picked up. If your Codex build has no skills directory, reference the file from AGENTS.md instead.",
+  },
+
+  raw: {
+    wrap: ({ body }) => body,
+    path: (name, scope) => ({
+      relativePath: `${name}.md`,
+      base: scope === "user" ? "home" : "project_root",
+    }),
+    postInstall: "No harness-specific step — this is the unwrapped skill content.",
+  },
+};
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Render a skill node for one harness, body included.
+ *
+ * `description` is derived from `skill.trigger`. That mapping is the load-bearing
+ * part: in Claude Code the local `description` decides whether the skill fires at
+ * all, and matching happens before any fetch can.
+ */
+export function renderSkill(
+  doc: SkillSource,
+  opts: RenderOptions & { vaultId: string; scope?: InstallScope },
+): RenderedSkill {
+  const skill = assertSkillNode(doc);
+  const name = skillNameFromPath(doc.id);
+  const description = substitutePlaceholders(skill.trigger, {
+    serverAlias: opts.serverAlias,
+    vaultId: opts.vaultId,
+    nodePath: doc.id,
+  }).trim();
+
+  const format = HARNESS_FORMATS[opts.harness];
+  const scope = opts.scope ?? "user";
+  const { relativePath, base } = format.path(name, scope);
+
+  return {
+    name,
+    description,
+    content: format.wrap({
+      name,
+      description,
+      title: doc.frontmatter.title,
+      body: fullBody(doc, skill, opts),
+    }),
+    relativePath,
+    base,
+  };
+}
+
+/**
+ * Build the file manifest for installing a skill locally.
+ *
+ * Nothing is written here — see the module header on why the caller owns the
+ * write. `mode` defaults to `"loader"` on purpose, for the same reason.
+ */
+export function buildInstallManifest(
+  doc: SkillSource,
+  opts: RenderOptions & {
+    vaultId: string;
+    scope: InstallScope;
+    mode: InstallMode;
+  },
+): InstallManifest {
+  const skill = assertSkillNode(doc);
+  const name = skillNameFromPath(doc.id);
+  const description = substitutePlaceholders(skill.trigger, {
+    serverAlias: opts.serverAlias,
+    vaultId: opts.vaultId,
+    nodePath: doc.id,
+  }).trim();
+
+  const format = HARNESS_FORMATS[opts.harness];
+  const { relativePath, base } = format.path(name, opts.scope);
+  const body = opts.mode === "full" ? fullBody(doc, skill, opts) : loaderBody(doc, skill, opts);
+
+  const writer =
+    "These files land outside the vault, in your project root or home directory — " +
+    "write them with `ctx skill install --write` or your own file tools. ";
+
+  return {
+    files: [
+      {
+        relative_path: relativePath,
+        base,
+        content: format.wrap({ name, description, title: doc.frontmatter.title, body }),
+      },
+    ],
+    post_install: format.postInstall.replace("/<name>", `/${name}`),
+    notes:
+      opts.mode === "loader"
+        ? writer +
+          "The file is a loader: it carries the trigger and a fetch instruction, not the procedure, so it cannot drift from the vault."
+        : writer +
+          "This is a full offline copy and WILL drift as the vault node changes. Re-run to refresh it, or install in loader mode instead.",
+    skill: {
+      name,
+      source_path: doc.id,
+      version: doc.frontmatter.version ?? null,
+      harness: opts.harness,
+      scope: opts.scope,
+      mode: opts.mode,
+      server_alias: opts.serverAlias,
+    },
+  };
+}

--- a/packages/engine/src/skills.ts
+++ b/packages/engine/src/skills.ts
@@ -181,10 +181,13 @@ function bulletList(items: string[] | undefined): string | null {
   return clean.map((i) => `- ${i}`).join("\n");
 }
 
-function contextBlocks(skill: SkillMeta, serverAlias: string): string {
+function contextBlocks(
+  skill: SkillMeta,
+  values: { serverAlias: string; vaultId: string; nodePath: string },
+): string {
   const parts: string[] = [];
 
-  const tools = bulletList((skill.tools_required ?? []).map((t) => qualifyTool(t, serverAlias)));
+  const tools = bulletList((skill.tools_required ?? []).map((t) => qualifyTool(t, values.serverAlias)));
   if (tools) parts.push(`## Tools required\n\n${tools}`);
 
   const inputs = bulletList(
@@ -201,7 +204,9 @@ function contextBlocks(skill: SkillMeta, serverAlias: string): string {
 
   if (skill.output_format) parts.push(`## Output format\n\n${skill.output_format}`);
 
-  return parts.join("\n\n");
+  // Guard rails, input descriptions and output_format are node-authored too, so they
+  // carry the same {{server_alias}} placeholders the trigger and body do.
+  return substitutePlaceholders(parts.join("\n\n"), values);
 }
 
 /**
@@ -239,7 +244,7 @@ function loaderBody(
     "",
     "2. Follow the returned body exactly. It supersedes anything in this file.",
     "",
-    contextBlocks(skill, alias),
+    contextBlocks(skill, { serverAlias: alias, vaultId: opts.vaultId, nodePath: doc.id }),
     "",
     "## If the vault is unreachable",
     "",
@@ -274,7 +279,7 @@ function fullBody(
     `> Refresh with \`mcp__${alias}__context_skill({ id: "${doc.id}" })\` whenever the vault`,
     "> is reachable, and prefer the fetched version over this one.",
     "",
-    contextBlocks(skill, alias),
+    contextBlocks(skill, { serverAlias: alias, vaultId: opts.vaultId, nodePath: doc.id }),
     "",
     "---",
     "",

--- a/packages/engine/src/types.ts
+++ b/packages/engine/src/types.ts
@@ -375,6 +375,17 @@ export interface NestConfig {
     auto_index?: boolean;
   };
   /**
+   * Vault-hosted skills (see `skills.ts`).
+   *
+   * `bootstrap` names the `type: skill` node an agent should install first —
+   * the entry point that teaches it how to use this particular vault. It is a
+   * pointer, not content: the node stays the source of truth, so the vault can
+   * change what onboarding means without anyone reinstalling anything.
+   */
+  skills?: {
+    bootstrap?: string;
+  };
+  /**
    * Agent maintenance directive — emitted into the managed section of
    * CLAUDE.md / GEMINI.md / .cursorrules / .windsurfrules /
    * .github/copilot-instructions.md by `ctx index`. Tells the agent

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -8,7 +8,7 @@
 [![License: AGPL-3.0](https://img.shields.io/badge/license-AGPL--3.0-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
 [![SOC 2 Type 2](https://img.shields.io/badge/SOC%202-Type%202-green.svg)](https://promptowl.ai)
 
-MCP server for [Context Nest](https://github.com/PromptOwl/ContextNest) — gives AI agents direct access to your context vault via the [Model Context Protocol](https://modelcontextprotocol.io). Every node is typed, versioned, and hash-chained, so what the agent reads is **governed and auditable, not a fuzzy memory blob**. Supports all node types — documents, source nodes, and skill nodes. Exposes **36 tools** over stdio transport.
+MCP server for [Context Nest](https://github.com/PromptOwl/ContextNest) — gives AI agents direct access to your context vault via the [Model Context Protocol](https://modelcontextprotocol.io). Every node is typed, versioned, and hash-chained, so what the agent reads is **governed and auditable, not a fuzzy memory blob**. Supports all node types — documents, source nodes, and skill nodes. Exposes **38 tools** over stdio transport.
 
 > **New in 2.2.1** — `context_folders` lists the vault's folders and their
 > document counts without opening a document, and `context_list` takes a
@@ -108,6 +108,8 @@ them over the legacy tools below.
 |------|-------------|
 | `context_init` | Open a vault: its `CONTEXT.md` instructions, configuration, path, and what it holds (totals, counts by type and status, tag set). `include_nodes` to also list nodes |
 | `context_nests` | List every nest in the central registry — alias, path, description, which is default, whether it exists |
+| `context_skill` | Render a `type: skill` node for an agent harness (Claude Code, Cursor, Codex, raw) — trigger becomes the harness matcher |
+| `context_skill_install` | Build the file manifest that installs a vault skill. Loader mode (default) fetches at runtime and cannot drift; `full` embeds an offline copy that will |
 | `context_get` | Read one node. `include_raw` for the exact stored bytes, `verify_checksum` to detect drift on read, `allow_rejected` to read a retired node |
 | `context_list` | List nodes with folder / type / status / tag filters. Takes `folder` (a path relative to the vault root — the id prefix) and `recursive`, an array of types, `include_retired`, `full`, `limit` |
 | `context_folders` | List the vault's folders and their document counts, read from directory entries without opening a document. `folder` to scope it, `recursive: false` for the immediate children only |

--- a/packages/mcp-server/src/__tests__/mcp-server.regression.test.ts
+++ b/packages/mcp-server/src/__tests__/mcp-server.regression.test.ts
@@ -48,6 +48,8 @@ const EXPECTED_TOOLS = [
   "context_packs",
   "context_import",
   "context_nests",
+  "context_skill",
+  "context_skill_install",
   // Hand-written, still current.
   "document_format",
   "read_index",


### PR DESCRIPTION
## Summary

Four pieces of work land together. The headline is **vault-hosted skills** (#86, contributed by @jhs129): a procedure stored in a Context Nest vault can now be installed into an AI coding agent's own harness, so the agent picks it up and runs it on its own. The rest closes gaps that made the vault unsafe or unreliable underneath that: writes that silently dropped data, writes that corrupted each other when run in parallel, and remote nests that could not be talked to at all.

Rolls up:

| PR | Author | What |
|----|--------|------|
| #86 | @jhs129 | Install vault-hosted skill nodes into agent harnesses |
| #87 (incl. #85) | @hirenf14 | Refuse misnamed write params; make `type: source` nodes writable |
| #78 | @QaziKilla | Vault-aware capture, sweep-check, curator agent, per-vault write lock |
| #77 | @QaziKilla | Read the `structuredContent` half of a governed nest's reply |

Plus one review fix on top: vault placeholders now resolve in a skill's guard rails, input descriptions and output format, not just its trigger and body.

## What we change

**Skills become installable (#86).** A vault holds procedures — how we cut a release, how to onboard to this vault. Until now they just sat there. An agent can now install one into Claude Code, Cursor or Codex and have it fire when the situation matches.

What gets installed is a *loader*, not a copy: it carries the trigger plus an instruction to fetch the steps from the vault at run time. A copy goes stale the moment someone edits the node and nobody notices. A loader cannot, because it never holds the content. An offline snapshot mode exists for disconnected use and says out loud that it will drift.

A vault can also nominate one skill as its bootstrap — the skill that teaches an agent how to use *that* vault — and hand it to every agent that opens it.

**Writes fail loudly instead of quietly (#87, #85).** A caller that misnamed a parameter used to get a success response for a write that never landed: the version bumped, the timestamp moved, and a checkpoint was sealed over unchanged text. The only way to find out was to read the document back and compare it. Unknown parameters are now refused, at every layer and inside nested objects too.

Related: nodes of type `source` were effectively write-once — creatable in a broken state, then unrepairable. They are writable now, and a node already broken by this can be fixed without destroying its history.

**Concurrent writes are serialized (#78).** Every write updates the vault's hash chain. With nothing guarding that, parallel writers corrupted it silently — six concurrent updates lost three checkpoint seals and left the vault failing verification. Writes now take a per-vault lock. Reads are unaffected.

**Remote nests work (#77).** A nest that also serves chat clients answers in two halves, and the client only read one — so every operation against such a nest failed. Both halves are read now, along with the follow-on fixes for what that implies about history, publishing through review, and verification.

## Impact

- Vault knowledge reaches agents as **runnable procedure**, not just retrievable text — and it stays current, because the vault is the copy.
- A silent data-loss class is gone. Failures that were invisible are now errors at the call site.
- Parallel agents can share a vault without corrupting it.
- Governed and hosted nests are usable, not just local ones.

**Breaking-ish:** callers that previously sent unknown parameters now get a validation error rather than a silent partial write — that error is the point. Downstream consumers should also map the new lock-timeout error code.

**Verified:** build, typecheck, plugin-sync check and the full unit suite green on Windows. Regression suites not yet run — worth one pass before merge.

Note: #86's commit is authored by John Schneider (jhs129), the outside collaborator — credited in Summary and the table.
