### PR TITLE
ctx push: confirmation-gate polling (--no-wait/--timeout)

### DIFF
--- a/.changeset/push-confirmation-gate-cli.md
+++ b/.changeset/push-confirmation-gate-cli.md
@@ -1,0 +1,14 @@
+---
+"@promptowl/contextnest-cli": minor
+---
+
+`ctx push`: honor a nest's push-confirmation gate instead of misreporting a pending push as applied.
+
+A hosted nest can require a human to confirm an incoming push in the web UI before it is applied. When it does, the publish endpoint answers `202 { status: "pending_confirmation", … }` and parks the documents rather than applying them. `ctx push` treated any 2xx as success, so against a gated nest it printed "Pushed N documents" though nothing had landed.
+
+- On `202 pending_confirmation`, the CLI now prints the server's message and a `Confirm in the UI: <confirm_url>` line, then — unless `--no-wait` — polls `poll_url` (`/nests/:id/pending-pushes/:pid`, same Bearer key) on a capped 2s→10s backoff until the decision.
+- The process exit code reflects the outcome: `0` when the push is applied, non-zero for rejected / expired / timeout.
+- New flags: `--no-wait` (submit, print the confirm URL, exit 0 without polling) and `--timeout <sec>` (default: the server's `expires_at` window, else 15m).
+- The 200 path (ungated / allowlisted nests) is unchanged.
+
+Wire contract shared with the paired Community server change (PromptOwl/contextnest-community).

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -157,6 +157,14 @@ it would put both the documents and your API key on the wire in the clear.
 Prefer `CONTEXTNEST_API_KEY` over `--key`: command-line arguments are visible
 to other processes and land in shell history.
 
+**Confirmation gate.** A nest can require a human to confirm a push in the web
+UI before it is applied. When it does, `ctx push` prints a `Confirm in the UI:`
+link and waits for the decision, exiting `0` once the push is applied and
+non-zero if it is rejected, expires, or the wait times out. Use `--no-wait` to
+submit and exit without waiting, or `--timeout <sec>` to bound the wait (it
+defaults to the server's window, else 15 minutes). Ungated nests apply
+immediately, exactly as before.
+
 ### Errors
 
 Every failure prints as a single line — `Error [CODE]: message` for engine

--- a/packages/cli/src/__tests__/cli.regression.test.ts
+++ b/packages/cli/src/__tests__/cli.regression.test.ts
@@ -147,6 +147,88 @@ function startMockEngine(
   });
 }
 
