### PR TITLE
fix(cli): keep the folder path when adding a node to a remote nest

### DIFF
--- a/packages/cli/src/__tests__/remote-capabilities.test.ts
+++ b/packages/cli/src/__tests__/remote-capabilities.test.ts
@@ -51,7 +51,7 @@ vi.mock("@promptowl/contextnest-engine", async (importOriginal) => {
   };
 });
 
-const { remotePublish, remoteVerify } = await import("../remote.js");
+const { remoteAdd, remotePublish, remoteVerify } = await import("../remote.js");
 const { configureSafety } = await import("../safety.js");
 
 const target = {
@@ -163,5 +163,25 @@ describe("remotePublish — capability gate", () => {
     expect((err as Error).message).toContain("Nothing was published");
     expect(calls).toEqual([]);
     expect(closed).toBe(opened);
+  });
+});
+
+describe("remoteAdd — folder", () => {
+  it("sends the folder segment alongside the id so a nest that ignores id still files it right", async () => {
+    advertised = new Set(["context_create"]);
+    replies.context_create = { id: "nodes/repo/thing", version: 1 };
+
+    await remoteAdd(target, "nodes/repo/thing", {});
+
+    expect(calls[0].input).toMatchObject({ id: "nodes/repo/thing", folder: "repo" });
+  });
+
+  it("omits folder for a node at the nest root", async () => {
+    advertised = new Set(["context_create"]);
+    replies.context_create = { id: "nodes/thing", version: 1 };
+
+    await remoteAdd(target, "nodes/thing", {});
+
+    expect(calls[0].input).not.toHaveProperty("folder");
   });
 });

--- a/packages/cli/src/remote.ts
+++ b/packages/cli/src/remote.ts
@@ -337,6 +337,17 @@ async function confirmRemoteWrite(
   await confirmOrExit(question, opts);
 }
 
+/**
+ * Folder segment of a document id — everything between the `nodes/` root and
+ * the final slug. `nodes/repo/thing` -> `repo`; `nodes/thing` -> `""`.
+ */
+export function folderFromId(id: string): string {
+  const segments = id.split("/");
+  if (segments[0] === "nodes") segments.shift();
+  segments.pop();
+  return segments.join("/");
+}
+
 export async function remoteAdd(
   target: RemoteTarget,
   path: string,
@@ -362,6 +373,13 @@ export async function remoteAdd(
       title,
       content: opts.body ? `\n${opts.body}\n` : `\n# ${title}\n\n`,
     };
+    // Send the folder alongside the id. A nest whose `context_create` predates
+    // the catalog's `id` parameter drops that key and derives the id from the
+    // title alone, filing every remote `ctx add nodes/<folder>/<slug>` flat at
+    // the nest root; `folder` has been in the op the whole time. A catalog-
+    // conformant nest is unaffected — an explicit `id` overrides `folder`.
+    const folder = folderFromId(id);
+    if (folder) input.folder = folder;
     if (opts.type) input.type = opts.type;
     if (tags) input.tags = tags;
 


### PR DESCRIPTION
## What

`ctx add nodes/<folder>/<slug>` against a **remote** nest ignored the folder and filed the node flat at the nest root. This makes the folder land where it was typed.

Closes CU-wdqcq01cat.

## Why

The CLI addressed the new node by full path, on the assumption that every nest's `context_create` accepts an explicit id. The engine's catalog version does — a hand-rolled schema on the hosted nest does not, so the path was dropped and the id was re-derived from the title at the root. Net effect: the one-folder-per-repo convention couldn't be maintained through the CLI at all, on any remote nest.

## How

Remote creates now send the folder *alongside* the id, rather than relying on the id alone. Nests that don't understand the id honour the folder; catalog-conformant nests are unaffected, since an explicit id takes precedence over the folder there.

Belt-and-braces on purpose: it needs no server deploy and it can't regress a nest that was already working.

## Not in scope

The underlying divergence — the hosted nest declaring its own `context_create` schema instead of taking the engine catalog's — stays open, tracked on the ticket. Until that lands, an old nest still derives the id from the title text, so a remote-created id can differ from the exact slug typed. Only the folder is fixed here.

## Testing

Unit coverage for both branches (nested path sends a folder, root-level node doesn't). `pnpm lint` and `pnpm test` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)