### PR TITLE
fix(plugin): cwd vault first, skip missing/tmp vaults in auto-retrieval [CU-wdqcq01c5v]

### DIFF
--- a/.changeset/vault-which-json.md
+++ b/.changeset/vault-which-json.md
@@ -1,0 +1,5 @@
+---
+"@promptowl/contextnest-cli": patch
+---
+
+`ctx vault which --json`: machine-readable resolution (`{kind, path|endpoint, source, alias?, warning?}`), so scripted callers — the coding-agent plugin hooks in particular — can find the vault in the working directory without parsing the coloured text output.

--- a/README.md
+++ b/README.md
@@ -487,7 +487,7 @@ export CONTEXTNEST_VAULT_PATH=/path/to/your/vault
 | `ctx vault describe <alias> [description]` | Set a registry description; omit the text to clear it |
 | `ctx vault remove <alias>` | Unregister an alias |
 | `ctx vault default <alias>` | Set the default vault |
-| `ctx vault which` | Show the resolved vault and the reason |
+| `ctx vault which [--json]` | Show the resolved vault and the reason |
 
 ### Document Management
 

--- a/packages/cli/src/__tests__/vault-registry.test.ts
+++ b/packages/cli/src/__tests__/vault-registry.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, mkdirSync, existsSync, readFileSync, rmSync } from "node:fs";
+import { mkdtempSync, mkdirSync, existsSync, readFileSync, realpathSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -101,6 +101,25 @@ describe("ctx vault — central registry", () => {
     const which = run(["vault", "which"], outside, { CONTEXTNEST_VAULT: "alpha" });
     expect(which).toContain("source: env-alias");
     expect(which).toContain("alias: alpha");
+  });
+
+  it("vault which --json reports the resolved vault as a machine-readable object [CU-wdqcq01c5v]", () => {
+    const a = join(tmp, "a");
+    mkdirSync(a, { recursive: true });
+    run(["init", "--name", "A", "--vault", "alpha"], a);
+
+    // Inside the vault: resolved by the cwd walk-up.
+    const local = JSON.parse(run(["vault", "which", "--json"], a));
+    expect(local.kind).toBe("local");
+    expect(local.source).toBe("local");
+    expect(realpathSync(local.path)).toBe(realpathSync(a));
+    expect(local.alias).toBeUndefined();
+
+    // Outside, by flag: same shape, with the alias that was used.
+    const outside = join(tmp, "outside");
+    mkdirSync(outside, { recursive: true });
+    const flagged = JSON.parse(run(["vault", "which", "--json", "--vault", "alpha"], outside));
+    expect(flagged).toMatchObject({ kind: "local", source: "flag", alias: "alpha" });
   });
 
   it("surfaces a clear error for an unknown --vault alias", () => {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2942,7 +2942,8 @@ vaultCmd
 vaultCmd
   .command("which")
   .description("Show which vault the CLI would use right now, and why (respects --vault)")
-  .action(() => {
+  .option("--json", "Output as JSON ({kind, path|endpoint, source, alias?, warning?})")
+  .action((opts) => {
     try {
       const resolved = resolveNest({
         vaultAlias: selectedVaultAlias,
@@ -2953,6 +2954,30 @@ vaultCmd
       // a local resolution).
       if (resolved.warning) {
         console.error(chalk.yellow(resolved.warning));
+      }
+      if (opts.json) {
+        // Machine-readable form for scripted callers (the plugin hooks use it
+        // to find the vault in the working directory). Same fields as the text
+        // output, no colour, one object.
+        const out =
+          resolved.kind === "remote"
+            ? {
+                kind: "remote",
+                alias: resolved.alias,
+                source: resolved.source,
+                transport: resolved.remote.transport,
+                endpoint: describeRemoteEndpoint(resolved.remote),
+                ...(resolved.warning ? { warning: resolved.warning } : {}),
+              }
+            : {
+                kind: "local",
+                path: resolved.path,
+                source: resolved.source,
+                ...(resolved.alias ? { alias: resolved.alias } : {}),
+                ...(resolved.warning ? { warning: resolved.warning } : {}),
+              };
+        console.log(JSON.stringify(out, null, 2));
+        return;
       }
       if (resolved.kind === "remote") {
         console.log(`${resolved.alias} ${chalk.magenta(`(remote, ${resolved.remote.transport})`)}`);

--- a/plugins/__tests__/core.unit.test.ts
+++ b/plugins/__tests__/core.unit.test.ts
@@ -50,6 +50,7 @@ import {
   VALID_RETRIEVAL_MODES,
   makeExec,
   winQuote,
+  MAX_FANOUT_VAULTS,
 } from "../shared/core/lib.js";
 
 /** Transcript stub in the shape the gate's reader returns. */
@@ -388,6 +389,78 @@ describe("lib helpers", () => {
     expect(vaultTargets(getConfig({ CONTEXTNEST_VAULT_ALIAS: "gone" }), missing)).toEqual([null]);
   });
 
+  // CU-wdqcq01c5v — the vault in the working directory used to be ignored
+  // whenever the registry was non-empty, and the fan-out happily hit demo/tmp
+  // vaults ahead of it.
+  it("vaultTargets: the cwd vault is searched first (as null), then the registry", () => {
+    const ex = fakeExec([
+      ["vault list", [
+        { alias: "demo", path: "/vaults/demo", exists: true },
+        { alias: "crm", path: "/vaults/crm", exists: true },
+      ]],
+      ["vault which", { kind: "local", path: "/work/notes", source: "local" }],
+    ]);
+    expect(vaultTargets(getConfig({}), ex)).toEqual([null, "demo", "crm"]);
+  });
+
+  it("vaultTargets: a cwd vault that is also registered is searched once, by alias, first", () => {
+    const ex = fakeExec([
+      ["vault list", [
+        { alias: "demo", path: "/vaults/demo", exists: true },
+        { alias: "crm", path: "/vaults/crm", exists: true },
+      ]],
+      ["vault which", { kind: "local", path: "/vaults/crm", source: "local" }],
+    ]);
+    expect(vaultTargets(getConfig({}), ex)).toEqual(["crm", "demo"]);
+  });
+
+  it("vaultTargets: registry entries that are missing or live under os.tmpdir() are never targeted", () => {
+    const scratch = join(tmpdir(), "cn-scratch-vault");
+    const registry = [
+      { alias: "gone", path: "/vaults/gone", exists: false },
+      { alias: "scratch", path: scratch, exists: true },
+      { alias: "demo", path: "/vaults/demo", exists: true },
+    ];
+    // No cwd vault (ctx would fall back to the bare cwd) → only the real one.
+    const noCwd = fakeExec([
+      ["vault list", registry],
+      ["vault which", { kind: "local", path: "/elsewhere", source: "cwd" }],
+    ]);
+    expect(vaultTargets(getConfig({}), noCwd)).toEqual(["demo"]);
+    // Nothing eligible and no cwd vault → let ctx resolve, as with an empty registry.
+    const nothing = fakeExec([
+      ["vault list", registry.slice(0, 2)],
+      ["vault which", { kind: "local", path: "/elsewhere", source: "cwd" }],
+    ]);
+    expect(vaultTargets(getConfig({}), nothing)).toEqual([null]);
+    // A cwd vault that happens to live under tmp is a deliberate choice → kept.
+    const cwdInTmp = fakeExec([
+      ["vault list", registry],
+      ["vault which", { kind: "local", path: scratch, source: "local" }],
+    ]);
+    expect(vaultTargets(getConfig({}), cwdInTmp)).toEqual(["scratch", "demo"]);
+  });
+
+  it("vaultTargets: the cwd vault counts against MAX_FANOUT_VAULTS", () => {
+    const many = Array.from({ length: 8 }, (_, i) => ({ alias: `v${i}`, path: `/vaults/v${i}`, exists: true }));
+    const ex = fakeExec([
+      ["vault list", many],
+      ["vault which", { kind: "local", path: "/work/notes", source: "local" }],
+    ]);
+    const targets = vaultTargets(getConfig({}), ex);
+    expect(targets).toHaveLength(MAX_FANOUT_VAULTS);
+    expect(targets[0]).toBeNull();
+    expect(targets.slice(1)).toEqual(["v0", "v1", "v2", "v3"]);
+  });
+
+  it("vaultTargets: a registered pin still short-circuits, even with a cwd vault", () => {
+    const ex = fakeExec([
+      ["vault list", [{ alias: "a", path: "/vaults/a", exists: true }, { alias: "b", path: "/vaults/b", exists: true }]],
+      ["vault which", { kind: "local", path: "/work/notes", source: "local" }],
+    ]);
+    expect(vaultTargets(getConfig({ CONTEXTNEST_VAULT_ALIAS: "a" }), ex)).toEqual(["a"]);
+  });
+
   it("isVaultRegistered: true only for a registered, present alias", () => {
     const vaults = [{ alias: "a", exists: true }, { alias: "gone", exists: false }];
     expect(isVaultRegistered("a", vaults)).toBe(true);
@@ -442,6 +515,22 @@ describe("retrieve", () => {
     const out = retrieve({ input: { prompt: "topic" }, env: env("search"), exec: ex });
     expect(additional(out)).toContain("work:nodes/w");
     expect(additional(out)).toContain("home:nodes/h");
+  });
+
+  it("search → the cwd vault's hits come first and are cited without an alias prefix", () => {
+    const ex = (args: string[]) => {
+      const k = args.join(" ");
+      if (k.includes("vault list")) return json([{ alias: "demo", path: "/vaults/demo", exists: true }]);
+      if (k.includes("vault which")) return json({ kind: "local", path: "/work/notes", source: "local" });
+      if (k.includes("--vault demo")) return json([{ id: "nodes/gi", title: "Gastro", type: "document" }]);
+      if (k.startsWith("search")) return json([{ id: "nodes/local", title: "Local Note", type: "document" }]);
+      return json([]);
+    };
+    const out = retrieve({ input: { prompt: "topic" }, env: env("search"), exec: ex });
+    const text = additional(out)!;
+    expect(text).toContain("- nodes/local — Local Note");
+    expect(text).toContain("- demo:nodes/gi — Gastro");
+    expect(text.indexOf("nodes/local")).toBeLessThan(text.indexOf("demo:nodes/gi"));
   });
 
   it("query → maps ids to tags via ctx list then injects graph documents", () => {
@@ -542,6 +631,37 @@ describe("session-start", () => {
     // Must NOT claim the ghost pin is in effect, and no vault is flagged pinned.
     expect(ctx).not.toContain("all queries/captures use it");
     expect(ctx).not.toContain("pinned");
+  });
+
+  it("mentions a working-directory vault when one is detected", () => {
+    const ex = fakeExec([
+      ["vault list", [{ alias: "work", path: "/vaults/work", exists: true }]],
+      ["vault which", { kind: "local", path: "/proj/notes", source: "local" }],
+    ]);
+    const out = sessionStart({ input: { cwd: "/proj/notes" }, env: {}, exec: ex });
+    const ctx = additional(out)!;
+    expect(ctx).toMatch(/working-directory vault/i);
+    expect(ctx).toContain("/proj/notes");
+    expect(ctx).toMatch(/not registered/i);
+  });
+
+  it("names the alias when the working-directory vault is registered", () => {
+    const ex = fakeExec([
+      ["vault list", [{ alias: "work", path: "/vaults/work", exists: true }]],
+      ["vault which", { kind: "local", path: "/vaults/work", source: "local" }],
+    ]);
+    const ctx = additional(sessionStart({ input: {}, env: {}, exec: ex }))!;
+    expect(ctx).toMatch(/working-directory vault/i);
+    expect(ctx).toContain("`work`");
+    expect(ctx).not.toMatch(/not registered/i);
+  });
+
+  it("does not mention a working-directory vault when the cwd is not a vault", () => {
+    const ex = fakeExec([
+      ["vault list", [{ alias: "work", path: "/vaults/work", exists: true }]],
+      ["vault which", { kind: "local", path: "/elsewhere", source: "default", alias: "work" }],
+    ]);
+    expect(additional(sessionStart({ input: {}, env: {}, exec: ex }))).not.toMatch(/working-directory vault/i);
   });
 
   it("notes local resolution when no vaults are registered", () => {

--- a/plugins/__tests__/retrieval.regression.test.ts
+++ b/plugins/__tests__/retrieval.regression.test.ts
@@ -53,22 +53,40 @@ const ctx = (out: any): string => out?.hookSpecificOutput?.additionalContext ?? 
 
 let alphaDir: string;
 let betaDir: string;
+let gammaDir: string;
+let scratchDir: string;
 let workspace: string;
 
+// The registered vaults must NOT live under os.tmpdir(): auto-retrieval skips
+// tmp-registered vaults on purpose (scratch vaults agents create — see
+// vaultTargets), so a workspace there would never fan out. `fixtures/*` at the
+// repo root is gitignored (only minimal-vault is tracked).
+const SCRATCH_ROOT = join(here, "..", "..", "fixtures");
+
 beforeAll(() => {
-  workspace = mkdtempSync(join(tmpdir(), "cn-plugin-reg-"));
+  mkdirSync(SCRATCH_ROOT, { recursive: true });
+  workspace = mkdtempSync(join(SCRATCH_ROOT, "cn-plugin-reg-"));
   alphaDir = join(workspace, "alpha");
   betaDir = join(workspace, "beta");
+  gammaDir = join(workspace, "gamma");
+  scratchDir = mkdtempSync(join(tmpdir(), "cn-plugin-reg-scratch-"));
   mkdirSync(alphaDir, { recursive: true });
   mkdirSync(betaDir, { recursive: true });
-  // `ctx init` initializes in the cwd and auto-registers an alias = --name.
-  ctl(alphaDir, ["init", "--name", "alpha", "--description", "security and auth"]);
-  ctl(betaDir, ["init", "--name", "beta", "--description", "performance and caching"]);
+  mkdirSync(gammaDir, { recursive: true });
+  // `ctx init` initializes in the cwd and registers it under --vault <alias>.
+  ctl(alphaDir, ["init", "--name", "alpha", "--vault", "alpha", "--description", "security and auth"]);
+  ctl(betaDir, ["init", "--name", "beta", "--vault", "beta", "--description", "performance and caching"]);
+  // gamma is a vault on disk but NOT in the registry (the cwd-vault case).
+  ctl(gammaDir, ["init", "--name", "gamma", "--vault", "gamma", "--description", "unregistered local notes"]);
+  ctl(workspace, ["vault", "remove", "gamma", "--yes"]);
+  // scratch is registered but lives under os.tmpdir() (an agent's throwaway).
+  ctl(scratchDir, ["init", "--name", "scratch", "--vault", "scratch", "--description", "throwaway"]);
 });
 
 afterAll(() => {
   rmSync(CONFIG_DIR, { recursive: true, force: true });
   rmSync(workspace, { recursive: true, force: true });
+  rmSync(scratchDir, { recursive: true, force: true });
 });
 
 describe("[regression] plugin retrieval against a real vault", () => {
@@ -96,8 +114,57 @@ describe("[regression] plugin retrieval against a real vault", () => {
     // At least the registry fan-out wiring resolves both aliases without error.
     // (Search relevance for the word "design" may vary; assert the mechanism.)
     const vaults = JSON.parse(ctl(workspace, ["vault", "list", "--json"]));
-    expect(vaults.map((v: any) => v.alias).sort()).toEqual(["alpha", "beta"]);
+    expect(vaults.map((v: any) => v.alias).sort()).toEqual(["alpha", "beta", "scratch"]);
     expect(out === null || typeof ctx(out) === "string").toBe(true);
+  });
+
+  // CU-wdqcq01c5v — the vault in the working directory is searched first, and
+  // registered vaults that are missing or live under os.tmpdir() are skipped.
+  it("unpinned, cwd inside registered vault alpha → alpha is searched (once, by alias)", () => {
+    const out = retrieve({
+      input: { prompt: "auth", cwd: alphaDir },
+      env: { CONTEXTNEST_RETRIEVAL_MODE: "search" },
+      exec: realExec(alphaDir),
+    });
+    // The cwd vault is also registered, so it is targeted by alias rather than
+    // searched twice: the ref keeps the `alpha:` prefix and appears exactly once.
+    const text = ctx(out);
+    expect(text).toContain("alpha:nodes/auth");
+    expect(text.match(/nodes\/auth/g)).toHaveLength(1);
+  });
+
+  it("unpinned, cwd inside an UNREGISTERED vault → its nodes come first, unprefixed, ahead of the registry", () => {
+    ctl(gammaDir, ["add", "nodes/local-auth", "--title", "Local Auth Notes", "--tags", "auth", "--body", "JWT rotation, local copy."]);
+    const out = retrieve({
+      input: { prompt: "auth", cwd: gammaDir },
+      env: { CONTEXTNEST_RETRIEVAL_MODE: "search" },
+      exec: realExec(gammaDir),
+    });
+    const text = ctx(out);
+    // gamma is not registered → cited without an alias prefix.
+    expect(text).toContain("- nodes/local-auth — Local Auth Notes");
+    expect(text).not.toContain("gamma:");
+    // The registry is still consulted after the cwd vault.
+    expect(text).toContain("alpha:nodes/auth");
+    expect(text.indexOf("nodes/local-auth")).toBeLessThan(text.indexOf("alpha:nodes/auth"));
+  });
+
+  it("a registered vault under os.tmpdir() is never searched", () => {
+    ctl(scratchDir, ["add", "nodes/scratch-auth", "--title", "Scratch Auth", "--tags", "auth", "--body", "JWT rotation, throwaway."]);
+    const out = retrieve({
+      input: { prompt: "auth", cwd: workspace },
+      env: { CONTEXTNEST_RETRIEVAL_MODE: "search" },
+      exec: realExec(workspace),
+    });
+    const text = ctx(out);
+    expect(text).toContain("alpha:nodes/auth");
+    expect(text).not.toContain("scratch");
+  });
+
+  it("session-start names the working-directory vault", () => {
+    const out = sessionStart({ input: { cwd: gammaDir }, env: {}, exec: realExec(gammaDir) });
+    expect(ctx(out)).toMatch(/working-directory vault/i);
+    expect(ctx(out)).toMatch(/not registered/i);
   });
 
   it("query tier maps tags and loads the graph for a seeded node", () => {

--- a/plugins/__tests__/retrieval.regression.test.ts
+++ b/plugins/__tests__/retrieval.regression.test.ts
@@ -19,6 +19,25 @@ const distPath = join(here, "..", "..", "packages", "cli", "dist", "index.js");
 
 // Sandbox the central registry so `ctx init` never touches the real config.
 const CONFIG_DIR = mkdtempSync(join(tmpdir(), "cn-plugin-reg-cfg-"));
+
+// The core's getConfig() reads the real override files when the caller doesn't
+// inject cwd/homedir, and the file layers beat env — so a developer's own
+// ~/.contextnest/plugin-settings.json (a pinned vault, or retrieval_mode:
+// "query") silently overrides the CONTEXTNEST_RETRIEVAL_MODE these tests pass
+// and changes both the targets and the rendered format. Point the home and
+// project dirs at an empty temp dir before baseEnv is built, so the in-process
+// run() calls and the spawned CLI both see it. os.homedir() reads $HOME on
+// POSIX and %USERPROFILE% on Windows, so both are set.
+const NO_SETTINGS = mkdtempSync(join(tmpdir(), "cn-plugin-reg-nosettings-"));
+const realEnv = {
+  HOME: process.env.HOME,
+  USERPROFILE: process.env.USERPROFILE,
+  CLAUDE_PROJECT_DIR: process.env.CLAUDE_PROJECT_DIR,
+};
+process.env.HOME = NO_SETTINGS;
+process.env.USERPROFILE = NO_SETTINGS;
+process.env.CLAUDE_PROJECT_DIR = NO_SETTINGS;
+
 const baseEnv = {
   ...process.env,
   CONTEXTNEST_NO_BROWSER: "1",
@@ -84,7 +103,12 @@ beforeAll(() => {
 });
 
 afterAll(() => {
+  for (const [key, value] of Object.entries(realEnv)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
   rmSync(CONFIG_DIR, { recursive: true, force: true });
+  rmSync(NO_SETTINGS, { recursive: true, force: true });
   rmSync(workspace, { recursive: true, force: true });
   rmSync(scratchDir, { recursive: true, force: true });
 });

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "contextnest",
   "displayName": "Context Nest",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Vault-aware context retrieval and automatic knowledge capture, powered by the Context Nest `ctx` CLI.",
   "author": { "name": "PromptOwl" },
   "homepage": "https://github.com/promptowl/contextnest",

--- a/plugins/claude-code/CHANGELOG.md
+++ b/plugins/claude-code/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## 0.5.2
+
+Auto-retrieval searches the vault you are standing in first, and stops
+injecting nodes from vaults you never meant to search.
+
+- **The working-directory vault is searched first.** `vaultTargets()` fanned
+  out across the first five registry entries, in registry order, and never
+  looked at the vault in the working directory once the registry was
+  non-empty. A session inside an unregistered vault got every prompt answered
+  with six nodes from a demo vault instead. Targets now resolve as: pinned
+  alias (if registered) → the vault `ctx vault which` finds from the cwd → the
+  registry, capped at five in total. The cwd vault is searched with no
+  `--vault` flag, so ctx resolves it locally and its hits are cited as a bare
+  `id`. When that same directory is also registered, it is searched once, by
+  its alias, still first — a hit keeps a citable `alias:id` and is never
+  listed twice.
+- **Missing and scratch vaults are skipped.** Registry entries whose path is
+  gone (`exists: false`) or lives under the OS temp directory — the throwaway
+  vaults agents `ctx init` while testing — are no longer fanned out to. A cwd
+  vault or a pin is a deliberate choice and is never filtered.
+- **SessionStart names the working-directory vault** and whether it is
+  registered, so "which vault is this session using?" is answered up front.
+- Needs a CLI that knows `ctx vault which --json` (any release after
+  2.3.0); an older CLI simply behaves as before, minus the cwd-first step.
+
 ## 0.5.1
 
 Retrieval worked on paper and returned nothing on Windows, and returned too

--- a/plugins/claude-code/core/lib.js
+++ b/plugins/claude-code/core/lib.js
@@ -369,8 +369,11 @@ export function samePath(a, b) {
 }
 
 /**
- * True when `path` is `root` or lives under it. `path.relative` is already
- * case-insensitive on Windows; realpath'd forms are compared too (see samePath).
+ * True when `path` is `root` or lives under it. Both the given and the
+ * realpath'd forms of each side are compared (see samePath), so a symlinked
+ * temp dir still matches. Note: `path.relative` does not case-fold; on Windows
+ * the realpath step normalizes to on-disk casing when the path exists, and a
+ * not-yet-existing path is compared as given.
  */
 function isUnder(path, root) {
   const inside = (p, r) => {

--- a/plugins/claude-code/core/lib.js
+++ b/plugins/claude-code/core/lib.js
@@ -12,9 +12,9 @@
  */
 
 import { execFileSync } from "node:child_process";
-import { readFileSync } from "node:fs";
-import { homedir as osHomedir } from "node:os";
-import { join } from "node:path";
+import { readFileSync, realpathSync } from "node:fs";
+import { homedir as osHomedir, tmpdir as osTmpdir } from "node:os";
+import { isAbsolute, join, relative, resolve } from "node:path";
 
 /** Windows needs shell-based spawning for npm's .cmd shims — see makeExec. */
 const WIN32 = process.platform === "win32";
@@ -345,6 +345,77 @@ export function isVaultRegistered(alias, vaults) {
   return vaults.some((v) => v.alias === alias && v.exists !== false);
 }
 
+/** Best-effort canonical form of a path: realpath when it exists, else resolved. */
+function canonical(p) {
+  const abs = resolve(String(p));
+  try {
+    return realpathSync(abs);
+  } catch {
+    return abs;
+  }
+}
+
+/**
+ * True when two paths name the same directory. Compared in both their given
+ * and realpath'd forms, so a symlinked temp dir (macOS `/var` → `/private/var`)
+ * or a path that doesn't exist yet still matches its twin.
+ */
+export function samePath(a, b) {
+  if (!a || !b) return false;
+  const forms = (p) => new Set([resolve(String(p)), canonical(p)]);
+  const fa = forms(a);
+  for (const f of forms(b)) if (fa.has(f)) return true;
+  return false;
+}
+
+/**
+ * True when `path` is `root` or lives under it. `path.relative` is already
+ * case-insensitive on Windows; realpath'd forms are compared too (see samePath).
+ */
+function isUnder(path, root) {
+  const inside = (p, r) => {
+    const rel = relative(r, p);
+    return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
+  };
+  for (const r of [resolve(String(root)), canonical(root)]) {
+    for (const p of [resolve(String(path)), canonical(path)]) {
+      if (inside(p, r)) return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * True when a vault path lives under the OS temp directory. Agents create
+ * scratch vaults there (and `ctx init` registers them), and nobody wants a
+ * throwaway's nodes injected into every prompt of a real session.
+ * `tmp` is injectable for tests; defaults to os.tmpdir().
+ */
+export function isTmpVaultPath(path, tmp = osTmpdir()) {
+  if (!path || !tmp) return false;
+  return isUnder(path, tmp);
+}
+
+/**
+ * The vault ctx resolves from the working directory alone, via
+ * `ctx vault which --json` (exec already runs in the hook's cwd). Only a
+ * `source: "local"` resolution counts — i.e. a `.context/config.yaml` found by
+ * walking up from cwd. A registry default, an env override, or the bare-cwd
+ * fallback is NOT a cwd vault. Returns `{ path, alias }` where `alias` is the
+ * registered alias for that same path when there is one (else null), or null
+ * when the cwd is not inside a vault (or ctx is too old to know `--json`).
+ *
+ * @param {(args:string[]) => any} exec
+ * @param {{alias:string, path?:string, exists?:boolean}[]} vaults from listVaults()
+ */
+export function cwdVault(exec, vaults = []) {
+  const which = ctxJson(exec, ["vault", "which", "--json"], null);
+  if (!which || typeof which !== "object" || Array.isArray(which)) return null;
+  if (which.kind !== "local" || which.source !== "local" || !which.path) return null;
+  const match = vaults.find((v) => v.exists !== false && v.path && samePath(v.path, which.path));
+  return { path: which.path, alias: match ? match.alias : null };
+}
+
 /**
  * Decide which vault aliases the cheap (non-agent) tiers should search.
  *
@@ -352,19 +423,37 @@ export function isVaultRegistered(alias, vaults) {
  *  - Pinned alias, NOT registered (stale/removed pin) → ignore the pin and
  *    behave as unpinned, rather than passing ctx a bad --vault that resolves to
  *    nothing. session-start surfaces a warning so this isn't silent.
- *  - Unpinned + registry     → fan out across registered vaults (capped).
- *  - Unpinned + empty registry → a single null target, i.e. let ctx resolve the
- *                                 local/default vault with no --vault flag.
+ *  - Unpinned → the vault in the working directory FIRST, then registered
+ *    vaults in registry order, capped at MAX_FANOUT_VAULTS in total.
+ *      · The cwd vault is targeted as `null` (no --vault, ctx resolves it
+ *        locally) and its hits are cited without an alias prefix. When that
+ *        same directory is also registered it is targeted by its alias
+ *        instead — once, still first — so a hit keeps a citable `alias:id`
+ *        and is never listed twice.
+ *      · Registry entries whose path is missing (`exists: false`) or lives
+ *        under os.tmpdir() (scratch vaults agents create) are skipped. A cwd
+ *        vault or a pin is a deliberate choice and is never filtered.
+ *  - Unpinned + nothing eligible + no cwd vault → a single null target, i.e.
+ *    let ctx resolve the local/default vault with no --vault flag.
  *
  * @param {ReturnType<typeof getConfig>} config
  * @param {(args:string[]) => any} exec
  * @returns {(string|null)[]} list of alias targets (null = ctx default resolution)
  */
 export function vaultTargets(config, exec) {
-  const vaults = listVaults(exec).filter((v) => v.exists !== false);
-  if (isVaultRegistered(config.vault, vaults)) return [config.vault];
-  if (vaults.length === 0) return [null];
-  return vaults.slice(0, MAX_FANOUT_VAULTS).map((v) => v.alias);
+  const present = listVaults(exec).filter((v) => v.exists !== false);
+  if (isVaultRegistered(config.vault, present)) return [config.vault];
+
+  const local = cwdVault(exec, present);
+  const targets = [];
+  if (local) targets.push(local.alias);
+  for (const v of present) {
+    if (targets.length >= MAX_FANOUT_VAULTS) break;
+    if (local && v.alias === local.alias) continue;
+    if (isTmpVaultPath(v.path)) continue;
+    targets.push(v.alias);
+  }
+  return targets.length === 0 ? [null] : targets;
 }
 
 /** Collapse internal whitespace and trim, for compact single-line context. */

--- a/plugins/claude-code/core/session-start.js
+++ b/plugins/claude-code/core/session-start.js
@@ -4,12 +4,14 @@
  * Runs `ctx vault list --json`. If ctx is unavailable, injects a one-line
  * warning instead of failing (a hook must never break the session). Otherwise
  * injects the registered vault aliases + descriptions, marks the pinned/default
- * one, and nudges the model to use the vault before answering.
+ * one, names the vault found in the working directory (if any), and nudges the
+ * model to use the vault before answering.
  */
 
 import {
   getConfig,
   ctxJson,
+  cwdVault,
   isVaultRegistered,
   squish,
   runAsHook,
@@ -59,9 +61,24 @@ export function run({ env, exec }) {
     lines.push(`Pinned vault: \`${config.vault}\` (all queries/captures use it).`);
   }
 
+  // The vault in the working directory is what auto-retrieval searches first
+  // (see vaultTargets); say so, and whether it is also a registered alias.
+  const local = cwdVault(exec, vaults);
+  if (local) {
+    const how = local.alias
+      ? `registered as \`${local.alias}\``
+      : "not registered — cited without an alias prefix";
+    const rank = pinnedIsRegistered
+      ? "the pinned vault takes precedence for auto-retrieval"
+      : "searched first on every prompt";
+    lines.push(`Working-directory vault: \`${local.path}\` (${how}; ${rank}).`);
+  }
+
   if (vaults.length === 0) {
     lines.push(
-      "No vaults are registered; `ctx` will resolve a local `.context` vault from the working directory if present.",
+      local
+        ? "No vaults are registered; `ctx` resolves the working-directory vault above."
+        : "No vaults are registered; `ctx` will resolve a local `.context` vault from the working directory if present.",
     );
   } else {
     lines.push("Registered vaults:");

--- a/plugins/shared/core/lib.js
+++ b/plugins/shared/core/lib.js
@@ -369,8 +369,11 @@ export function samePath(a, b) {
 }
 
 /**
- * True when `path` is `root` or lives under it. `path.relative` is already
- * case-insensitive on Windows; realpath'd forms are compared too (see samePath).
+ * True when `path` is `root` or lives under it. Both the given and the
+ * realpath'd forms of each side are compared (see samePath), so a symlinked
+ * temp dir still matches. Note: `path.relative` does not case-fold; on Windows
+ * the realpath step normalizes to on-disk casing when the path exists, and a
+ * not-yet-existing path is compared as given.
  */
 function isUnder(path, root) {
   const inside = (p, r) => {

--- a/plugins/shared/core/lib.js
+++ b/plugins/shared/core/lib.js
@@ -12,9 +12,9 @@
  */
 
 import { execFileSync } from "node:child_process";
-import { readFileSync } from "node:fs";
-import { homedir as osHomedir } from "node:os";
-import { join } from "node:path";
+import { readFileSync, realpathSync } from "node:fs";
+import { homedir as osHomedir, tmpdir as osTmpdir } from "node:os";
+import { isAbsolute, join, relative, resolve } from "node:path";
 
 /** Windows needs shell-based spawning for npm's .cmd shims — see makeExec. */
 const WIN32 = process.platform === "win32";
@@ -345,6 +345,77 @@ export function isVaultRegistered(alias, vaults) {
   return vaults.some((v) => v.alias === alias && v.exists !== false);
 }
 
+/** Best-effort canonical form of a path: realpath when it exists, else resolved. */
+function canonical(p) {
+  const abs = resolve(String(p));
+  try {
+    return realpathSync(abs);
+  } catch {
+    return abs;
+  }
+}
+
+/**
+ * True when two paths name the same directory. Compared in both their given
+ * and realpath'd forms, so a symlinked temp dir (macOS `/var` → `/private/var`)
+ * or a path that doesn't exist yet still matches its twin.
+ */
+export function samePath(a, b) {
+  if (!a || !b) return false;
+  const forms = (p) => new Set([resolve(String(p)), canonical(p)]);
+  const fa = forms(a);
+  for (const f of forms(b)) if (fa.has(f)) return true;
+  return false;
+}
+
+/**
+ * True when `path` is `root` or lives under it. `path.relative` is already
+ * case-insensitive on Windows; realpath'd forms are compared too (see samePath).
+ */
+function isUnder(path, root) {
+  const inside = (p, r) => {
+    const rel = relative(r, p);
+    return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
+  };
+  for (const r of [resolve(String(root)), canonical(root)]) {
+    for (const p of [resolve(String(path)), canonical(path)]) {
+      if (inside(p, r)) return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * True when a vault path lives under the OS temp directory. Agents create
+ * scratch vaults there (and `ctx init` registers them), and nobody wants a
+ * throwaway's nodes injected into every prompt of a real session.
+ * `tmp` is injectable for tests; defaults to os.tmpdir().
+ */
+export function isTmpVaultPath(path, tmp = osTmpdir()) {
+  if (!path || !tmp) return false;
+  return isUnder(path, tmp);
+}
+
+/**
+ * The vault ctx resolves from the working directory alone, via
+ * `ctx vault which --json` (exec already runs in the hook's cwd). Only a
+ * `source: "local"` resolution counts — i.e. a `.context/config.yaml` found by
+ * walking up from cwd. A registry default, an env override, or the bare-cwd
+ * fallback is NOT a cwd vault. Returns `{ path, alias }` where `alias` is the
+ * registered alias for that same path when there is one (else null), or null
+ * when the cwd is not inside a vault (or ctx is too old to know `--json`).
+ *
+ * @param {(args:string[]) => any} exec
+ * @param {{alias:string, path?:string, exists?:boolean}[]} vaults from listVaults()
+ */
+export function cwdVault(exec, vaults = []) {
+  const which = ctxJson(exec, ["vault", "which", "--json"], null);
+  if (!which || typeof which !== "object" || Array.isArray(which)) return null;
+  if (which.kind !== "local" || which.source !== "local" || !which.path) return null;
+  const match = vaults.find((v) => v.exists !== false && v.path && samePath(v.path, which.path));
+  return { path: which.path, alias: match ? match.alias : null };
+}
+
 /**
  * Decide which vault aliases the cheap (non-agent) tiers should search.
  *
@@ -352,19 +423,37 @@ export function isVaultRegistered(alias, vaults) {
  *  - Pinned alias, NOT registered (stale/removed pin) → ignore the pin and
  *    behave as unpinned, rather than passing ctx a bad --vault that resolves to
  *    nothing. session-start surfaces a warning so this isn't silent.
- *  - Unpinned + registry     → fan out across registered vaults (capped).
- *  - Unpinned + empty registry → a single null target, i.e. let ctx resolve the
- *                                 local/default vault with no --vault flag.
+ *  - Unpinned → the vault in the working directory FIRST, then registered
+ *    vaults in registry order, capped at MAX_FANOUT_VAULTS in total.
+ *      · The cwd vault is targeted as `null` (no --vault, ctx resolves it
+ *        locally) and its hits are cited without an alias prefix. When that
+ *        same directory is also registered it is targeted by its alias
+ *        instead — once, still first — so a hit keeps a citable `alias:id`
+ *        and is never listed twice.
+ *      · Registry entries whose path is missing (`exists: false`) or lives
+ *        under os.tmpdir() (scratch vaults agents create) are skipped. A cwd
+ *        vault or a pin is a deliberate choice and is never filtered.
+ *  - Unpinned + nothing eligible + no cwd vault → a single null target, i.e.
+ *    let ctx resolve the local/default vault with no --vault flag.
  *
  * @param {ReturnType<typeof getConfig>} config
  * @param {(args:string[]) => any} exec
  * @returns {(string|null)[]} list of alias targets (null = ctx default resolution)
  */
 export function vaultTargets(config, exec) {
-  const vaults = listVaults(exec).filter((v) => v.exists !== false);
-  if (isVaultRegistered(config.vault, vaults)) return [config.vault];
-  if (vaults.length === 0) return [null];
-  return vaults.slice(0, MAX_FANOUT_VAULTS).map((v) => v.alias);
+  const present = listVaults(exec).filter((v) => v.exists !== false);
+  if (isVaultRegistered(config.vault, present)) return [config.vault];
+
+  const local = cwdVault(exec, present);
+  const targets = [];
+  if (local) targets.push(local.alias);
+  for (const v of present) {
+    if (targets.length >= MAX_FANOUT_VAULTS) break;
+    if (local && v.alias === local.alias) continue;
+    if (isTmpVaultPath(v.path)) continue;
+    targets.push(v.alias);
+  }
+  return targets.length === 0 ? [null] : targets;
 }
 
 /** Collapse internal whitespace and trim, for compact single-line context. */

--- a/plugins/shared/core/session-start.js
+++ b/plugins/shared/core/session-start.js
@@ -4,12 +4,14 @@
  * Runs `ctx vault list --json`. If ctx is unavailable, injects a one-line
  * warning instead of failing (a hook must never break the session). Otherwise
  * injects the registered vault aliases + descriptions, marks the pinned/default
- * one, and nudges the model to use the vault before answering.
+ * one, names the vault found in the working directory (if any), and nudges the
+ * model to use the vault before answering.
  */
 
 import {
   getConfig,
   ctxJson,
+  cwdVault,
   isVaultRegistered,
   squish,
   runAsHook,
@@ -59,9 +61,24 @@ export function run({ env, exec }) {
     lines.push(`Pinned vault: \`${config.vault}\` (all queries/captures use it).`);
   }
 
+  // The vault in the working directory is what auto-retrieval searches first
+  // (see vaultTargets); say so, and whether it is also a registered alias.
+  const local = cwdVault(exec, vaults);
+  if (local) {
+    const how = local.alias
+      ? `registered as \`${local.alias}\``
+      : "not registered — cited without an alias prefix";
+    const rank = pinnedIsRegistered
+      ? "the pinned vault takes precedence for auto-retrieval"
+      : "searched first on every prompt";
+    lines.push(`Working-directory vault: \`${local.path}\` (${how}; ${rank}).`);
+  }
+
   if (vaults.length === 0) {
     lines.push(
-      "No vaults are registered; `ctx` will resolve a local `.context` vault from the working directory if present.",
+      local
+        ? "No vaults are registered; `ctx` resolves the working-directory vault above."
+        : "No vaults are registered; `ctx` will resolve a local `.context` vault from the working directory if present.",
     );
   } else {
     lines.push("Registered vaults:");


### PR DESCRIPTION
ClickUp: https://app.clickup.com/t/wdqcq01c5v

## Why

**As** someone running a Claude Code session inside a vault, **I want** auto-retrieval to search *that* vault first, **so that** every prompt is not answered with nodes from a demo or scratch vault I never meant to search.

`vaultTargets()` in `plugins/shared/core/lib.js` fanned out across the first five registry entries in registry order and never considered the vault in the working directory whenever the registry was non-empty. Observed: a session cwd'd inside an unregistered vault got six gastroenterology nodes from a demo vault injected on every prompt. Finding #1 (P0) of the 2026-09-06 usability sweep ("sweep the context nest for connection usability and overall ease of use given the use cases we are trying to accomplish" → "fix it all, go, with the loop").

## What changed

- **`vaultTargets()` order** (`plugins/shared/core/lib.js`): pinned alias (if registered) → the cwd vault → registry vaults, capped at `MAX_FANOUT_VAULTS` (5) total.
  - The cwd vault is detected with `ctx vault which --json` (exec already runs in the hook's `input.cwd`); only a `source: "local"` resolution counts.
  - It is targeted as `null` (no `--vault`), so ctx resolves it locally and its hits are cited as a bare `id`.
  - **Dedupe decision:** if the cwd vault is also a registered alias, it is searched once, **by its alias**, still first — a hit keeps a citable `alias:id` and is never listed twice.
  - Registry entries with `exists: false` or a `path` under `os.tmpdir()` are skipped. A cwd vault or a pin is a deliberate choice and is never filtered. Nothing eligible and no cwd vault → `[null]`, as before with an empty registry.
- **`ctx vault which --json`** (`packages/cli/src/index.ts`): machine-readable `{kind, path|endpoint, source, alias?, warning?}`. Changeset: `@promptowl/contextnest-cli` patch.
- **`session-start.js`** names the working-directory vault and whether it is registered (or that the pin takes precedence).
- Vendored copies re-synced (`pnpm plugins:sync`); plugin `0.5.1 → 0.5.2` with a CHANGELOG entry; README table row for `ctx vault which [--json]`.
- Regression fixtures (`plugins/__tests__/retrieval.regression.test.ts`) moved from `os.tmpdir()` to the gitignored `fixtures/` dir (registered tmp vaults are now skipped by design), plus an unregistered `gamma` vault and a tmp-registered `scratch` vault.

Out of scope, unchanged: search ranking, the `agent` tier, and `sweepTargets()` in `sweep-check.js` (the sweep is deliberately per-registry).

## FAIL-FIRST evidence

Tests were written first and run red before any code change.

Unit (`pnpm test plugins/__tests__/core.unit.test.ts`):

```
 FAIL  lib helpers > vaultTargets: the cwd vault is searched first (as null), then the registry
AssertionError: expected [ 'demo', 'crm' ] to deeply equal [ null, 'demo', 'crm' ]
 FAIL  lib helpers > vaultTargets: a cwd vault that is also registered is searched once, by alias, first
AssertionError: expected [ 'demo', 'crm' ] to deeply equal [ 'crm', 'demo' ]
 FAIL  lib helpers > vaultTargets: registry entries that are missing or live under os.tmpdir() are never targeted
AssertionError: expected [ 'scratch', 'demo' ] to deeply equal [ 'demo' ]
 FAIL  lib helpers > vaultTargets: the cwd vault counts against MAX_FANOUT_VAULTS
AssertionError: expected 'v0' to be null
 FAIL  retrieve > search → the cwd vault's hits come first and are cited without an alias prefix
 FAIL  session-start > mentions a working-directory vault when one is detected
 FAIL  session-start > names the alias when the working-directory vault is registered
      Tests  7 failed | 121 passed (128)
```

CLI (`pnpm test packages/cli/src/__tests__/vault-registry.test.ts`):

```
 FAIL  ctx vault — central registry > vault which --json reports the resolved vault as a machine-readable object [CU-wdqcq01c5v]
error: unknown option '--json'
      Tests  1 failed | 5 passed (6)
```

Regression (`vitest run --config vitest.regression.config.ts plugins/__tests__/retrieval.regression.test.ts`, built CLI, real vaults):

```
 FAIL  unpinned, cwd inside an UNREGISTERED vault → its nodes come first, unprefixed, ahead of the registry
AssertionError: expected 'Relevant Context Nest vault material …' to contain '- nodes/local-auth — Local Auth Notes'
 FAIL  a registered vault under os.tmpdir() is never searched
AssertionError: expected 'Relevant Context Nest vault material …' not to contain 'scratch'
 FAIL  session-start names the working-directory vault
      Tests  4 failed | 4 passed (8)
```

After the change, green:

```
plugins/__tests__/core.unit.test.ts            Tests  128 passed (128)
packages/cli/src/__tests__/vault-registry.test.ts  Tests  6 passed (6)
plugins/__tests__/retrieval.regression.test.ts   Tests  8 passed (8)
pnpm test                                       Test Files 64 passed, Tests 1057 passed (1057)
```

## Acceptance criteria → tests

| # | Criterion | Test |
|---|---|---|
| 1 | unpinned, registry `demo`+`crm`, cwd in unregistered vault → `[null, "demo", "crm"]` | `vaultTargets: the cwd vault is searched first (as null), then the registry` |
| 2 | `exists:false` / path under `os.tmpdir()` never returned | `vaultTargets: registry entries that are missing or live under os.tmpdir() are never targeted` |
| 3 | registered pin → only that alias | existing `a registered pin is honoured…` + new `a registered pin still short-circuits, even with a cwd vault` |
| 4 | empty registry, no cwd vault → `[null]` | existing `…empty registry → [null]` (fake exec returns no `which` object) |
| 5 | regression: cwd inside alpha, unpinned, registry alpha+beta → alpha's node appears, labelled `alpha:` (dedupe prefers the alias), exactly once | `unpinned, cwd inside registered vault alpha → alpha is searched (once, by alias)`; the bare-`id` path is covered by the `UNREGISTERED vault` case |

## Commands run

```
pnpm plugins:sync && pnpm plugins:check && pnpm lint && pnpm test
pnpm test:regression
```

Note: `pnpm test:regression`'s filter `...@promptowl/contextnest-cli` selects dependents, not dependencies, so in a fresh worktree it does not build the engine first; a one-off `pnpm build` was run before it (unchanged, pre-existing quirk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ZgqxXk3NsHCPvB8Mtr95H