+/**
+ * Like runCtxAsync, but tolerates a non-zero exit — needed for the gated-push
+ * paths that exit non-zero (rejected/expired) while an in-process mock server
+ * must stay responsive (so spawnSync/runCtxResult, which blocks the event loop,
+ * would deadlock the poll). Returns status + captured streams.
+ */
+async function runCtxAsyncResult(
+  cwd: string,
+  args: string[],
+): Promise<{ status: number; stdout: string; stderr: string }> {
+  try {
+    const { stdout, stderr } = await execFileAsync("node", [distPath, ...args], {
+      cwd,
+      env: ENV,
+      encoding: "utf-8",
+    });
+    return { status: 0, stdout, stderr };
+  } catch (e: any) {
+    return { status: typeof e.code === "number" ? e.code : 1, stdout: e.stdout ?? "", stderr: e.stderr ?? "" };
+  }
+}
+
+interface GatedServer {
+  url: string;
+  /** The most recently received publish (POST) body, parsed. */
+  lastBody: () => unknown;
+  /** How many times the pending-push poll endpoint was hit. */
+  pollCount: () => number;
+  close: () => Promise<void>;
+}
+
+/**
+ * A mock engine that gates the push: POST /nests/:id/publish answers 202 with a
+ * pending_confirmation envelope, and GET /nests/:id/pending-pushes/:pid returns
+ * the next body in `pollSequence` (repeating the last), so the CLI's confirm-gate
+ * polling can be driven end to end. The first terminal poll returns immediately,
+ * so tests never pay the real backoff.
+ */
+function startGatedEngine(pollSequence: Array<Record<string, unknown>>): Promise<GatedServer> {
+  const polls = [...pollSequence];
+  return new Promise((resolve) => {
+    let captured: unknown;
+    let gets = 0;
+    const server: Server = createServer((req, res) => {
+      if (req.method === "POST") {
+        let raw = "";
+        req.on("data", (c) => (raw += c));
+        req.on("end", () => {
+          captured = JSON.parse(raw);
+          const nest = (req.url ?? "").split("/")[2] ?? "nest-1";
+          res.writeHead(202, { "Content-Type": "application/json" });
+          res.end(
+            JSON.stringify({
+              status: "pending_confirmation",
+              pending_id: "pid1",
+              confirm_url: "https://ui.example/confirm/pid1",
+              poll_url: `/nests/${nest}/pending-pushes/pid1`,
+              message: "This nest requires confirmation before the push is applied.",
+              expires_at: new Date(Date.now() + 15 * 60 * 1000).toISOString(),
+            }),
+          );
+        });
+        return;
+      }
+      // GET poll
+      gets++;
+      const body = polls.length > 1 ? polls.shift()! : polls[0];
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(body));
+    });
+    server.listen(0, () => {
+      const port = (server.address() as AddressInfo).port;
+      resolve({
+        url: `http://localhost:${port}`,
+        lastBody: () => captured,
+        pollCount: () => gets,
+        close: () => new Promise((r) => server.close(() => r())),
+      });
+    });
+  });
+}
+
 let tmp: string;
 
 beforeEach(() => {
@@ -946,6 +1028,68 @@ describe("[regression] ctx push", () => {
       expect(res.stdout).toMatch(/No documents to push/);
     } finally {
       rmSync(empty, { recursive: true, force: true });
+    }
+  });
+
+  // ─── confirmation gate (202) ────────────────────────────────────────────────
+  // A gated nest parks the push for a human to confirm and answers 202 instead
+  // of applying. The CLI must recognize that, surface the confirm URL, and (by
+  // default) poll to the decision — never misreport the pending 202 as applied.
+
+  it("a gated push (202) polls to 'applied' and reports the confirmed count (exit 0)", async () => {
+    const server = await startGatedEngine([{ status: "applied", applied_node_count: 1, decided_by: "steward@ex" }]);
+    try {
+      const res = await runCtxAsyncResult(tmp, [
+        "push",
+        "--server", server.url,
+        "--nest", "nest-1",
+        "--key", "cnst_testkey",
+        "--yes",
+      ]);
+      expect(res.status).toBe(0);
+      expect(res.stdout).toMatch(/Confirm in the UI: https:\/\/ui\.example\/confirm\/pid1/);
+      expect(res.stdout).toMatch(/Pushed 1 document/);
+      expect(server.pollCount()).toBeGreaterThanOrEqual(1);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("a gated push that is rejected exits non-zero and says nothing was applied", async () => {
+    const server = await startGatedEngine([{ status: "rejected", decided_by: "steward@ex" }]);
+    try {
+      const res = await runCtxAsyncResult(tmp, [
+        "push",
+        "--server", server.url,
+        "--nest", "nest-1",
+        "--key", "cnst_testkey",
+        "--yes",
+      ]);
+      expect(res.status).not.toBe(0);
+      expect(res.stderr).toMatch(/rejected/i);
+      expect(res.stdout).not.toMatch(/Pushed/);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("--no-wait submits, prints the confirm URL, and exits 0 without polling", async () => {
+    const server = await startGatedEngine([{ status: "pending" }]);
+    try {
+      const res = await runCtxAsyncResult(tmp, [
+        "push",
+        "--server", server.url,
+        "--nest", "nest-1",
+        "--key", "cnst_testkey",
+        "--yes",
+        "--no-wait",
+      ]);
+      expect(res.status).toBe(0);
+      expect(res.stdout).toMatch(/Confirm in the UI: https:\/\/ui\.example\/confirm\/pid1/);
+      expect(res.stdout).not.toMatch(/Pushed/);
+      expect(server.pollCount()).toBe(0);
+    } finally {
+      await server.close();
     }
   });
 });

--- a/packages/cli/src/__tests__/push-confirm.test.ts
+++ b/packages/cli/src/__tests__/push-confirm.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  asPendingConfirmation,
+  exitCodeFor,
+  pollUntilDecided,
+  resolveTimeoutMs,
+  type PollResult,
+  type PollOptions,
+} from "../push-confirm.js";
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+/** A minimal Response stand-in the state machine reads (status/ok/json). */
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+/**
+ * A fake clock: `now()` advances only when the injected `sleep` is awaited, so
+ * the state machine's timeout is fully deterministic without real timers.
+ */
+function fakeClock() {
+  let t = 0;
+  return {
+    now: () => t,
+    sleep: async (ms: number) => {
+      t += ms;
+    },
+  };
+}
+
+/** A fetch that returns each queued poll body in order, then repeats the last. */
+function queuedFetch(bodies: Array<{ status: number; body: unknown }>) {
+  const calls: string[] = [];
+  const fetchFn = vi.fn(async (url: string | URL | Request) => {
+    calls.push(String(url));
+    const next = bodies.length > 1 ? bodies.shift()! : bodies[0];
+    return jsonResponse(next.status, next.body);
+  }) as unknown as typeof fetch;
+  return { fetchFn, calls };
+}
+
+const BASE: Omit<PollOptions, "fetchFn" | "sleep" | "now"> = {
+  serverUrl: "https://engine.test",
+  pollUrl: "/nests/n1/pending-pushes/p1",
+  apiKey: "cnst_key",
+  timeoutMs: 15 * 60 * 1000,
+  minDelayMs: 2_000,
+  maxDelayMs: 10_000,
+};
+
+// ─── asPendingConfirmation ────────────────────────────────────────────────────
+
+describe("asPendingConfirmation", () => {
+  it("recognizes a well-formed 202 pending_confirmation envelope", () => {
+    const env = asPendingConfirmation(202, {
+      status: "pending_confirmation",
+      pending_id: "p1",
+      confirm_url: "https://ui.test/confirm/p1",
+      poll_url: "/nests/n1/pending-pushes/p1",
+      message: "Confirm this push",
+      expires_at: "2026-01-01T00:00:00Z",
+    });
+    expect(env).not.toBeNull();
+    expect(env!.pending_id).toBe("p1");
+    expect(env!.poll_url).toBe("/nests/n1/pending-pushes/p1");
+  });
+
+  it("returns null for a 200 (the normal apply path)", () => {
+    expect(asPendingConfirmation(200, { published: 3 })).toBeNull();
+  });
+
+  it("returns null for a 202 whose body is not the pending shape", () => {
+    expect(asPendingConfirmation(202, { status: "queued" })).toBeNull();
+    expect(asPendingConfirmation(202, { status: "pending_confirmation" })).toBeNull(); // no poll_url/id
+  });
+});
+
+// ─── exitCodeFor ──────────────────────────────────────────────────────────────
+
+describe("exitCodeFor", () => {
+  it("is 0 only when applied", () => {
+    const r: PollResult = { status: "applied" };
+    expect(exitCodeFor({ kind: "applied", result: r })).toBe(0);
+    expect(exitCodeFor({ kind: "rejected", result: { status: "rejected" } })).not.toBe(0);
+    expect(exitCodeFor({ kind: "expired", result: { status: "expired" } })).not.toBe(0);
+    expect(exitCodeFor({ kind: "timeout" })).not.toBe(0);
+  });
+});
+
+// ─── resolveTimeoutMs ─────────────────────────────────────────────────────────
+
+describe("resolveTimeoutMs", () => {
+  it("prefers an explicit --timeout (seconds → ms)", () => {
+    expect(resolveTimeoutMs(30, "2026-01-01T00:00:00Z", () => 0)).toBe(30_000);
+  });
+
+  it("falls back to the server's expires_at window", () => {
+    const now = () => Date.parse("2026-01-01T00:00:00Z");
+    const ms = resolveTimeoutMs(undefined, "2026-01-01T00:05:00Z", now);
+    expect(ms).toBe(5 * 60 * 1000);
+  });
+
+  it("defaults to 15m when there is no timeout and no usable expires_at", () => {
+    expect(resolveTimeoutMs(undefined, undefined, () => 0)).toBe(15 * 60 * 1000);
+    // An already-past expires_at is ignored, not turned into a zero/negative wait.
+    const now = () => Date.parse("2026-01-01T00:10:00Z");
+    expect(resolveTimeoutMs(undefined, "2026-01-01T00:00:00Z", now)).toBe(15 * 60 * 1000);
+  });
+});
+
+// ─── pollUntilDecided: the state machine ──────────────────────────────────────
+
+describe("pollUntilDecided", () => {
+  it("202 → poll(pending) → poll(applied) resolves to an applied outcome", async () => {
+    const clock = fakeClock();
+    const { fetchFn, calls } = queuedFetch([
+      { status: 200, body: { status: "pending", nest_name: "Team", doc_count: 3 } },
+      { status: 200, body: { status: "applied", applied_node_count: 3, decided_by: "alice" } },
+    ]);
+    const onPending = vi.fn();
+
+    const outcome = await pollUntilDecided({ ...BASE, fetchFn, sleep: clock.sleep, now: clock.now, onPending });
+
+    expect(outcome.kind).toBe("applied");
+    expect(exitCodeFor(outcome)).toBe(0);
+    if (outcome.kind === "applied") expect(outcome.result.applied_node_count).toBe(3);
+    // One still-pending tick, then the terminal poll — two fetches.
+    expect(calls).toHaveLength(2);
+    expect(calls[0]).toBe("https://engine.test/nests/n1/pending-pushes/p1");
+    expect(onPending).toHaveBeenCalledOnce();
+  });
+
+  it("202 → poll(rejected) resolves to a rejected outcome (non-zero exit)", async () => {
+    const clock = fakeClock();
+    const { fetchFn } = queuedFetch([{ status: 200, body: { status: "rejected", decided_by: "bob" } }]);
+
+    const outcome = await pollUntilDecided({ ...BASE, fetchFn, sleep: clock.sleep, now: clock.now });
+
+    expect(outcome.kind).toBe("rejected");
+    expect(exitCodeFor(outcome)).not.toBe(0);
+  });
+
+  it("resolves to expired when the server reports the push expired", async () => {
+    const clock = fakeClock();
+    const { fetchFn } = queuedFetch([{ status: 200, body: { status: "expired" } }]);
+    const outcome = await pollUntilDecided({ ...BASE, fetchFn, sleep: clock.sleep, now: clock.now });
+    expect(outcome.kind).toBe("expired");
+    expect(exitCodeFor(outcome)).not.toBe(0);
+  });
+
+  it("sends the Bearer key on every poll", async () => {
+    const clock = fakeClock();
+    const fetchFn = vi.fn(async () =>
+      jsonResponse(200, { status: "applied", applied_node_count: 1 }),
+    ) as unknown as typeof fetch;
+    await pollUntilDecided({ ...BASE, fetchFn, sleep: clock.sleep, now: clock.now });
+    const init = (fetchFn as unknown as ReturnType<typeof vi.fn>).mock.calls[0][1] as RequestInit;
+    expect((init.headers as Record<string, string>).Authorization).toBe("Bearer cnst_key");
+  });
+
+  it("gives up with a timeout outcome once the budget is spent while still pending", async () => {
+    const clock = fakeClock();
+    // Always pending — the loop must terminate on the clock, not spin forever.
+    const fetchFn = vi.fn(async () => jsonResponse(200, { status: "pending" })) as unknown as typeof fetch;
+
+    const outcome = await pollUntilDecided({
+      ...BASE,
+      timeoutMs: 5_000, // two 2s+ sleeps exhaust it
+      fetchFn,
+      sleep: clock.sleep,
+      now: clock.now,
+    });
+
+    expect(outcome.kind).toBe("timeout");
+    expect(exitCodeFor(outcome)).not.toBe(0);
+  });
+
+  it("retries through a transient 5xx and then resolves", async () => {
+    const clock = fakeClock();
+    const { fetchFn, calls } = queuedFetch([
+      { status: 503, body: { error: "unavailable" } },
+      { status: 200, body: { status: "applied", applied_node_count: 2 } },
+    ]);
+    const outcome = await pollUntilDecided({ ...BASE, fetchFn, sleep: clock.sleep, now: clock.now });
+    expect(outcome.kind).toBe("applied");
+    expect(calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("aborts immediately on a 401 (a bad key never comes good)", async () => {
+    const clock = fakeClock();
+    const fetchFn = vi.fn(async () => jsonResponse(401, { error: "unauthorized" })) as unknown as typeof fetch;
+    await expect(
+      pollUntilDecided({ ...BASE, fetchFn, sleep: clock.sleep, now: clock.now }),
+    ).rejects.toThrow(/not authorized/i);
+  });
+
+  it("caps the backoff at maxDelayMs", async () => {
+    const clock = fakeClock();
+    const sleeps: number[] = [];
+    const sleep = async (ms: number) => {
+      sleeps.push(ms);
+      await clock.sleep(ms);
+    };
+    // Enough pending ticks to climb 2s→4s→8s→10s(cap).
+    const bodies = Array.from({ length: 6 }, () => ({ status: 200, body: { status: "pending" as const } }));
+    const applied = { status: 200, body: { status: "applied", applied_node_count: 1 } };
+    const { fetchFn } = queuedFetch([...bodies, applied]);
+
+    await pollUntilDecided({
+      ...BASE,
+      timeoutMs: 10 * 60 * 1000,
+      fetchFn,
+      sleep,
+      now: clock.now,
+    });
+
+    expect(sleeps[0]).toBe(2_000);
+    expect(Math.max(...sleeps)).toBeLessThanOrEqual(10_000);
+    expect(sleeps.some((s) => s === 10_000)).toBe(true);
+  });
+});

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -111,6 +111,13 @@ import {
   assertNotRedirected,
   NO_REDIRECT,
 } from "./safety.js";
+import {
+  asPendingConfirmation,
+  pollUntilDecided,
+  resolveTimeoutMs,
+  exitCodeFor,
+  type TerminalOutcome,
+} from "./push-confirm.js";
 
 const program = new Command();
 
@@ -2349,6 +2356,33 @@ program
 
 // ─── ctx push ────────────────────────────────────────────────────────────────
 
+/** Print the terminal result of a gated push. Success stays on stdout. */
+function reportPushOutcome(outcome: TerminalOutcome): void {
+  switch (outcome.kind) {
+    case "applied": {
+      const n = outcome.result.applied_node_count ?? outcome.result.doc_count ?? 0;
+      console.log(chalk.green(`Pushed ${n} document${n !== 1 ? "s" : ""}`));
+      if (outcome.result.decided_by) console.log(chalk.dim(`  confirmed by ${outcome.result.decided_by}`));
+      return;
+    }
+    case "rejected":
+      console.error(
+        chalk.red(
+          `Push rejected${outcome.result.decided_by ? ` by ${outcome.result.decided_by}` : ""} — nothing was applied.`,
+        ),
+      );
+      return;
+    case "expired":
+      console.error(chalk.red("Push expired before it was confirmed — nothing was applied."));
+      return;
+    case "timeout":
+      console.error(
+        chalk.yellow("Timed out waiting for confirmation. The push is still pending — confirm it in the UI."),
+      );
+      return;
+  }
+}
+
 program
   .command("push")
   .description("Push the local vault to a hosted ContextNest server")
@@ -2356,6 +2390,22 @@ program
   .requiredOption("--nest <id>", "Target nest ID")
   .option("--key <apiKey>", "API key (cnst_…). Prefer the CONTEXTNEST_API_KEY env var — argv is visible to other processes")
   .option("--include-drafts", "Include draft documents (default: published only)", false)
+  .option(
+    "--no-wait",
+    "For a nest that gates pushes: submit, print the confirmation URL, and exit without waiting for the decision",
+  )
+  .option(
+    "--timeout <sec>",
+    "Max seconds to wait for a gated push to be confirmed (default: the server's window, else 15m)",
+    (v) => {
+      const n = Number(v);
+      if (!Number.isFinite(n) || n <= 0) {
+        console.error(chalk.red("--timeout must be a positive number of seconds."));
+        process.exit(1);
+      }
+      return n;
+    },
+  )
   .action(async (opts) => {
     // A key on the command line is readable by anyone who can list processes,
     // and lands in shell history. Accept it, but let the env var take over.
@@ -2427,13 +2477,55 @@ program
       // every document body to an unvalidated destination.
       assertNotRedirected(res, "--server");
 
-      if (!res.ok) {
+      if (!res.ok && res.status !== 202) {
         const err = await res.json().catch(() => ({ error: res.statusText }));
         console.error(chalk.red(`Push failed (${res.status}): ${err.error || res.statusText}`));
         process.exit(1);
       }
 
-      const data = (await res.json()) as { published: number; context_md_updated: boolean; node_ids: string[] };
+      const payload = await res.json().catch(() => null);
+
+      // A gated nest does not apply the push; it parks it for a human to
+      // confirm in the UI and answers 202. Treating that as success (any 2xx
+      // used to print "Pushed N") would misreport a push that never landed.
+      const pending = asPendingConfirmation(res.status, payload);
+      if (pending) {
+        console.log(chalk.yellow(pending.message || "This nest requires confirmation before the push is applied."));
+        console.log(chalk.cyan(`Confirm in the UI: ${pending.confirm_url}`));
+
+        // --no-wait → commander sets opts.wait = false.
+        if (opts.wait === false) {
+          console.error(chalk.dim("Submitted. Not waiting for the decision (--no-wait)."));
+          return; // exit 0: the submission itself succeeded
+        }
+
+        const timeoutMs = resolveTimeoutMs(opts.timeout as number | undefined, pending.expires_at);
+        console.error(chalk.dim("Waiting for confirmation… (Ctrl-C to stop; the push stays pending)"));
+
+        let printedProgress = false;
+        const outcome = await pollUntilDecided({
+          serverUrl,
+          pollUrl: pending.poll_url,
+          apiKey,
+          timeoutMs,
+          onPending: () => {
+            printedProgress = true;
+            process.stderr.write(chalk.dim("."));
+          },
+        });
+        if (printedProgress) process.stderr.write("\n");
+        reportPushOutcome(outcome);
+        process.exit(exitCodeFor(outcome));
+      }
+
+      if (res.status === 202) {
+        // 202, but not the pending-confirmation envelope we understand — do not
+        // claim success for a response whose meaning we can't read.
+        console.error(chalk.red("Push returned 202 with an unrecognized body — treating as not applied."));
+        process.exit(1);
+      }
+
+      const data = (payload ?? {}) as { published: number; context_md_updated: boolean; node_ids: string[] };
       console.log(chalk.green(`Pushed ${data.published} document${data.published !== 1 ? "s" : ""}`));
       if (data.context_md_updated) console.log(chalk.green("  CONTEXT.md updated"));
       for (const id of data.node_ids) {

--- a/packages/cli/src/push-confirm.ts
+++ b/packages/cli/src/push-confirm.ts
@@ -1,0 +1,204 @@
+/**
+ * Push confirmation gate for `ctx push`.
+ *
+ * A hosted nest can require a human to confirm an incoming push in the web UI
+ * before it is applied. When it does, the publish endpoint answers `202` with a
+ * `pending_confirmation` envelope instead of applying the documents, and the
+ * decision lands later. Treating that 202 as success (any 2xx used to print
+ * "Pushed N documents") would misreport a push that never applied — so the CLI
+ * has to recognise the pending envelope and, unless told not to, wait for the
+ * decision by polling the URL the server hands back.
+ *
+ * The wire contract is shared with the Community server (paired PR in
+ * PromptOwl/contextnest-community) and must not drift:
+ *
+ *   Normal push  → 200 { published, context_md_updated, node_ids }   (unchanged)
+ *   Gated push   → 202 { status: "pending_confirmation", pending_id,
+ *                          confirm_url, poll_url, message, expires_at }
+ *   Poll GET     → 200 { status: "pending" | "applied" | "rejected" | "expired",
+ *                          nest_name, doc_count, decided_by?, applied_node_count? }
+ *   where poll_url = /nests/:id/pending-pushes/:pid
+ *
+ * The polling state machine is deliberately free of wall-clock and network
+ * dependencies except through injectable `fetchFn` / `sleep` / `now`, so the
+ * branching (202 → poll → applied / rejected / expired / timeout) is unit
+ * testable with a mocked fetch and a fake clock — no real timers, no sockets.
+ */
+
+import { NO_REDIRECT, assertNotRedirected } from "./safety.js";
+
+// ─── Wire shapes ──────────────────────────────────────────────────────────────
+
+/** The 202 envelope a gated nest returns instead of applying the push. */
+export interface PendingConfirmation {
+  status: "pending_confirmation";
+  pending_id: string;
+  confirm_url: string;
+  /** Path (starts with `/`) to poll, e.g. `/nests/:id/pending-pushes/:pid`. */
+  poll_url: string;
+  message: string;
+  /** ISO timestamp after which the pending push is auto-expired, if provided. */
+  expires_at?: string;
+}
+
+export type PollStatus = "pending" | "applied" | "rejected" | "expired";
+
+/** The body of a poll response. */
+export interface PollResult {
+  status: PollStatus;
+  nest_name?: string;
+  doc_count?: number;
+  decided_by?: string;
+  applied_node_count?: number;
+}
+
+/**
+ * Recognise a POST response as the pending-confirmation envelope. Returns the
+ * parsed envelope for a well-formed `202 pending_confirmation`, or null for
+ * anything else (the caller keeps its existing 200 handling). A 202 whose body
+ * is *not* the pending shape is treated as unrecognised (null) so the caller
+ * can surface it rather than silently claiming success.
+ */
+export function asPendingConfirmation(status: number, body: unknown): PendingConfirmation | null {
+  if (status !== 202) return null;
+  if (!body || typeof body !== "object") return null;
+  const b = body as Record<string, unknown>;
+  if (b.status !== "pending_confirmation") return null;
+  if (typeof b.poll_url !== "string" || typeof b.pending_id !== "string") return null;
+  return {
+    status: "pending_confirmation",
+    pending_id: b.pending_id,
+    confirm_url: typeof b.confirm_url === "string" ? b.confirm_url : "",
+    poll_url: b.poll_url,
+    message: typeof b.message === "string" ? b.message : "",
+    expires_at: typeof b.expires_at === "string" ? b.expires_at : undefined,
+  };
+}
+
+// ─── Terminal outcome ─────────────────────────────────────────────────────────
+
+export type TerminalOutcome =
+  | { kind: "applied"; result: PollResult }
+  | { kind: "rejected"; result: PollResult }
+  | { kind: "expired"; result: PollResult }
+  | { kind: "timeout" };
+
+/** Process exit code for an outcome: 0 only when the push actually applied. */
+export function exitCodeFor(outcome: TerminalOutcome): number {
+  return outcome.kind === "applied" ? 0 : 1;
+}
+
+// ─── Timeout resolution ───────────────────────────────────────────────────────
+
+const DEFAULT_TIMEOUT_MS = 15 * 60 * 1000; // 15 minutes
+const MIN_TIMEOUT_MS = 1_000;
+
+/**
+ * Decide how long to wait for a decision.
+ *
+ * Explicit `--timeout <sec>` always wins. Otherwise fall back to the window the
+ * server itself advertised via `expires_at`, and if there is none (or it has
+ * already passed), the 15-minute default.
+ */
+export function resolveTimeoutMs(
+  timeoutSec: number | undefined,
+  expiresAt: string | undefined,
+  now: () => number = Date.now,
+): number {
+  if (typeof timeoutSec === "number" && Number.isFinite(timeoutSec) && timeoutSec > 0) {
+    return Math.max(MIN_TIMEOUT_MS, Math.round(timeoutSec * 1000));
+  }
+  if (expiresAt) {
+    const at = Date.parse(expiresAt);
+    if (!Number.isNaN(at)) {
+      const remaining = at - now();
+      if (remaining > 0) return Math.max(MIN_TIMEOUT_MS, remaining);
+    }
+  }
+  return DEFAULT_TIMEOUT_MS;
+}
+
+// ─── Polling state machine ────────────────────────────────────────────────────
+
+export interface PollOptions {
+  /** Hosted engine URL, trailing slash already trimmed. */
+  serverUrl: string;
+  /** `poll_url` from the server — an absolute path beginning with `/`. */
+  pollUrl: string;
+  apiKey: string;
+  /** Overall budget before giving up with a `timeout` outcome. */
+  timeoutMs: number;
+  /** Backoff floor (default 2s) and ceiling (default 10s). */
+  minDelayMs?: number;
+  maxDelayMs?: number;
+  /** Injectable seams — real implementations are the defaults. */
+  fetchFn?: typeof fetch;
+  sleep?: (ms: number) => Promise<void>;
+  now?: () => number;
+  /** Called before each wait with the still-pending poll result. */
+  onPending?: (attempt: number, result: PollResult) => void;
+}
+
+const realSleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * Poll `poll_url` until the server reports a terminal decision or the overall
+ * timeout is spent. Uncapped growth would either hammer the server or sleep
+ * past a decision, so the delay climbs from `minDelayMs` toward `maxDelayMs`
+ * and every sleep is clamped to the time left on the clock.
+ *
+ * A 401/403 is fatal (a bad key will never come good, so spinning for the whole
+ * timeout helps nobody). Any other transient failure — a 5xx, a 404 before the
+ * record is queryable, or a dropped connection — is retried until the deadline,
+ * then reported as a timeout.
+ */
+export async function pollUntilDecided(opts: PollOptions): Promise<TerminalOutcome> {
+  const fetchFn = opts.fetchFn ?? fetch;
+  const sleep = opts.sleep ?? realSleep;
+  const now = opts.now ?? Date.now;
+  const minDelay = opts.minDelayMs ?? 2_000;
+  const maxDelay = opts.maxDelayMs ?? 10_000;
+
+  const url = `${opts.serverUrl}${opts.pollUrl}`;
+  const deadline = now() + opts.timeoutMs;
+  let delay = minDelay;
+  let attempt = 0;
+
+  while (true) {
+    attempt++;
+    let result: PollResult | null = null;
+    try {
+      const res = await fetchFn(url, {
+        ...NO_REDIRECT,
+        method: "GET",
+        headers: { Authorization: `Bearer ${opts.apiKey}` },
+      });
+      assertNotRedirected(res, "--server");
+      if (res.status === 401 || res.status === 403) {
+        throw new Error(`poll rejected (${res.status}) — the API key is not authorized for this nest`);
+      }
+      if (res.ok) {
+        result = (await res.json()) as PollResult;
+      }
+      // A non-ok, non-auth status (5xx, 404) leaves result null → retried below.
+    } catch (err) {
+      // A hard auth failure is not recoverable; re-throw for the caller to
+      // report. Everything else is a transient blip we retry through.
+      if (err instanceof Error && /not authorized/.test(err.message)) throw err;
+      result = null;
+    }
+
+    if (result) {
+      if (result.status === "applied") return { kind: "applied", result };
+      if (result.status === "rejected") return { kind: "rejected", result };
+      if (result.status === "expired") return { kind: "expired", result };
+      // status === "pending" (or an unknown value treated as still-pending)
+      opts.onPending?.(attempt, result);
+    }
+
+    const remaining = deadline - now();
+    if (remaining <= 0) return { kind: "timeout" };
+    await sleep(Math.min(delay, remaining));
+    delay = Math.min(delay * 2, maxDelay);
+  }
+}


### PR DESCRIPTION
## Summary

The Community server is adding a **push-confirmation gate**: a nest can require a human to confirm an incoming push in the web UI before it is applied. When it does, the publish endpoint answers `202 pending_confirmation` and parks the documents instead of applying them.

Today `ctx push` POSTs the documents and treats **any 2xx as success** — so against a gated nest it prints `Pushed N documents` although nothing landed. This PR fixes that: the CLI recognizes the `202` envelope, surfaces the confirm URL, and (by default) polls to the decision, setting the exit code accordingly.

CLI-surface only — no engine core (versioning/hashing/compilation) touched, per the Engine Logic Boundary.

## What changed

- **`packages/cli/src/push-confirm.ts`** (new) — the response-branching + polling state machine:
  - `asPendingConfirmation(status, body)` — recognizes a well-formed `202 pending_confirmation` (else null; a 200 or a 202 of an unknown shape is never treated as pending).
  - `pollUntilDecided(opts)` — polls `poll_url` on a capped **2s → 10s** backoff until `applied | rejected | expired` or the overall timeout; `401/403` is fatal, other transient failures (5xx, 404, dropped connection) are retried until the deadline. Free of wall-clock/network deps except through injectable `fetchFn` / `sleep` / `now`, so it is deterministic under test.
  - `resolveTimeoutMs(--timeout, expires_at)` and `exitCodeFor(outcome)` (0 only when applied).
- **`packages/cli/src/index.ts`** — `ctx push` branches after the POST:
  - `200` → **unchanged** behavior.
  - `202 pending_confirmation` → print the server `message` and `Confirm in the UI: {confirm_url}`; unless `--no-wait`, print a lightweight `Waiting for confirmation…` progress line and poll to the terminal status. `applied` → `Pushed N documents` (exit 0); `rejected`/`expired`/`timeout` → the reason (exit non-zero).
  - New flags: **`--no-wait`** (submit, print confirm URL, exit 0 without polling) and **`--timeout <sec>`** (default: the server's `expires_at` window, else 15m).
- README + changeset (`@promptowl/contextnest-cli`: minor).

## Shared wire contract

Matches the paired server PR in **PromptOwl/contextnest-community** exactly:

- Normal (ungated/allowlisted) push → `200` with the existing body → unchanged.
- Gated push → `202 { status: "pending_confirmation", pending_id, confirm_url, poll_url, message, expires_at }`, where `poll_url = /nests/:id/pending-pushes/:pid`.
- Poll `GET {server}{poll_url}` (same Bearer key) → `{ status: "pending" | "applied" | "rejected" | "expired", nest_name, doc_count, decided_by?, applied_node_count? }`.

## Tests

- **Unit** (`push-confirm.test.ts`, mocked fetch + fake clock) — 15 tests: envelope recognition, timeout resolution, and the state machine: `202→pending→applied` (exit 0), `202→rejected` (non-zero), `expired`, timeout while pending, Bearer sent on every poll, transient-5xx retry, `401` abort, backoff cap.
- **Regression e2e** (`cli.regression.test.ts`, built CLI against a gated mock engine) — 3 new: `202→applied` reports the confirmed count (exit 0), rejected exits non-zero with nothing applied, `--no-wait` prints the confirm URL and never polls.
- **Results:** `pnpm lint` clean · `pnpm test` **1042 passed** · CLI regression suite **112 passed** (5 pre-existing push tests still green + 3 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013vxHApMPQycP1RcstM74mC