### PR TITLE
fix(plugin): restore vault retrieval on Windows and read hosted nests whole [CU-wdqcq00xxk]

### DIFF
--- a/plugins/__tests__/core.unit.test.ts
+++ b/plugins/__tests__/core.unit.test.ts
@@ -48,6 +48,8 @@ import {
   squish,
   VALID_CAPTURE_MODES,
   VALID_RETRIEVAL_MODES,
+  makeExec,
+  winQuote,
 } from "../shared/core/lib.js";
 
 /** Transcript stub in the shape the gate's reader returns. */
@@ -743,7 +745,7 @@ describe("sweep-check", () => {
   it("findStragglers: the tag channel catches a paraphrased node search cannot see", () => {
     const exec = fakeExec([
       // Tagged with the entity, body words the fact without the literal term.
-      ["list --tag redis --json --vault mkt", [{ id: "nodes/brand" }]],
+      ["list --tag redis", [{ id: "nodes/brand" }]],
       ["read nodes/brand --raw --vault mkt", "---\nt: x\n---\nOur flagship in-memory engine."],
       ["search redis --json --vault mkt", []],
     ]);
@@ -755,7 +757,7 @@ describe("sweep-check", () => {
 
   it("findStragglers: a node hit by both channels is reported once, as a straggler", () => {
     const exec = fakeExec([
-      ["list --tag redis --json", [{ id: "nodes/both" }]],
+      ["list --tag redis", [{ id: "nodes/both" }]],
       ["search redis --json", [{ id: "nodes/both" }]],
       ["read nodes/both --raw", "---\nt: x\n---\nStill uses Redis."],
     ]);
@@ -1187,5 +1189,41 @@ describe("capture-gate", () => {
     expect(isSubstantive(['{"role":"assistant","tool_use":1}'])).toBe(true);
     expect(isSubstantive([])).toBe(false);
     expect(isSubstantive(['{"role":"user"}', '{"role":"assistant"} short'])).toBe(false);
+  });
+});
+
+describe("makeExec", () => {
+  // The Windows shim path is the whole reason this quoting exists: npm installs
+  // ctx as ctx.cmd there, Node refuses to execFile a .cmd without a shell, and
+  // cmd.exe does no quoting of its own. On mac/linux `ctx` is a shebang symlink
+  // that execve handles directly, so none of this is engaged.
+  it("winQuote leaves shell-safe argv entries untouched", () => {
+    expect(winQuote("search")).toBe("search");
+    expect(winQuote("--json")).toBe("--json");
+    expect(winQuote("nodes/backend/auth")).toBe("nodes/backend/auth");
+  });
+
+  it("winQuote wraps anything cmd.exe would split or interpret", () => {
+    expect(winQuote("public nest sharing")).toBe('"public nest sharing"');
+    expect(winQuote("#a | #b")).toBe('"#a | #b"');
+    expect(winQuote("")).toBe('""');
+  });
+
+  it("winQuote doubles backslash runs that would escape the closing quote", () => {
+    expect(winQuote("C:\\Program Files\\ctx\\")).toBe('"C:\\Program Files\\ctx\\\\"');
+    expect(winQuote('say "hi"')).toBe('"say \\"hi\\""');
+  });
+
+  it("runs a real command and returns its stdout on every platform", () => {
+    const exec = makeExec({ ctxCommand: process.execPath });
+    const res = exec(["--version"]);
+    expect(res.status).toBe(0);
+    expect(res.stdout.trim()).toBe(process.version);
+  });
+
+  it("reports a failure instead of throwing when the command is missing", () => {
+    const exec = makeExec({ ctxCommand: "definitely-not-a-real-binary-xyz" });
+    const res = exec(["--version"]);
+    expect(res.status).not.toBe(0);
   });
 });

--- a/plugins/__tests__/core.unit.test.ts
+++ b/plugins/__tests__/core.unit.test.ts
@@ -1221,9 +1221,13 @@ describe("makeExec", () => {
     expect(res.stdout.trim()).toBe(process.version);
   });
 
-  it("reports a failure instead of throwing when the command is missing", () => {
-    const exec = makeExec({ ctxCommand: "definitely-not-a-real-binary-xyz" });
-    const res = exec(["--version"]);
-    expect(res.status).not.toBe(0);
+  // Deliberately not "the command is missing": that path ENOENTs into the npx
+  // fallback, which resolves the real CLI off the network and legitimately
+  // succeeds. A command that runs and fails is the case worth pinning — hooks
+  // must never break a session, so a non-zero exit is reported, never thrown.
+  it("reports a failing command instead of throwing", () => {
+    const exec = makeExec({ ctxCommand: process.execPath });
+    const res = exec(["-e", "process.exit(3)"]);
+    expect(res.status).toBe(3);
   });
 });

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "contextnest",
   "displayName": "Context Nest",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Vault-aware context retrieval and automatic knowledge capture, powered by the Context Nest `ctx` CLI.",
   "author": { "name": "PromptOwl" },
   "homepage": "https://github.com/promptowl/contextnest",

--- a/plugins/claude-code/CHANGELOG.md
+++ b/plugins/claude-code/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 0.5.1
+
+Retrieval worked on paper and returned nothing on Windows, and returned too
+little from any hosted nest. Both are fixed.
+
+- **The plugin can reach `ctx` on Windows.** Every hook shelled out with
+  `execFileSync("ctx", ...)` and no shell. npm installs `ctx` as a `.cmd` shim
+  there, and Node refuses to `execFile` one without a shell — it throws
+  `EINVAL`, which the `npx` fallback did not treat as "not found" either. The
+  result was silent: no error surfaced, hooks simply injected nothing, and the
+  SessionStart notice claimed the CLI was unavailable while `ctx` sat on PATH.
+  Windows now spawns through the shell, quoting each argument itself because
+  `cmd.exe` does not. macOS and Linux are untouched — `ctx` is a shebang symlink
+  there, so the branch never runs.
+- **A remote nest is no longer read 50 documents at a time.** The whole-vault
+  `ctx list` scans passed no `--limit`, and a hosted nest pages `list` at 50 by
+  default. A 166-document nest was seen as its first 50: the `query` tier built
+  its id→tag map from that slice and fell back to flat search whenever a seed
+  sat outside it, and the straggler sweep's tag channel missed anything past the
+  cut — the exact half-swept vault the sweep exists to prevent. Both scans now
+  ask for what they need. Local vaults were never affected.
+
 ## 0.5.0
 
 An update now lands in every node that carries the fact, across every nest that

--- a/plugins/claude-code/core/lib.js
+++ b/plugins/claude-code/core/lib.js
@@ -16,10 +16,31 @@ import { readFileSync } from "node:fs";
 import { homedir as osHomedir } from "node:os";
 import { join } from "node:path";
 
+/** Windows needs shell-based spawning for npm's .cmd shims — see makeExec. */
+const WIN32 = process.platform === "win32";
+
+/**
+ * Quote one argv entry for cmd.exe, which passes the command line through
+ * verbatim. Backslash runs before a quote (and before the closing quote) are
+ * doubled, per the Windows argv parsing rules.
+ * ponytail: `%VAR%` inside a quoted arg still expands; no cmd.exe escape for it.
+ */
+export function winQuote(s) {
+  const str = String(s);
+  if (str !== "" && !/[\s"^&|<>()%!]/.test(str)) return str;
+  return `"${str.replace(/(\\*)"/g, '$1$1\\"').replace(/(\\*)$/, "$1$1")}"`;
+}
+
 /** Default cap on how many registered vaults the cheap tiers fan out across. */
 export const MAX_FANOUT_VAULTS = 5;
 /** Default cap on how many retrieval hits we inject. */
 export const MAX_HITS = 6;
+/**
+ * Explicit `--limit` for whole-vault `ctx list` scans. A remote nest pages
+ * `list` at 50 by default, which silently truncated the id→tag map the query
+ * tier builds and the straggler sweep; local vaults return everything anyway.
+ */
+export const MAX_LIST_SCAN = 1000;
 
 /** Project-level settings override, relative to the project root. */
 export const PROJECT_SETTINGS_FILE = join(".claude", "contextnest.local.json");
@@ -227,13 +248,22 @@ export function makeExec(config, opts = {}) {
 
   const attempt = (cmd, args) => {
     try {
-      const stdout = execFileSync(cmd, args, {
-        cwd,
-        env,
-        encoding: "utf-8",
-        stdio: ["ignore", "pipe", "pipe"],
-        maxBuffer: 16 * 1024 * 1024,
-      });
+      const stdout = execFileSync(
+        WIN32 ? winQuote(cmd) : cmd,
+        WIN32 ? args.map(winQuote) : args,
+        {
+          cwd,
+          env,
+          encoding: "utf-8",
+          stdio: ["ignore", "pipe", "pipe"],
+          maxBuffer: 16 * 1024 * 1024,
+          // npm installs ctx/npx as .cmd shims on Windows, and Node refuses to
+          // execFile those without a shell (CVE-2024-27980) — it throws EINVAL,
+          // not ENOENT, so the npx fallback never fires either. Run through the
+          // shell there; cmd.exe does no quoting of its own, hence winQuote.
+          shell: WIN32,
+        },
+      );
       return { status: 0, stdout, stderr: "" };
     } catch (err) {
       return {
@@ -247,7 +277,8 @@ export function makeExec(config, opts = {}) {
 
   return (args) => {
     const res = attempt(config.ctxCommand, args);
-    if (res.code === "ENOENT") {
+    // EINVAL: shell-less .cmd refusal on older Node. ENOENT: no global install.
+    if (res.code === "ENOENT" || res.code === "EINVAL") {
       return attempt("npx", ["-y", "@promptowl/contextnest-cli", ...args]);
     }
     return res;

--- a/plugins/claude-code/core/retrieve.js
+++ b/plugins/claude-code/core/retrieve.js
@@ -27,6 +27,7 @@ import {
   runAsHook,
   isMain,
   MAX_HITS,
+  MAX_LIST_SCAN,
 } from "./lib.js";
 import { correctionIntent } from "./signals.js";
 import { loadLedger, saveLedger } from "./ledger.js";
@@ -130,7 +131,11 @@ function formatQuery(exec, config, hits) {
   const blocks = [];
   for (const [vaultKey, ids] of byVault) {
     const alias = vaultKey || null;
-    const docs = ctxJson(exec, withVault(["list", "--json"], alias), []);
+    const docs = ctxJson(
+      exec,
+      withVault(["list", "--json", "--limit", String(MAX_LIST_SCAN)], alias),
+      [],
+    );
     const tagOf = new Map(
       (Array.isArray(docs) ? docs : []).map((d) => [d.id, d.tags || []]),
     );

--- a/plugins/claude-code/core/sweep-check.js
+++ b/plugins/claude-code/core/sweep-check.js
@@ -24,7 +24,16 @@
  * SINGLE SOURCE OF TRUTH: plugins/shared/core/. Edit here, then `pnpm plugins:sync`.
  */
 
-import { ctxJson, envInt, getConfig, isMain, listVaults, runAsHook, withVault } from "./lib.js";
+import {
+  ctxJson,
+  envInt,
+  getConfig,
+  isMain,
+  listVaults,
+  MAX_LIST_SCAN,
+  runAsHook,
+  withVault,
+} from "./lib.js";
 
 /** Terms examined per edit. More than a few is noise, not signal. */
 export const MAX_TERMS = 3;
@@ -199,7 +208,14 @@ export function findStragglers(exec, terms, excludeId, writtenAlias, targets, bu
     if ((alias || null) === (writtenAlias || null)) checked.add(ref(excludeId));
 
     for (const term of terms) {
-      const tagged = ctxJson(exec, withVault(["list", "--tag", term, "--json"], alias), []);
+      const tagged = ctxJson(
+        exec,
+        withVault(
+          ["list", "--tag", term, "--json", "--limit", String(MAX_LIST_SCAN)],
+          alias,
+        ),
+        [],
+      );
       const searched = ctxJson(exec, withVault(["search", term, "--json"], alias), []);
       const tagHits = Array.isArray(tagged) ? tagged : [];
       const taggedIds = new Set(tagHits.map((d) => d?.id).filter(Boolean));

--- a/plugins/claude-code/package.json
+++ b/plugins/claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@promptowl/contextnest-claude-plugin",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "type": "module",
   "description": "Claude Code plugin for Context Nest — vault-aware retrieval + automatic capture via the ctx CLI",

--- a/plugins/shared/core/lib.js
+++ b/plugins/shared/core/lib.js
@@ -16,10 +16,31 @@ import { readFileSync } from "node:fs";
 import { homedir as osHomedir } from "node:os";
 import { join } from "node:path";
 
+/** Windows needs shell-based spawning for npm's .cmd shims — see makeExec. */
+const WIN32 = process.platform === "win32";
+
+/**
+ * Quote one argv entry for cmd.exe, which passes the command line through
+ * verbatim. Backslash runs before a quote (and before the closing quote) are
+ * doubled, per the Windows argv parsing rules.
+ * ponytail: `%VAR%` inside a quoted arg still expands; no cmd.exe escape for it.
+ */
+export function winQuote(s) {
+  const str = String(s);
+  if (str !== "" && !/[\s"^&|<>()%!]/.test(str)) return str;
+  return `"${str.replace(/(\\*)"/g, '$1$1\\"').replace(/(\\*)$/, "$1$1")}"`;
+}
+
 /** Default cap on how many registered vaults the cheap tiers fan out across. */
 export const MAX_FANOUT_VAULTS = 5;
 /** Default cap on how many retrieval hits we inject. */
 export const MAX_HITS = 6;
+/**
+ * Explicit `--limit` for whole-vault `ctx list` scans. A remote nest pages
+ * `list` at 50 by default, which silently truncated the id→tag map the query
+ * tier builds and the straggler sweep; local vaults return everything anyway.
+ */
+export const MAX_LIST_SCAN = 1000;
 
 /** Project-level settings override, relative to the project root. */
 export const PROJECT_SETTINGS_FILE = join(".claude", "contextnest.local.json");
@@ -227,13 +248,22 @@ export function makeExec(config, opts = {}) {
 
   const attempt = (cmd, args) => {
     try {
-      const stdout = execFileSync(cmd, args, {
-        cwd,
-        env,
-        encoding: "utf-8",
-        stdio: ["ignore", "pipe", "pipe"],
-        maxBuffer: 16 * 1024 * 1024,
-      });
+      const stdout = execFileSync(
+        WIN32 ? winQuote(cmd) : cmd,
+        WIN32 ? args.map(winQuote) : args,
+        {
+          cwd,
+          env,
+          encoding: "utf-8",
+          stdio: ["ignore", "pipe", "pipe"],
+          maxBuffer: 16 * 1024 * 1024,
+          // npm installs ctx/npx as .cmd shims on Windows, and Node refuses to
+          // execFile those without a shell (CVE-2024-27980) — it throws EINVAL,
+          // not ENOENT, so the npx fallback never fires either. Run through the
+          // shell there; cmd.exe does no quoting of its own, hence winQuote.
+          shell: WIN32,
+        },
+      );
       return { status: 0, stdout, stderr: "" };
     } catch (err) {
       return {
@@ -247,7 +277,8 @@ export function makeExec(config, opts = {}) {
 
   return (args) => {
     const res = attempt(config.ctxCommand, args);
-    if (res.code === "ENOENT") {
+    // EINVAL: shell-less .cmd refusal on older Node. ENOENT: no global install.
+    if (res.code === "ENOENT" || res.code === "EINVAL") {
       return attempt("npx", ["-y", "@promptowl/contextnest-cli", ...args]);
     }
     return res;

--- a/plugins/shared/core/retrieve.js
+++ b/plugins/shared/core/retrieve.js
@@ -27,6 +27,7 @@ import {
   runAsHook,
   isMain,
   MAX_HITS,
+  MAX_LIST_SCAN,
 } from "./lib.js";
 import { correctionIntent } from "./signals.js";
 import { loadLedger, saveLedger } from "./ledger.js";
@@ -130,7 +131,11 @@ function formatQuery(exec, config, hits) {
   const blocks = [];
   for (const [vaultKey, ids] of byVault) {
     const alias = vaultKey || null;
-    const docs = ctxJson(exec, withVault(["list", "--json"], alias), []);
+    const docs = ctxJson(
+      exec,
+      withVault(["list", "--json", "--limit", String(MAX_LIST_SCAN)], alias),
+      [],
+    );
     const tagOf = new Map(
       (Array.isArray(docs) ? docs : []).map((d) => [d.id, d.tags || []]),
     );

--- a/plugins/shared/core/sweep-check.js
+++ b/plugins/shared/core/sweep-check.js
@@ -24,7 +24,16 @@
  * SINGLE SOURCE OF TRUTH: plugins/shared/core/. Edit here, then `pnpm plugins:sync`.
  */
 
-import { ctxJson, envInt, getConfig, isMain, listVaults, runAsHook, withVault } from "./lib.js";
+import {
+  ctxJson,
+  envInt,
+  getConfig,
+  isMain,
+  listVaults,
+  MAX_LIST_SCAN,
+  runAsHook,
+  withVault,
+} from "./lib.js";
 
 /** Terms examined per edit. More than a few is noise, not signal. */
 export const MAX_TERMS = 3;
@@ -199,7 +208,14 @@ export function findStragglers(exec, terms, excludeId, writtenAlias, targets, bu
     if ((alias || null) === (writtenAlias || null)) checked.add(ref(excludeId));
 
     for (const term of terms) {
-      const tagged = ctxJson(exec, withVault(["list", "--tag", term, "--json"], alias), []);
+      const tagged = ctxJson(
+        exec,
+        withVault(
+          ["list", "--tag", term, "--json", "--limit", String(MAX_LIST_SCAN)],
+          alias,
+        ),
+        [],
+      );
       const searched = ctxJson(exec, withVault(["search", term, "--json"], alias), []);
       const tagHits = Array.isArray(tagged) ? tagged : [];
       const taggedIds = new Set(tagHits.map((d) => d?.id).filter(Boolean));


### PR DESCRIPTION
Closes [CU-wdqcq00xxk](https://app.clickup.com/t/wdqcq00xxk)

Two independent bugs left the Claude Code plugin's vault retrieval either dead or quietly degraded, depending on the platform. Neither surfaced an error.

## 1. The plugin could not launch `ctx` on Windows

`makeExec` ran `execFileSync("ctx", ...)` with no shell. npm installs `ctx` as a `.cmd` shim on Windows, and Node refuses to `execFile` one without a shell (CVE-2024-27980) — it throws `EINVAL`, not `ENOENT`, so the `npx` fallback never fired either. Every hook silently received zero results, and the SessionStart notice reported the CLI as unavailable while `ctx` sat on PATH and worked fine from the terminal.

Windows now spawns through the shell, quoting each argv entry itself because `cmd.exe` does not. `EINVAL` joins `ENOENT` as a fallback trigger. macOS and Linux are untouched — `ctx` is a shebang symlink there, so the branch is never taken.

## 2. A hosted nest was read 50 documents at a time, on every platform

The whole-vault `ctx list` scans passed no `--limit`, and a remote nest pages `list` at 50 by default. A 166-document nest was seen as its first 50. The `query` retrieval tier built its id→tag map from that slice and fell back to flat search whenever a seed sat outside it; the sweep-check's tag channel missed any straggler past the cut — the exact half-swept vault that sweep exists to prevent. Both scans now pass an explicit limit. Local vaults were never affected.

## Tests

`makeExec` and `winQuote` had no coverage at all. Added five cases, including one that runs a real command through `makeExec` so the POSIX path is exercised on macOS/Linux CI rather than only the Windows branch.

Two existing sweep-check stubs matched on exact argv strings and broke on the added flag; loosened to a prefix so they survive future flag changes. No assertion weakened.

## Verification

Confirmed live against the production Community nest, not just in unit tests. Before the fix, `vaultTargets` resolved to nothing on Windows and `exec(["vault","list","--json"])` returned `ENOENT`. After, the `query` tier returns real document bodies cited as `community:nodes/...`, and `list` returns all 166 documents instead of 50.

`145/145` plugin tests pass. `plugins:sync --check` clean.

## Release

Ships as plugin `0.5.1` with a CHANGELOG entry, versioned by hand in a separate commit.

No changeset — and this is deliberate, not an oversight. `plugins/claude-code` sits outside the pnpm workspace (`packages/*`) and is `private: true`, so changesets cannot see it. A changeset naming it does not get ignored; it hard-fails `changeset status` and `changeset version` for the entire repo with `Found changeset ... which is not in the workspace`. This follows the precedent set by the 0.2.0 → 0.5.0 bump in ca181c3.

Installed plugins pick this up once it lands on `development`, which is the branch the marketplace clone tracks.