### PR TITLE
Add caller attribution (client metadata) to reads and writes

### DIFF
--- a/.changeset/tidy-pugs-attend.md
+++ b/.changeset/tidy-pugs-attend.md
@@ -1,0 +1,30 @@
+---
+"@promptowl/contextnest-engine": minor
+"@promptowl/contextnest-mcp-server": minor
+---
+
+Add `client` — caller metadata on every read and write in the operation catalog
+
+Every `core` operation now accepts an optional `client` object naming the
+calling agent and its session, plus any custom scalar keys:
+
+```jsonc
+{ "title": "API Design", "content": "…",
+  "client": { "agent": "claude-code", "session_id": "s-9f2" } }
+```
+
+A write that publishes records it on the version-history entry it seals, so
+`context_versions` answers "which agent wrote v7, in which session"; a graph
+read stamps it on the §9.2 access traces it emits; every other operation hands
+it to extension `authorize` / `onResult` hooks. The MCP tool surface picks it up
+automatically — its schemas come from the catalog.
+
+`client` is a label, not an identity claim: it is never authenticated, never
+used to authorize, and deliberately not an input to any hash chain, so histories
+recorded before the field existed keep verifying byte-for-byte. It is bounded
+(scalar values ≤ 512 chars, ≤ 16 custom keys) because it lands in an append-only
+audit trail. It is distinct from the `metadata` argument, which is frontmatter
+and describes the document rather than the call.
+
+Specified in `CONTEXT_NEST_SPEC.md` §9.4, with the `client` field on version
+entries added to §6.2.

--- a/.changeset/tidy-pugs-attend.md
+++ b/.changeset/tidy-pugs-attend.md
@@ -1,9 +1,10 @@
 ---
 "@promptowl/contextnest-engine": minor
 "@promptowl/contextnest-mcp-server": minor
+"@promptowl/contextnest-cli": minor
 ---
 
-Add `client` — caller metadata on every read and write in the operation catalog
+Add `client` — caller attribution on every read and write
 
 Every `core` operation now accepts an optional `client` object naming the
 calling agent and its session, plus any custom scalar keys:
@@ -16,15 +17,29 @@ calling agent and its session, plus any custom scalar keys:
 A write that publishes records it on the version-history entry it seals, so
 `context_versions` answers "which agent wrote v7, in which session"; a graph
 read stamps it on the §9.2 access traces it emits; every other operation hands
-it to extension `authorize` / `onResult` hooks. The MCP tool surface picks it up
-automatically — its schemas come from the catalog.
+it to extension `authorize` / `onResult` hooks.
 
-`client` is a label, not an identity claim: it is never authenticated, never
-used to authorize, and deliberately not an input to any hash chain, so histories
+**MCP** fills both fields from the connection when the caller sends none —
+`agent` from the `initialize` handshake's `clientInfo.name`, `session_id` from a
+per-process id (over stdio, one process is one client connection). Caller values
+win, merged per key, so supplying only `agent` still gains a session id.
+
+**CLI** gains three global flags: `--agent <name>`, `--session <id>` and a
+repeatable `--client <key=value>`, with `CONTEXTNEST_AGENT` /
+`CONTEXTNEST_SESSION_ID` as env fallbacks so a wrapping agent sets them once per
+session. `ctx history` renders the recorded block on each version, distinct from
+`By:`, which is the authoring identity. Values from `--client` are stored as
+strings — coercing `version=1.0` to `1` would lose characters from an audit
+record.
+
+`client` is a label, not an identity claim: never authenticated, never used to
+authorize, and deliberately not an input to any hash chain, so histories
 recorded before the field existed keep verifying byte-for-byte. It is bounded
 (scalar values ≤ 512 chars, ≤ 16 custom keys) because it lands in an append-only
-audit trail. It is distinct from the `metadata` argument, which is frontmatter
-and describes the document rather than the call.
+audit trail, and a near-miss on a reserved key (`sessionId`) is rejected rather
+than filed as a custom key, which would leave the write silently unattributed.
+It is distinct from the `metadata` argument, which is frontmatter and describes
+the document rather than the call.
 
-Specified in `CONTEXT_NEST_SPEC.md` §9.4, with the `client` field on version
-entries added to §6.2.
+Specified in `CONTEXT_NEST_SPEC.md` §9.4 (with §9.4.1 reserved/custom keys and
+§9.4.2 binding conventions), and the `client` field on version entries in §6.2.

--- a/.changeset/tidy-pugs-attend.md
+++ b/.changeset/tidy-pugs-attend.md
@@ -19,10 +19,17 @@ A write that publishes records it on the version-history entry it seals, so
 read stamps it on the §9.2 access traces it emits; every other operation hands
 it to extension `authorize` / `onResult` hooks.
 
+Everything about it is optional: the object, and each field within it. No
+operation requires it, and an unattributed call is a valid call.
+
 **MCP** fills both fields from the connection when the caller sends none —
 `agent` from the `initialize` handshake's `clientInfo.name`, `session_id` from a
 per-process id (over stdio, one process is one client connection). Caller values
-win, merged per key, so supplying only `agent` still gains a session id.
+win, merged per key, so supplying only `agent` still gains a session id. Set
+`CONTEXTNEST_NO_ATTRIBUTION=1` to derive nothing, or `CONTEXTNEST_AGENT` /
+`CONTEXTNEST_SESSION_ID` to override what the connection reports — precedence
+per key is caller > env > connection. With nothing to record, `client` is left
+off the record entirely rather than written as `{}`.
 
 **CLI** gains three global flags: `--agent <name>`, `--session <id>` and a
 repeatable `--client <key=value>`, with `CONTEXTNEST_AGENT` /

--- a/CONTEXT_NEST_SPEC.md
+++ b/CONTEXT_NEST_SPEC.md
@@ -1147,8 +1147,14 @@ Each version entry in `history.yaml` records:
 - `note` — reason for change (optional)
 - `content_hash` — SHA-256 of the entry's content (see §8)
 - `chain_hash` — SHA-256 linking this entry to all previous entries (see §8)
+- `client` — caller metadata supplied with the write (see §9.4); omitted when the caller supplied none
 
 `published_at` is the authoritative record used to reconstruct checkpoint history (see §7.3).
+
+`client` is an annotation, NOT chained evidence: it MUST NOT be an input to
+`chain_hash` (§8.2). A history recorded before any caller sent one therefore
+keeps verifying unchanged, and a `client` block proves only what the caller
+asserted about itself — `edited_by` remains the authoritative authoring record.
 
 ```yaml
 # .versions/api-design/history.yaml
@@ -1162,6 +1168,9 @@ versions:
     note: "Initial draft"
     content_hash: sha256:3a7bd3e2360a3d29aa625ddc5b74dac9f9b5b393f7d1e6b5a0c4f2e8d1a3c5b7
     chain_hash:   sha256:f4c2b3a1d9e8f7c6b5a4d3e2f1c0b9a8d7e6f5c4b3a2d1e0f9c8b7a6d5e4f3c2
+    client:
+      agent: claude-code
+      session_id: sess-9f2c41
   - version: 2
     diff: |
       --- v1
@@ -1458,6 +1467,47 @@ The trace records `result_hash`, not `result_content`. The trace proves *what wa
 This extends the provenance chain from knowledge through to action: "The agent resolved `pack:sprint.standup` → read 3 static docs at checkpoint 12 → hydrated `sources/current-sprint-tickets` via Jira MCP (cache miss, result hash `sha256:9f1b...`) → hydrated `sources/recent-pr-activity` via GitHub MCP (cache hit, 4m old) → generated summary."
 
 Note: Audit logging format, storage, and analytics are implementation-defined. This section defines the fields that SHOULD be captured, not the storage format.
+
+### 9.4 Client Metadata
+
+§9.2 answers *what* was read and §6.2 answers *what* was written. Neither says
+*who was calling*. A vault serving several agents, or one agent across many
+sessions, cannot attribute either from the record alone: `edited_by` names a
+person or a service account, and a read leaves no author at all.
+
+Every read and every write operation SHOULD therefore accept an optional
+`client` object describing the CALL:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `agent` | string | Name of the calling agent, e.g. `claude-code` |
+| `session_id` | string | Identifier of the calling session, opaque to the implementation |
+| *(other keys)* | string \| number \| boolean | Custom metadata, recorded verbatim |
+
+Where it is recorded:
+
+- A write that publishes SHOULD record it on the version entry it seals as
+  `client` (§6.2), so history answers "which agent wrote v7, in which session".
+- A read SHOULD stamp it on the access traces it emits (§9.2), so provenance
+  names the reader as well as the document.
+- An operation that records neither SHOULD still make it available to whatever
+  audit or authorization layer the implementation wraps around the call.
+
+Three constraints are normative:
+
+1. `client` is a **label, not an identity claim.** Implementations MUST NOT
+   authorize from it and MUST NOT treat it as authenticated. Any caller that
+   can set it can set it to anything; authorization belongs to the
+   implementation's identity layer, not to this field.
+2. It MUST NOT be an input to any hash (§8). It annotates a record; it does not
+   seal one.
+3. It MUST be bounded — key count and value size — because it is written to an
+   append-only audit trail by an untrusted caller. Values are scalars.
+   Implementations SHOULD reject an oversized or non-scalar payload rather than
+   truncating it silently.
+
+`client` is distinct from a node's `metadata` frontmatter (§1.5): `metadata`
+describes the document, `client` describes the call that touched it.
 
 ---
 

--- a/CONTEXT_NEST_SPEC.md
+++ b/CONTEXT_NEST_SPEC.md
@@ -1509,6 +1509,40 @@ Three constraints are normative:
 `client` is distinct from a node's `metadata` frontmatter (§1.5): `metadata`
 describes the document, `client` describes the call that touched it.
 
+#### 9.4.1 Reserved and custom keys
+
+`agent` and `session_id` are RESERVED. An implementation accepting custom keys
+alongside them MUST NOT silently accept a near-miss on a reserved key
+(`sessionId`, `session-id`, `Agent`) as a custom key: the write is then recorded
+but not in the slot readers look in, so it is silently unattributed while
+appearing to succeed. Reject it and name the intended key.
+
+Custom keys and reserved keys share one namespace and travel together in the
+same object. An implementation SHOULD bound the number of custom keys and the
+length of every value, and SHOULD restrict values to scalars.
+
+#### 9.4.2 Binding conventions
+
+A caller will often not populate `client` — an agent has no reason to know the
+field exists — so a binding SHOULD supply what its transport already knows, and
+MUST merge those defaults per KEY, under anything the caller sent. A caller that
+names its agent but no session keeps its agent and still gains a session id.
+
+| Binding | `agent` | `session_id` |
+|---|---|---|
+| MCP | The `clientInfo.name` from the `initialize` handshake | An identifier for the connection. Over stdio one process is one session, so a value minted per process is an accurate statement |
+| CLI | An explicit flag, falling back to an environment variable so a wrapping agent sets it once per session rather than per invocation | Same |
+| REST / other | Whatever the transport authenticates or correlates by | The transport's own session or request-correlation id |
+
+A binding MUST NOT invent a value it cannot stand behind. Where the transport
+knows nothing — a REST call with no session concept — the field is better absent
+than filled with a placeholder, because a reader cannot tell a synthesized value
+from a real one.
+
+Defaults do not change the trust level of anything in §9.4: `clientInfo.name` is
+a client's self-report, exactly like a caller-supplied `agent`, and neither is
+authenticated.
+
 ---
 
 ## 10. INDEX.md Format

--- a/CONTEXT_NEST_SPEC.md
+++ b/CONTEXT_NEST_SPEC.md
@@ -1538,7 +1538,7 @@ appearing to succeed. Reject it and name the intended key.
 
 Custom keys and reserved keys share one namespace and travel together in the
 same object. An implementation SHOULD bound the number of custom keys and the
-length of every value, and SHOULD restrict values to scalars.
+length of every key and every value, and SHOULD restrict values to scalars.
 
 #### 9.4.2 Binding conventions
 

--- a/CONTEXT_NEST_SPEC.md
+++ b/CONTEXT_NEST_SPEC.md
@@ -1476,7 +1476,11 @@ sessions, cannot attribute either from the record alone: `edited_by` names a
 person or a service account, and a read leaves no author at all.
 
 Every read and every write operation SHOULD therefore accept an optional
-`client` object describing the CALL:
+`client` object describing the CALL. Every part of it is optional — the object,
+and each field within it. An implementation MUST NOT require `agent`,
+`session_id`, or the object itself, and MUST NOT reject a call that omits them:
+attribution is evidence a caller offers, not a toll it pays. An unattributed
+call is a valid call.
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -1538,6 +1542,16 @@ A binding MUST NOT invent a value it cannot stand behind. Where the transport
 knows nothing — a REST call with no session concept — the field is better absent
 than filled with a placeholder, because a reader cannot tell a synthesized value
 from a real one.
+
+For the same reason, a record with no attribution MUST omit `client` rather than
+store an empty object: "not attributed" and "attributed to nobody" are different
+claims, and only the first is true.
+
+A binding that derives defaults SHOULD let an operator turn that off. What a
+binding derives is written to an append-only history, so consent has to be
+available before the first write — there is no later pass to remove it. Turning
+derivation off MUST NOT discard a `client` a caller sent explicitly; that is the
+caller's own record to make.
 
 Defaults do not change the trust level of anything in §9.4: `clientInfo.name` is
 a client's self-report, exactly like a caller-supplied `agent`, and neither is

--- a/README.md
+++ b/README.md
@@ -599,6 +599,13 @@ cloud:
 | `context_delete` | Delete a node and its history; returns the deleted node's `title` |
 | `context_import` | Bulk create-and-publish from `documents` and/or existing `ids` — one checkpoint for the batch |
 
+Every tool above also takes an optional `client` object — `{ agent, session_id, …custom }` —
+naming the agent and session behind the call. A write that publishes records it on the
+version-history entry it seals (so `context_versions` shows which agent wrote which version);
+a graph read stamps it on the access traces it emits. It is a label, not an identity claim:
+it is never authenticated, never used to authorize, and never an input to a hash chain. See
+spec §9.4.
+
 **Vault tools:**
 
 | Tool | Description |

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -155,6 +155,40 @@ it would put both the documents and your API key on the wire in the clear.
 Prefer `CONTEXTNEST_API_KEY` over `--key`: command-line arguments are visible
 to other processes and land in shell history.
 
+### Caller attribution
+
+Three global flags record *who is calling* on every read and write
+(spec §9.4):
+
+| Flag | Effect |
+|------|--------|
+| `--agent <name>` | Name of the calling agent (env: `CONTEXTNEST_AGENT`) |
+| `--session <id>` | Calling session id (env: `CONTEXTNEST_SESSION_ID`) |
+| `--client <key=value>` | Extra caller metadata, repeatable |
+
+```bash
+ctx add nodes/spec --title "Spec" --agent claude-code --session s-9f2
+ctx history nodes/spec
+#   v1 [keyframe] published
+#     By: you@example.com at 2026-08-22T15:54:47.356Z
+#     Client: claude-code (session s-9f2)
+```
+
+A write that publishes records the block on its version-history entry, so
+`ctx history` shows which agent produced each version — distinct from `By:`,
+which is the authoring identity. Reads carry it too; nothing is persisted for
+them locally, but a governed backend receives it.
+
+The env vars are the reason this is practical for agents: a plugin that shells
+out to `ctx` exports them once for a session instead of threading flags through
+every call. A flag beats the env var per key, so `--agent` on one command
+overrides the ambient agent while keeping the ambient session.
+
+Values from `--client` are recorded as **strings** — a shell argument is text,
+and coercing `version=1.0` to `1` would quietly lose characters from an audit
+record. Attribution is a label, never an identity claim: nothing authenticates
+it, and it is never used to authorize.
+
 ### Errors
 
 Every failure prints as a single line — `Error [CODE]: message` for engine
@@ -173,6 +207,7 @@ CONTEXTNEST_DEBUG=1 ctx verify   # full stack trace when you need to debug
 
 ### Index & Agent Configs
 - `ctx index` — Regenerate context.yaml, INDEX.md, and agent config files (CLAUDE.md, GEMINI.md, .cursorrules, .windsurfrules, .github/copilot-instructions.md)
+
 
 ## Upgrading to 2.0
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -218,7 +218,6 @@ CONTEXTNEST_DEBUG=1 ctx verify   # full stack trace when you need to debug
 ### Index & Agent Configs
 - `ctx index` — Regenerate context.yaml, INDEX.md, and agent config files (CLAUDE.md, GEMINI.md, .cursorrules, .windsurfrules, .github/copilot-instructions.md)
 
-
 ## Upgrading to 2.0
 
 Your vault files are untouched — no migration to run. Behaviour that changes:

--- a/packages/cli/src/__tests__/cli.regression.test.ts
+++ b/packages/cli/src/__tests__/cli.regression.test.ts
@@ -11,7 +11,7 @@
  * `vitest run -t regression`.
  */
 
-import { describe, it, expect, beforeEach, afterEach, afterAll } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach, afterEach, afterAll } from "vitest";
 import { execFileSync, execFile, spawnSync } from "node:child_process";
 import { promisify } from "node:util";
 import {
@@ -1393,5 +1393,114 @@ describe("[regression] file safety — generic folder names in a vault", () => {
     // Modified, not created — the subtree made it into the sandbox copy.
     expect(res.stderr).toContain("~ nodes/out/formats.md");
     expect(readFileSync(join(tmp, "nodes", "out", "formats.md"), "utf-8")).toContain("original");
+  });
+});
+
+// ─── Caller attribution (spec §9.4) ─────────────────────────────────────────
+
+describe("[regression] caller attribution — --agent / --session / --client", () => {
+  let dir: string;
+
+  beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), "cn-cli-reg-client-"));
+    initVault(dir);
+  });
+  afterAll(() => rmSync(dir, { recursive: true, force: true }));
+
+  it("records the flags on the version entry and shows them in `ctx history`", () => {
+    runCtx(dir, [
+      "add",
+      "nodes/attributed-note",
+      "--title",
+      "Attributed Note",
+      "--body",
+      "body",
+      "--agent",
+      "claude-code",
+      "--session",
+      "sess-cli-1",
+      "--client",
+      "workspace=acme",
+    ]);
+
+    const history = runCtx(dir, ["history", "nodes/attributed-note", "--json"]);
+    const parsed = JSON.parse(history) as {
+      versions: Array<{ client?: Record<string, string> }>;
+    };
+    expect(parsed.versions.at(-1)!.client).toEqual({
+      agent: "claude-code",
+      session_id: "sess-cli-1",
+      workspace: "acme",
+    });
+
+    // …and the human rendering surfaces it, distinct from the `By:` line, which
+    // is the authoring identity rather than the caller.
+    const rendered = runCtx(dir, ["history", "nodes/attributed-note"]);
+    expect(rendered).toMatch(/Client: claude-code \(session sess-cli-1\), workspace=acme/);
+  });
+
+  it("falls back to env, and an explicit flag still wins", () => {
+    const envRun = { ...ENV, CONTEXTNEST_AGENT: "env-agent", CONTEXTNEST_SESSION_ID: "sess-env" };
+    execFileSync(
+      "node",
+      [distPath, "add", "nodes/from-env", "--title", "From Env", "--body", "body"],
+      { cwd: dir, env: envRun, encoding: "utf-8" },
+    );
+    execFileSync(
+      "node",
+      [distPath, "add", "nodes/flag-wins", "--title", "Flag Wins", "--body", "body",
+       "--agent", "flag-agent"],
+      { cwd: dir, env: envRun, encoding: "utf-8" },
+    );
+
+    const fromEnv = JSON.parse(runCtx(dir, ["history", "nodes/from-env", "--json"]));
+    expect(fromEnv.versions.at(-1).client).toEqual({
+      agent: "env-agent",
+      session_id: "sess-env",
+    });
+
+    const flagWins = JSON.parse(runCtx(dir, ["history", "nodes/flag-wins", "--json"]));
+    // The flag overrides the agent; the session still comes from env, because
+    // the fallback is per-key rather than all-or-nothing.
+    expect(flagWins.versions.at(-1).client).toEqual({
+      agent: "flag-agent",
+      session_id: "sess-env",
+    });
+  });
+
+  it("writes no client block at all when nothing is supplied", () => {
+    runCtx(dir, ["add", "nodes/unattributed", "--title", "Unattributed", "--body", "body"]);
+    const parsed = JSON.parse(runCtx(dir, ["history", "nodes/unattributed", "--json"]));
+    expect(parsed.versions.at(-1)).not.toHaveProperty("client");
+  });
+
+  it("rejects a malformed --client pair instead of recording a broken key", () => {
+    const res = runCtxResult(dir, [
+      "add",
+      "nodes/bad-pair",
+      "--title",
+      "Bad Pair",
+      "--body",
+      "body",
+      "--client",
+      "no-equals-sign",
+    ]);
+    expect(res.status).not.toBe(0);
+    expect(res.stderr).toMatch(/expected key=value/);
+  });
+
+  it("attributes reads too, not only writes", () => {
+    // The flags are global, so a query carries them the same way a write does.
+    // Nothing is persisted for a read, so this asserts the call is accepted
+    // rather than rejected as an unknown option.
+    const out = runCtx(dir, [
+      "query",
+      "#none",
+      "--agent",
+      "claude-code",
+      "--session",
+      "sess-cli-1",
+    ]);
+    expect(out).toBeDefined();
   });
 });

--- a/packages/cli/src/__tests__/cli.regression.test.ts
+++ b/packages/cli/src/__tests__/cli.regression.test.ts
@@ -45,6 +45,10 @@ const ENV = {
   // Neutralize any ambient selectors so resolution is deterministic.
   CONTEXTNEST_VAULT: "",
   CONTEXTNEST_VAULT_PATH: "",
+  // Likewise ambient attribution — the "no client block" assertions depend on
+  // nothing being supplied. Empty is falsy in buildCallClient.
+  CONTEXTNEST_AGENT: "",
+  CONTEXTNEST_SESSION_ID: "",
 } as NodeJS.ProcessEnv;
 
 /** Run the CLI and return stdout. Throws on a non-zero exit. */
@@ -1813,18 +1817,22 @@ describe("[regression] caller attribution — --agent / --session / --client", (
   });
 
   it("rejects a malformed --client pair instead of recording a broken key", () => {
-    const res = runCtxResult(dir, [
-      "add",
-      "nodes/bad-pair",
-      "--title",
-      "Bad Pair",
-      "--body",
-      "body",
-      "--client",
-      "no-equals-sign",
-    ]);
-    expect(res.status).not.toBe(0);
-    expect(res.stderr).toMatch(/expected key=value/);
+    // `" =v"` has an `=` past position 0 but no key once trimmed — it used to
+    // slip through and record an empty key.
+    for (const pair of ["no-equals-sign", "=value", " =value"]) {
+      const res = runCtxResult(dir, [
+        "add",
+        "nodes/bad-pair",
+        "--title",
+        "Bad Pair",
+        "--body",
+        "body",
+        "--client",
+        pair,
+      ]);
+      expect(res.status, JSON.stringify(pair)).not.toBe(0);
+      expect(res.stderr).toMatch(/expected key=value/);
+    }
   });
 
   it("attributes reads too, not only writes", () => {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -87,6 +87,7 @@ import type {
   GovernanceTier,
   RbacHook,
   VaultRegistry,
+  ClientMetadata,
 } from "@promptowl/contextnest-engine";
 import { getStarter, listStarters } from "./starters/index.js";
 import { detectAgentTools, type AgentTool } from "./agent-tools.js";
@@ -110,6 +111,11 @@ import {
   NO_REDIRECT,
 } from "./safety.js";
 
+/** Commander collector for repeatable `--client key=value` flags. */
+function collectClientPair(value: string, previous: string[]): string[] {
+  return [...previous, value];
+}
+
 const program = new Command();
 
 program
@@ -124,7 +130,24 @@ program
   // three flags. See safety.ts for the mechanics.
   .option("--dry-run", "Preview a write command against a throwaway copy of the vault; touch nothing")
   .option("-y, --yes", "Skip confirmation prompts (required for destructive commands in scripts/CI)")
-  .option("--force", "Overwrite existing files, and allow plaintext-HTTP pushes");
+  .option("--force", "Overwrite existing files, and allow plaintext-HTTP pushes")
+  // Caller attribution (spec §9.4). Global so a write and a read attribute the
+  // same way, and env-backed so a coding-agent plugin that shells out to `ctx`
+  // can set them once for a whole session instead of on every invocation.
+  .option(
+    "--agent <name>",
+    "Name of the calling agent, recorded with reads and writes (env: CONTEXTNEST_AGENT)",
+  )
+  .option(
+    "--session <id>",
+    "Calling session id, recorded with reads and writes (env: CONTEXTNEST_SESSION_ID)",
+  )
+  .option(
+    "--client <key=value>",
+    "Extra caller metadata, repeatable (e.g. --client workspace=acme)",
+    collectClientPair,
+    [] as string[],
+  );
 
 // ---------------------------------------------------------------------------
 // Friendly top-level help
@@ -224,8 +247,16 @@ function renderRootHelp(): string {
   lines.push(`${indent}${chalk.cyan("--dry-run".padEnd(col + 2))}preview a write command without touching the filesystem`);
   lines.push(`${indent}${chalk.cyan("-y, --yes".padEnd(col + 2))}skip confirmation prompts`);
   lines.push(`${indent}${chalk.cyan("--force".padEnd(col + 2))}allow overwriting existing files`);
+  lines.push(`${indent}${chalk.cyan("--agent <name>".padEnd(col + 2))}name of the calling agent, recorded with reads and writes`);
+  lines.push(`${indent}${chalk.cyan("--session <id>".padEnd(col + 2))}calling session id, recorded with reads and writes`);
+  lines.push(`${indent}${chalk.cyan("--client <k=v>".padEnd(col + 2))}extra caller metadata, repeatable`);
   lines.push(`${indent}${chalk.cyan("-V, --version".padEnd(col + 2))}print the version number`);
   lines.push(`${indent}${chalk.cyan("-h, --help".padEnd(col + 2))}show this help`);
+  lines.push("");
+  lines.push(chalk.bold("CALLER ATTRIBUTION"));
+  lines.push(`${indent}${chalk.cyan("--agent")} and ${chalk.cyan("--session")} record WHO is calling on every read and write.`);
+  lines.push(`${indent}A write stores them in version history, where ${chalk.cyan("ctx history")} shows them. Set`);
+  lines.push(`${indent}${chalk.cyan("CONTEXTNEST_AGENT")}/${chalk.cyan("CONTEXTNEST_SESSION_ID")} to attribute a whole session at once.`);
   lines.push("");
   lines.push(chalk.bold("FILE SAFETY"));
   lines.push(`${indent}Every command that writes asks before it does, then prints the exact list of`);
@@ -253,6 +284,89 @@ program.configureHelp({
 // preAction hook so it works whether the flag is given before the subcommand
 // (`ctx --vault work list`) or after it (`ctx list --vault work`).
 let selectedVaultAlias: string | undefined;
+
+/**
+ * Caller attribution for the currently-running command (spec §9.4) — the
+ * `client` block every catalog call carries. Captured by the same preAction
+ * hook as the vault alias, for the same reason: the flags work before or after
+ * the subcommand.
+ */
+let callClient: ClientMetadata | undefined;
+
+/**
+ * Build the `client` block from flags and env.
+ *
+ * Env is the fallback, not an override: a coding-agent plugin exports
+ * CONTEXTNEST_AGENT/CONTEXTNEST_SESSION_ID once for a whole session, and a
+ * one-off `ctx --agent …` on top of that still wins.
+ *
+ * Returns undefined when nothing was supplied, so an unattributed run writes no
+ * empty `client:` key into history.
+ */
+function buildCallClient(opts: {
+  agent?: string;
+  session?: string;
+  client?: string[];
+}): ClientMetadata | undefined {
+  const client: ClientMetadata = {};
+  const agent = opts.agent ?? process.env.CONTEXTNEST_AGENT;
+  const session = opts.session ?? process.env.CONTEXTNEST_SESSION_ID;
+  if (agent) client.agent = agent;
+  if (session) client.session_id = session;
+
+  for (const pair of opts.client ?? []) {
+    // Split on the FIRST `=` only — a value may legitimately contain one
+    // (a URL, a base64 fragment), and splitting on every one would truncate it.
+    const eq = pair.indexOf("=");
+    if (eq <= 0) {
+      console.error(chalk.red(`Invalid --client "${pair}" — expected key=value`));
+      process.exit(1);
+    }
+    const key = pair.slice(0, eq).trim();
+    // Recorded as a STRING, always. Coercing digits to numbers would silently
+    // rewrite `version=1.0` as 1 and `build=007` as 7 — a shell argument is
+    // text, and an audit record that quietly loses characters is worse than one
+    // that stores a number as "2". Callers needing real scalars use the API.
+    client[key] = pair.slice(eq + 1);
+  }
+
+  return Object.keys(client).length > 0 ? client : undefined;
+}
+
+/** One-line rendering of a recorded `client` block: `agent (session), k=v`. */
+function formatClient(client: ClientMetadata): string {
+  const { agent, session_id, ...custom } = client;
+  const head = agent ?? "(unnamed agent)";
+  const session = session_id ? ` (session ${session_id})` : "";
+  const extras = Object.entries(custom)
+    .map(([k, v]) => `${k}=${String(v)}`)
+    .join(", ");
+  return `${head}${session}${extras ? `, ${extras}` : ""}`;
+}
+
+/**
+ * The engine API with this run's caller attribution folded in.
+ *
+ * Every CLI call goes through here rather than `createEngineApi()` directly, so
+ * a new command cannot silently ship unattributed: there is one place the
+ * `client` block is attached, not thirteen. An input that names its own
+ * `client` wins, which is what lets a command attribute a call more precisely
+ * than the global flags do.
+ */
+function cliApi() {
+  const api = createEngineApi();
+  return {
+    run<T = unknown>(
+      name: string,
+      input: Record<string, unknown>,
+      ctx: OperationContext,
+    ): Promise<T> {
+      const merged =
+        callClient && input.client === undefined ? { ...input, client: callClient } : input;
+      return api.run<T>(name, merged, ctx);
+    },
+  };
+}
 
 /**
  * Commands that mutate the vault tree. Listed explicitly rather than audited
@@ -306,6 +420,7 @@ function commandPath(cmd: Command): string {
 program.hook("preAction", async (_thisCommand, actionCommand) => {
   const opts = actionCommand.optsWithGlobals();
   selectedVaultAlias = opts.vault as string | undefined;
+  callClient = buildCallClient(opts as { agent?: string; session?: string; client?: string[] });
   configureSafety({ dryRun: opts.dryRun, yes: opts.yes, force: opts.force });
 
   const name = commandPath(actionCommand);
@@ -1053,7 +1168,7 @@ program
     // allow_rejected: `ctx read` has always shown a retired document — reading
     // one is not republishing it, and refusing would hide it from the person
     // deciding whether to revive it.
-    const got = await createEngineApi().run<{
+    const got = await cliApi().run<{
       id: string;
       frontmatter: ContextNode["frontmatter"];
       body: string;
@@ -1212,7 +1327,7 @@ program
     // Scaffolding above stays a CLI concern (heading/steps templates are an
     // authoring nicety, not vault semantics); the write + publish + index pass
     // goes through the catalog so this matches every other surface.
-    const result = await createEngineApi().run<{
+    const result = await cliApi().run<{
       id: string;
       version: number;
       checkpoint: number | null;
@@ -1386,7 +1501,7 @@ program
 
     await confirmOrExit(`Publish ${normalizeDocumentId(path)} — cuts a new version and seals a checkpoint. Continue?`);
 
-    const result = await createEngineApi().run<{
+    const result = await cliApi().run<{
       id: string;
       version: number;
       checkpoint: number;
@@ -1434,7 +1549,7 @@ async function publishAll(storage: NestStorage, author: string): Promise<void> {
     }
   });
 
-  const result = await createEngineApi().run<{
+  const result = await cliApi().run<{
     published: { id: string; version: number }[];
     failed: { id?: string; title?: string; error: string }[];
     checkpoint: number | null;
@@ -1466,7 +1581,7 @@ program
     }
     const storage = getStorage();
     const id = normalizeDocumentId(path);
-    const history = await createEngineApi().run<{
+    const history = await cliApi().run<{
       id: string;
       keyframe_interval: number;
       versions: Array<{
@@ -1478,6 +1593,7 @@ program
         note?: string;
         chain_hash: string;
         diff?: string;
+        client?: ClientMetadata;
       }>;
     }>("context_versions", { id, ...(opts.diff ? { include_diff: true } : {}) }, opContext(storage, "cli@contextnest.local"));
 
@@ -1497,6 +1613,9 @@ program
       console.log(`  v${entry.version}${keyframe}${published}`);
       console.log(`    By: ${entry.edited_by} at ${entry.edited_at}`);
       if (entry.note) console.log(`    Note: ${entry.note}`);
+      // Who was CALLING, as distinct from `By:` above, which is the authoring
+      // identity. Rendered only when the write carried attribution.
+      if (entry.client) console.log(`    Client: ${formatClient(entry.client)}`);
       if (entry.diff) console.log(entry.diff.replace(/^/gm, "    "));
     }
   });
@@ -1508,7 +1627,7 @@ program
   .description("Reconstruct a specific version of a document")
   .action(async (path, version) => {
     const storage = getStorage();
-    const { content } = await createEngineApi().run<{ content: string }>(
+    const { content } = await cliApi().run<{ content: string }>(
       "context_reconstruct",
       { id: normalizeDocumentId(path), version: parseInt(version, 10) },
       opContext(storage, "cli@contextnest.local"),
@@ -1529,7 +1648,7 @@ program
   .option("--json", "Output as JSON")
   .action(async (opts) => {
     const storage = getStorage();
-    const out = await createEngineApi().run<{
+    const out = await cliApi().run<{
       context_md: string | null;
       vault_path: string;
       config: { name: string; description?: string; servers: string[] } | null;
@@ -1856,7 +1975,7 @@ program
     // Local query — graph-aware traversal
     const storage = getStorage();
     type Doc = { id: string; title: string; body?: string; source?: unknown };
-    const result = await createEngineApi().run<{
+    const result = await cliApi().run<{
       documents: Doc[];
       source_nodes?: Doc[];
       trace_count?: number;
@@ -1937,7 +2056,7 @@ program
     const storage = getStorage();
     // Aliases collapse here; the operation owns the rest of the filtering,
     // including hiding retired documents when no status was asked for.
-    const { documents } = await createEngineApi().run<{
+    const { documents } = await cliApi().run<{
       documents: Array<{
         id: string;
         title: string;
@@ -2004,7 +2123,7 @@ program
       `Rewrite ${normalizeDocumentId(path)} in ${realRootPath() ?? storage.root}? The previous content stays recoverable from version history.`,
     );
 
-    const result = await createEngineApi().run<{
+    const result = await cliApi().run<{
       id: string;
       version: number;
       status: string;
@@ -2057,7 +2176,7 @@ program
       `Delete ${normalizeDocumentId(path)} and its entire version history from ${realRootPath() ?? storage.root}? This cannot be undone.`,
       { destructive: true },
     );
-    const result = await createEngineApi().run<{ id: string; title: string }>(
+    const result = await cliApi().run<{ id: string; title: string }>(
       "context_delete",
       { id: normalizeDocumentId(path) },
       opContext(storage, "cli@contextnest.local"),
@@ -2079,7 +2198,7 @@ program
       return;
     }
     const storage = getStorage();
-    const { results } = await createEngineApi().run<{
+    const { results } = await cliApi().run<{
       results: Array<{ id: string; title: string; description?: string; type: string }>;
     }>(
       "context_search",
@@ -2118,7 +2237,7 @@ packCmd
   .option("--json", "Output as JSON")
   .action(async (opts) => {
     const storage = getStorage();
-    const { packs } = await createEngineApi().run<{
+    const { packs } = await cliApi().run<{
       packs: Array<{ id: string; label: string; description?: string }>;
     }>("context_packs", {}, opContext(storage, "cli@contextnest.local"));
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -336,11 +336,12 @@ function buildCallClient(opts: {
     // Split on the FIRST `=` only — a value may legitimately contain one
     // (a URL, a base64 fragment), and splitting on every one would truncate it.
     const eq = pair.indexOf("=");
-    if (eq <= 0) {
+    const key = eq > 0 ? pair.slice(0, eq).trim() : "";
+    // `" =v"` has an `=` past position 0 but no key once trimmed.
+    if (!key) {
       console.error(chalk.red(`Invalid --client "${pair}" — expected key=value`));
       process.exit(1);
     }
-    const key = pair.slice(0, eq).trim();
     // Recorded as a STRING, always. Coercing digits to numbers would silently
     // rewrite `version=1.0` as 1 and `build=007` as 7 — a shell argument is
     // text, and an audit record that quietly loses characters is worse than one

--- a/packages/engine/src/__tests__/api-client-metadata.test.ts
+++ b/packages/engine/src/__tests__/api-client-metadata.test.ts
@@ -91,6 +91,22 @@ describe("client metadata — validation bounds", () => {
     expect(clientMetadataSchema.safeParse({ agent: "x".repeat(513) }).success).toBe(false);
   });
 
+  it("rejects a near-miss on a reserved key rather than filing it as custom", () => {
+    // The one failure an open catchall cannot catch on its own: `sessionId` is
+    // a valid custom key, so without this guard the write is recorded but NOT
+    // in the slot context_versions reads — silently un-attributed.
+    for (const typo of ["sessionId", "session-id", "SESSION_ID", "Agent"]) {
+      const result = clientMetadataSchema.safeParse({ [typo]: "value" });
+      expect(result.success, `${typo} should be rejected`).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0].message).toMatch(/reserved key/);
+      }
+    }
+    // A key that merely mentions a reserved word is still fine.
+    expect(clientMetadataSchema.safeParse({ agent_version: "1.2.0" }).success).toBe(true);
+    expect(clientMetadataSchema.safeParse({ parent_session_id: "s-1" }).success).toBe(true);
+  });
+
   it(`rejects more than ${CLIENT_METADATA_MAX_CUSTOM_KEYS} custom keys`, () => {
     const tooMany: Record<string, string> = { ...CLIENT };
     for (let i = 0; i <= CLIENT_METADATA_MAX_CUSTOM_KEYS; i++) tooMany[`k${i}`] = "v";

--- a/packages/engine/src/__tests__/api-client-metadata.test.ts
+++ b/packages/engine/src/__tests__/api-client-metadata.test.ts
@@ -1,0 +1,301 @@
+/**
+ * `client` — caller metadata on the read and write calls of the operation
+ * catalog (§9.4).
+ *
+ * Covers the three things that make the field worth having: every operation
+ * accepts it, a write records it where an auditor can find it, and a read
+ * stamps it on the access traces it emits — plus the bounds that keep an
+ * append-only audit trail from becoming a caller-controlled dumping ground.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { basename, dirname, join } from "node:path";
+import { mkdtemp, rm, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { NestStorage } from "../storage.js";
+import { GraphQueryEngine } from "../graph-query-engine.js";
+import { VersionManager } from "../versioning.js";
+import { computeChainHash } from "../integrity.js";
+import { clientMetadataSchema, CLIENT_METADATA_MAX_CUSTOM_KEYS } from "../schemas.js";
+import {
+  createEngineApi,
+  inputJsonSchema,
+  listOperations,
+  type OperationContext,
+} from "../api/index.js";
+
+const CLIENT = { agent: "claude-code", session_id: "sess-9f2c" };
+
+/** Where storage keeps a document's history — `<dir>/<parent>/.versions/<name>/`. */
+function historyPath(dir: string, docId: string): string {
+  return join(dir, dirname(docId), ".versions", basename(docId), "history.yaml");
+}
+
+async function makeContext(): Promise<{ ctx: OperationContext; dir: string }> {
+  const dir = await mkdtemp(join(tmpdir(), "contextnest-client-meta-"));
+  const storage = new NestStorage(dir);
+  return {
+    dir,
+    ctx: {
+      storage,
+      query: new GraphQueryEngine(storage),
+      versions: new VersionManager(storage),
+      actor: "tester@example.com",
+    },
+  };
+}
+
+describe("client metadata — catalog surface", () => {
+  it("every core operation accepts `client`, read and write alike", () => {
+    for (const op of listOperations("core")) {
+      const schema = inputJsonSchema(op) as {
+        properties?: Record<string, { properties?: Record<string, unknown> }>;
+      };
+      expect(schema.properties, `${op.name} has no properties`).toBeDefined();
+      const client = schema.properties?.client;
+      expect(client, `${op.name} is missing the client field`).toBeDefined();
+      // The published JSON Schema must describe the two named keys — a client
+      // reading it has to know what to send without reading our source.
+      expect(Object.keys(client?.properties ?? {})).toEqual(["agent", "session_id"]);
+    }
+  });
+
+  it("does not collide with the frontmatter `metadata` argument", () => {
+    // Both exist on context_create and mean opposite things: `metadata` lands in
+    // the document, `client` describes the call that wrote it.
+    const schema = inputJsonSchema(
+      listOperations("core").find((o) => o.name === "context_create")!,
+    ) as { properties: Record<string, unknown> };
+    expect(schema.properties.metadata).toBeDefined();
+    expect(schema.properties.client).toBeDefined();
+  });
+});
+
+describe("client metadata — validation bounds", () => {
+  it("accepts agent, session_id, and custom scalar keys", () => {
+    const parsed = clientMetadataSchema.parse({
+      ...CLIENT,
+      workspace: "acme",
+      attempt: 2,
+      retry: false,
+    });
+    expect(parsed).toMatchObject({ ...CLIENT, workspace: "acme", attempt: 2, retry: false });
+  });
+
+  it("rejects a non-scalar custom value", () => {
+    expect(clientMetadataSchema.safeParse({ agent: "a", nested: { deep: 1 } }).success).toBe(
+      false,
+    );
+  });
+
+  it("rejects an over-long value", () => {
+    expect(clientMetadataSchema.safeParse({ agent: "x".repeat(513) }).success).toBe(false);
+  });
+
+  it(`rejects more than ${CLIENT_METADATA_MAX_CUSTOM_KEYS} custom keys`, () => {
+    const tooMany: Record<string, string> = { ...CLIENT };
+    for (let i = 0; i <= CLIENT_METADATA_MAX_CUSTOM_KEYS; i++) tooMany[`k${i}`] = "v";
+    expect(clientMetadataSchema.safeParse(tooMany).success).toBe(false);
+    // The reserved keys do not count against the custom budget.
+    const atLimit: Record<string, string> = { ...CLIENT };
+    for (let i = 0; i < CLIENT_METADATA_MAX_CUSTOM_KEYS; i++) atLimit[`k${i}`] = "v";
+    expect(clientMetadataSchema.safeParse(atLimit).success).toBe(true);
+  });
+});
+
+describe("client metadata — writes", () => {
+  let ctx: OperationContext;
+  let dir: string;
+
+  beforeEach(async () => {
+    ({ ctx, dir } = await makeContext());
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("context_create records it on the version entry, and context_versions returns it", async () => {
+    const api = createEngineApi();
+    const created = await api.run<{ id: string }>(
+      "context_create",
+      { title: "API Design", content: "body", client: CLIENT },
+      ctx,
+    );
+
+    const history = await api.run<{
+      versions: Array<{ version: number; client?: Record<string, unknown> }>;
+    }>("context_versions", { id: created.id }, ctx);
+    expect(history.versions.at(-1)?.client).toEqual(CLIENT);
+
+    // It is on disk, not just in the response — the point is an audit trail.
+    const raw = await readFile(historyPath(dir, created.id), "utf8");
+    expect(raw).toContain("agent: claude-code");
+    expect(raw).toContain("session_id: sess-9f2c");
+  });
+
+  it("context_update and context_publish attribute their own versions", async () => {
+    const api = createEngineApi();
+    const { id } = await api.run<{ id: string }>(
+      "context_create",
+      { title: "Attribution", content: "v1", client: { agent: "a1", session_id: "s1" } },
+      ctx,
+    );
+    await api.run("context_update", { id, append: "v2", client: { agent: "a2", session_id: "s2" } }, ctx);
+    await api.run("context_publish", { id, client: { agent: "a3", session_id: "s3" } }, ctx);
+
+    const history = await api.run<{
+      versions: Array<{ client?: { agent?: string } }>;
+    }>("context_versions", { id }, ctx);
+    expect(history.versions.map((v) => v.client?.agent)).toEqual(["a1", "a2", "a3"]);
+  });
+
+  it("context_import stamps the whole batch", async () => {
+    const api = createEngineApi();
+    const result = await api.run<{ published: Array<{ id: string }> }>(
+      "context_import",
+      {
+        documents: [
+          { title: "One", content: "1" },
+          { title: "Two", content: "2" },
+        ],
+        client: CLIENT,
+      },
+      ctx,
+    );
+    expect(result.published).toHaveLength(2);
+    for (const doc of result.published) {
+      const history = await api.run<{ versions: Array<{ client?: unknown }> }>(
+        "context_versions",
+        { id: doc.id },
+        ctx,
+      );
+      expect(history.versions.at(-1)?.client).toEqual(CLIENT);
+    }
+  });
+
+  it("omits the key entirely when the caller sends nothing", async () => {
+    const api = createEngineApi();
+    const { id } = await api.run<{ id: string }>(
+      "context_create",
+      { title: "Anonymous", content: "body" },
+      ctx,
+    );
+    const raw = await readFile(historyPath(dir, id), "utf8");
+    expect(raw).not.toContain("client:");
+    const history = await api.run<{ versions: Array<Record<string, unknown>> }>(
+      "context_versions",
+      { id },
+      ctx,
+    );
+    expect(history.versions.at(-1)).not.toHaveProperty("client");
+  });
+
+  it("is not an input to the chain hash, so old histories keep verifying", async () => {
+    // If `client` fed computeChainHash, every history recorded before the field
+    // existed would stop verifying the moment a caller started sending one.
+    const api = createEngineApi();
+    const { id } = await api.run<{ id: string }>(
+      "context_create",
+      { title: "Chained", content: "body", client: CLIENT },
+      ctx,
+    );
+    const history = await ctx.storage.readHistory(id);
+    const entry = history!.versions[0];
+    expect(entry.client).toEqual(CLIENT);
+    // Recomputed from the spec's §8.2 inputs alone — no client anywhere.
+    expect(
+      computeChainHash(null, entry.content_hash, entry.version, entry.edited_by, entry.edited_at),
+    ).toBe(entry.chain_hash);
+
+    await expect(api.run("context_verify", {}, ctx)).resolves.toMatchObject({ valid: true });
+  });
+
+  it("rejects an invalid client before touching the vault", async () => {
+    const api = createEngineApi();
+    await expect(
+      api.run(
+        "context_create",
+        { title: "Bad Client", content: "body", client: { agent: { name: "nope" } } },
+        ctx,
+      ),
+    ).rejects.toThrow(/Invalid input for context_create/);
+    const listed = await api.run<{ documents: unknown[] }>("context_list", {}, ctx);
+    expect(listed.documents).toHaveLength(0);
+  });
+});
+
+describe("client metadata — reads", () => {
+  let ctx: OperationContext;
+  let dir: string;
+
+  beforeEach(async () => {
+    ({ ctx, dir } = await makeContext());
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("stamps the access traces a graph query emits (§9.2)", async () => {
+    const api = createEngineApi();
+    await api.run("context_create", { title: "Traced", content: "body", tags: ["#t"] }, ctx);
+
+    const result = await ctx.query.query("#t", { client: CLIENT });
+    expect(result.documents.length).toBeGreaterThan(0);
+    expect(result.traces.length).toBeGreaterThan(0);
+    for (const trace of result.traces) {
+      expect(trace).toMatchObject({ trace_type: "access", client: CLIENT });
+    }
+  });
+
+  it("stamps traces in full mode too", async () => {
+    const api = createEngineApi();
+    await api.run("context_create", { title: "Full Mode", content: "body", tags: ["#t"] }, ctx);
+    const result = await ctx.query.query("#t", { full: true, client: CLIENT });
+    expect(result.traces.length).toBeGreaterThan(0);
+    expect(result.traces[0]).toMatchObject({ client: CLIENT });
+  });
+
+  it("leaves traces unstamped when no client is supplied", async () => {
+    const api = createEngineApi();
+    await api.run("context_create", { title: "Unstamped", content: "body", tags: ["#t"] }, ctx);
+    const result = await ctx.query.query("#t");
+    expect(result.traces[0]).not.toHaveProperty("client");
+  });
+
+  it("read operations accept it without changing their result", async () => {
+    const api = createEngineApi();
+    const { id } = await api.run<{ id: string }>(
+      "context_create",
+      { title: "Read Me", content: "body", tags: ["#t"] },
+      ctx,
+    );
+    const plain = await api.run("context_get", { id }, ctx);
+    const attributed = await api.run("context_get", { id, client: CLIENT }, ctx);
+    expect(attributed).toEqual(plain);
+
+    // The same holds for the argument-free reads, which had to grow an input
+    // object to carry it.
+    await expect(api.run("context_verify", { client: CLIENT }, ctx)).resolves.toMatchObject({
+      valid: true,
+    });
+    await expect(api.run("context_packs", { client: CLIENT }, ctx)).resolves.toMatchObject({
+      packs: [],
+    });
+  });
+
+  it("reaches extension hooks for operations that write nothing", async () => {
+    const seen: unknown[] = [];
+    const api = createEngineApi({
+      extensions: [
+        {
+          name: "audit",
+          authorize: ({ input }) => {
+            seen.push((input as { client?: unknown }).client);
+          },
+        },
+      ],
+    });
+    await api.run("context_create", { title: "Hooked", content: "body" }, ctx);
+    await api.run("context_delete", { title: "Hooked", client: CLIENT }, ctx);
+    expect(seen).toEqual([undefined, CLIENT]);
+  });
+});

--- a/packages/engine/src/__tests__/api-client-metadata.test.ts
+++ b/packages/engine/src/__tests__/api-client-metadata.test.ts
@@ -59,6 +59,27 @@ describe("client metadata — catalog surface", () => {
     }
   });
 
+  it("never requires `client`, nor any field inside it", () => {
+    // Attribution is evidence a caller offers, not a toll it pays (spec §9.4).
+    // Pinned as a contract because the easy mistake is the opposite: a schema
+    // that quietly makes agent mandatory breaks every existing caller.
+    for (const op of listOperations("core")) {
+      const schema = inputJsonSchema(op) as {
+        required?: string[];
+        properties?: Record<string, { required?: string[] }>;
+      };
+      expect(schema.required ?? [], `${op.name} requires client`).not.toContain("client");
+      expect(
+        schema.properties?.client?.required ?? [],
+        `${op.name} requires fields inside client`,
+      ).toEqual([]);
+    }
+    // Every partial shape validates, including the empty object.
+    for (const shape of [{}, { agent: "a" }, { session_id: "s" }, { workspace: "acme" }]) {
+      expect(clientMetadataSchema.safeParse(shape).success, JSON.stringify(shape)).toBe(true);
+    }
+  });
+
   it("does not collide with the frontmatter `metadata` argument", () => {
     // Both exist on context_create and mean opposite things: `metadata` lands in
     // the document, `client` describes the call that wrote it.

--- a/packages/engine/src/__tests__/api-client-metadata.test.ts
+++ b/packages/engine/src/__tests__/api-client-metadata.test.ts
@@ -15,7 +15,11 @@ import { NestStorage } from "../storage.js";
 import { GraphQueryEngine } from "../graph-query-engine.js";
 import { VersionManager } from "../versioning.js";
 import { computeChainHash } from "../integrity.js";
-import { clientMetadataSchema, CLIENT_METADATA_MAX_CUSTOM_KEYS } from "../schemas.js";
+import {
+  clientMetadataSchema,
+  versionEntrySchema,
+  CLIENT_METADATA_MAX_CUSTOM_KEYS,
+} from "../schemas.js";
 import {
   createEngineApi,
   inputJsonSchema,
@@ -110,6 +114,34 @@ describe("client metadata — validation bounds", () => {
 
   it("rejects an over-long value", () => {
     expect(clientMetadataSchema.safeParse({ agent: "x".repeat(513) }).success).toBe(false);
+  });
+
+  it("bounds custom key NAMES too — empty or over-long keys are refused", () => {
+    // Keys land in the same append-only trail as values; an unbounded key is
+    // the same bloat vector with a different spelling.
+    for (const key of ["", "   ", "x".repeat(513)]) {
+      expect(clientMetadataSchema.safeParse({ [key]: "v" }).success, JSON.stringify(key)).toBe(
+        false,
+      );
+    }
+    expect(clientMetadataSchema.safeParse({ ["x".repeat(512)]: "v" }).success).toBe(true);
+  });
+
+  it("stays lenient on READ so an input-side tightening can never quarantine a chain", () => {
+    // versionEntrySchema is what storage validates history.yaml against, and a
+    // failure there is CorruptHistoryError → historyOrRepair restarts the chain.
+    // An entry carrying a client the INPUT schema would now refuse must still
+    // load: the annotation is not hashed, so it cannot be allowed to break one.
+    const entry = {
+      version: 1,
+      edited_by: "someone",
+      edited_at: "2026-01-01T00:00:00.000Z",
+      content_hash: `sha256:${"a".repeat(64)}`,
+      chain_hash: `sha256:${"b".repeat(64)}`,
+      client: { sessionId: "near-miss", ["k".repeat(600)]: "long key" },
+    };
+    expect(clientMetadataSchema.safeParse(entry.client).success).toBe(false);
+    expect(versionEntrySchema.safeParse(entry).success).toBe(true);
   });
 
   it("rejects a near-miss on a reserved key rather than filing it as custom", () => {

--- a/packages/engine/src/api/README.md
+++ b/packages/engine/src/api/README.md
@@ -63,6 +63,42 @@ filesystem topology across vaults — the registry file is written `0600` for
 exactly that reason. Local stdio MCP and the CLI already have filesystem
 access, so both include it.
 
+### `client` — caller metadata on every read and write
+
+Every `core` operation takes an optional `client` object naming the calling
+agent and its session, plus any custom scalar keys (spec §9.4):
+
+```jsonc
+// write
+{ "title": "API Design", "content": "…",
+  "client": { "agent": "claude-code", "session_id": "s-9f2", "workspace": "acme" } }
+
+// read
+{ "query": "#api", "client": { "agent": "claude-code", "session_id": "s-9f2" } }
+```
+
+| Operation kind | Where it lands |
+|---|---|
+| Writes that publish (`context_create`, `context_update`, `context_publish`, `context_import`) | The version-history entry the publish seals — `context_versions` returns it as `client` on each entry |
+| Graph reads (`context_query`, `context_resolve`, `context_search`) | The §9.2 access traces the query emits |
+| Everything else | Extension `authorize` / `onResult` hooks, which receive the validated input |
+
+Three things it is not:
+
+- **Not identity.** The engine never authenticates `agent` and no executor
+  branches on it. Authorization stays with the `RbacHook` and the context's
+  `actor`.
+- **Not hashed.** `VersionEntry.client` is deliberately outside
+  `computeChainHash`'s inputs, so a history recorded before the field existed
+  still verifies byte-for-byte.
+- **Not `metadata`.** `metadata` on create/update/import is *frontmatter* — it
+  lands in the document. `client` describes the call that touched it. The two
+  mean opposite things, which is why they cannot share a name.
+
+Bounded on purpose (`clientMetadataSchema` in `schemas.ts`): values are scalars
+of at most 512 chars, and at most 16 custom keys beyond the reserved two.
+It is written into an append-only audit trail by a caller we do not trust.
+
 ## Public API
 
 ```ts
@@ -74,6 +110,9 @@ import {
   inputJsonSchema,   // draft-07 JSON Schema for an op's input
   outputJsonSchema,  // draft-07 JSON Schema for an op's output
   createEngineApi,   // executable runtime: .run(name, input, ctx)
+  clientField,       // { client } — spread into an extension op's input object
+  clientMetadataSchema,
+  type ClientMetadata,
 } from "@promptowl/contextnest-engine/api";
 ```
 

--- a/packages/engine/src/api/README.md
+++ b/packages/engine/src/api/README.md
@@ -97,7 +97,7 @@ Three things it is not:
   mean opposite things, which is why they cannot share a name.
 
 Bounded on purpose (`clientMetadataSchema` in `schemas.ts`): values are scalars
-of at most 512 chars, and at most 16 custom keys beyond the reserved two.
+of at most 512 chars, key names likewise, and at most 16 custom keys beyond the reserved two.
 It is written into an append-only audit trail by a caller we do not trust.
 
 ## Public API

--- a/packages/engine/src/api/client.ts
+++ b/packages/engine/src/api/client.ts
@@ -1,0 +1,61 @@
+/**
+ * `client` — caller metadata on every operation in the catalog.
+ *
+ * Every read and every write accepts an optional `client` object naming the
+ * calling agent and its session, plus any custom keys the caller wants recorded
+ * with the action:
+ *
+ * ```json
+ * { "id": "nodes/api-design", "client": { "agent": "claude-code", "session_id": "s-9f2" } }
+ * ```
+ *
+ * Where it goes:
+ *
+ *  - **writes** that publish (`context_create`, `context_update`,
+ *    `context_publish`, `context_import`) record it on the version-history
+ *    entry they seal, so `context_versions` can answer "which agent wrote v7,
+ *    in which session". It is not an input to the chain hash — see
+ *    `VersionEntry.client`.
+ *  - **reads** that traverse the graph (`context_query`, `context_resolve`,
+ *    `context_search`) stamp it on the §9.2 access traces they emit.
+ *  - **every** operation, read or write, hands it to extension `authorize` /
+ *    `onResult` hooks along with the rest of the validated input — which is how
+ *    a consumer logs or gates on it for the operations that write nothing.
+ *
+ * Why `client` and not `metadata`: `metadata` is already the frontmatter
+ * metadata argument on `context_create` / `context_update` / `context_import`,
+ * and that lands in the document. These two mean opposite things — one
+ * describes the node, the other describes the call that touched it — so they
+ * cannot share a name.
+ *
+ * This is a LABEL, never an identity claim. The engine does not authenticate
+ * `agent`, and no executor branches on it. Authorization is the `RbacHook` and
+ * the `actor` on {@link OperationContext}; a caller that could lie about its
+ * agent name could equally lie about anything else on the wire.
+ */
+import { clientMetadataSchema } from "../schemas.js";
+
+export {
+  clientMetadataSchema,
+  CLIENT_METADATA_RESERVED_KEYS,
+  CLIENT_METADATA_MAX_CUSTOM_KEYS,
+  CLIENT_METADATA_MAX_VALUE_LENGTH,
+} from "../schemas.js";
+
+export type { ClientMetadata } from "../types.js";
+
+const DESCRIPTION =
+  "Caller metadata recorded with this call: `agent` (name of the calling agent), " +
+  "`session_id` (its session), plus any custom scalar keys. Writes that publish " +
+  "store it on the version-history entry; graph reads stamp it on their access " +
+  "traces. Not an identity claim and never used to authorize — describes the " +
+  "CALL, unlike `metadata`, which describes the document.";
+
+/**
+ * Spread into an operation's input object to give it the `client` field. Every
+ * `core` operation carries it, so a binding never has to special-case which
+ * calls may be attributed.
+ */
+export const clientField = {
+  client: clientMetadataSchema.optional().describe(DESCRIPTION),
+} as const;

--- a/packages/engine/src/api/core-executors.ts
+++ b/packages/engine/src/api/core-executors.ts
@@ -11,7 +11,12 @@
  * existing surfaces (published-only search, index regeneration after publish,
  * status/tag normalization, document validation before write).
  */
-import type { ContextNode, Frontmatter, SkillMeta } from "../types.js";
+import type {
+  ClientMetadata,
+  ContextNode,
+  Frontmatter,
+  SkillMeta,
+} from "../types.js";
 import {
   serializeDocument,
   validateDocument,
@@ -169,10 +174,12 @@ async function publishAndIndex(
   ctx: OperationContext,
   id: string,
   note?: string,
+  client?: ClientMetadata,
 ): Promise<{ version: number; checkpoint: number }> {
   const res = await publishDocument(ctx.storage, id, {
     editedBy: ctx.actor ?? "engine",
     ...(note ? { note } : {}),
+    ...(client ? { client } : {}),
   });
   // publishDocument does NOT touch context.yaml; graph-mode reads (the default
   // context_query) seed from it, so a stale index would hide the write. OSS
@@ -186,6 +193,9 @@ const query: OperationExecutor = async (ctx, input: any) => {
     hops: clampHops(input.hops),
     full: input.full ?? false,
     includeDrafts: input.include_drafts ?? false,
+    // Every access trace this query emits is stamped with the caller (§9.4),
+    // so provenance records which agent read the node, not just which node.
+    client: input.client,
   });
   return {
     documents: result.documents.map((d) => toSummary(d, true)),
@@ -205,6 +215,7 @@ const resolve: OperationExecutor = async (ctx, input: any) => {
   const result = await ctx.query.query(input.selector, {
     hops: clampHops(input.hops),
     full: false,
+    client: input.client,
   });
   const budget = input.max_tokens ?? 8000;
   const documents: Array<{ id: string; frontmatter: Frontmatter; body: string }> = [];
@@ -236,7 +247,10 @@ const search: OperationExecutor = async (ctx, input: any) => {
   // keeps recall while guaranteeing a single well-formed URI token.
   const q = slugify(String(input.query));
   if (!q) return { results: [] };
-  const result = await ctx.query.query(`contextnest://search/${q}`, { full: true });
+  const result = await ctx.query.query(`contextnest://search/${q}`, {
+    full: true,
+    client: input.client,
+  });
   const docs = input.limit ? result.documents.slice(0, input.limit) : result.documents;
   return { results: docs.map((d) => toSummary(d)) };
 };
@@ -359,7 +373,7 @@ const create: OperationExecutor = async (ctx, input: any) => {
       checkpoint: null,
     };
   }
-  const result = await publishAndIndex(ctx, node.id, input.note);
+  const result = await publishAndIndex(ctx, node.id, input.note, input.client);
   return {
     id: node.id,
     version: result.version,
@@ -455,7 +469,7 @@ const update: OperationExecutor = async (ctx, input: any) => {
       checkpoint: null,
     };
   }
-  const result = await publishAndIndex(ctx, id, input.note);
+  const result = await publishAndIndex(ctx, id, input.note, input.client);
   return { id, version: result.version, status: "published", checkpoint: result.checkpoint };
 };
 
@@ -466,6 +480,7 @@ const publish: OperationExecutor = async (ctx, input: any) => {
   const result = await publishDocument(ctx.storage, id, {
     editedBy: ctx.actor ?? "engine",
     ...(input.note ? { note: input.note } : {}),
+    ...(input.client ? { client: input.client } : {}),
   });
   await ctx.storage.regenerateIndex();
   return {
@@ -513,6 +528,7 @@ const versions: OperationExecutor = async (ctx, input: any) => {
         note: v.note,
         content_hash: v.content_hash,
         chain_hash: v.chain_hash,
+        ...(v.client ? { client: v.client } : {}),
         ...(versionManager
           ? { diff: (await versionManager.getDiff(id, v.version)) ?? undefined }
           : {}),
@@ -701,6 +717,7 @@ const importDocs: OperationExecutor = async (ctx, input: any) => {
     const result = await publishDocuments(ctx.storage, batch, {
       editedBy: ctx.actor ?? "engine",
       onProgress: ctx.onProgress,
+      ...(input.client ? { client: input.client } : {}),
       // The importer's metadata rides along with the publish write instead of
       // costing its own pass. Title falls back to the filename; the author is
       // the importing user, since the source's own `author:` names someone who

--- a/packages/engine/src/api/core.ts
+++ b/packages/engine/src/api/core.ts
@@ -19,6 +19,7 @@ import {
   TAG_PATTERN,
   frontmatterSchema,
 } from "../schemas.js";
+import { clientField, clientMetadataSchema } from "./client.js";
 import type { OperationDescriptor } from "./types.js";
 
 const tag = z.string().regex(TAG_PATTERN);
@@ -79,7 +80,7 @@ const nodeSelectorShape = {
  * what to send. `resolveId` raises the same VALIDATION_FAILED at execution
  * time, which every transport surfaces identically.
  */
-const nodeSelector = z.object(nodeSelectorShape);
+const nodeSelector = z.object({ ...nodeSelectorShape, ...clientField });
 
 // ─── context_search ──────────────────────────────────────────────────────────
 
@@ -91,6 +92,7 @@ const searchOp: OperationDescriptor = {
   input: z.object({
     query: z.string().min(1).describe("Search terms"),
     limit: z.number().int().positive().optional().describe("Max results"),
+    ...clientField,
   }),
   output: z.object({
     results: z.array(nodeSummary.extend({ score: z.number().optional() })),
@@ -130,6 +132,7 @@ const queryOp: OperationDescriptor = {
       .describe(
         "Include unpublished documents (default: published only). For authoring surfaces, where the point is to find the draft you are working on.",
       ),
+    ...clientField,
   }),
   output: z.object({
     documents: z.array(nodeSummary),
@@ -166,6 +169,7 @@ const resolveOp: OperationDescriptor = {
       .min(0)
       .optional()
       .describe("Graph traversal depth (default: 2)"),
+    ...clientField,
   }),
   output: z.object({
     documents: z.array(documentPayload),
@@ -203,6 +207,7 @@ const getOp: OperationDescriptor = {
       .describe(
         "Return a rejected node instead of refusing. Reading one is not the same as republishing it — surfaces that let a steward see and revive retired documents set this.",
       ),
+    ...clientField,
   }),
   output: documentPayload,
   errors: [
@@ -248,6 +253,7 @@ const listOp: OperationDescriptor = {
       .describe(
         "Return each node's full frontmatter and body instead of a summary. For callers that go on to render or gate the documents themselves and would otherwise have to read them all again.",
       ),
+    ...clientField,
   }),
   output: z.object({
     documents: z.array(nodeSummary),
@@ -310,6 +316,7 @@ const createOp: OperationDescriptor = {
     // skill block has exactly one authoritative schema.
     inputs: z.array(z.record(z.unknown())).optional().describe("Skill input parameters"),
     guard_rails: z.array(z.string()).optional().describe("Skill execution constraints"),
+    ...clientField,
   }),
   output: z.object({
     id: z.string(),
@@ -374,6 +381,7 @@ const updateOp: OperationDescriptor = {
       .describe(
         "Explicit version to stamp, for governed callers that assign version numbers themselves (a draft revision awaiting review). Ignored when publishing, which assigns the version.",
       ),
+    ...clientField,
   }),
   output: z.object({
     id: z.string(),
@@ -407,6 +415,7 @@ const publishOp: OperationDescriptor = {
       .string()
       .optional()
       .describe("Version-history note recorded against the publish (audit trail)."),
+    ...clientField,
   }),
   output: z.object({
     id: z.string(),
@@ -454,6 +463,12 @@ const versionEntryOut = z.object({
   /** Only present when the caller passes `include_diff`. Absent for a keyframe
    *  (a full snapshot has no patch) and for v1. */
   diff: z.string().optional().describe("Unified diff from the previous version"),
+  /** Caller metadata recorded with the write that sealed this version (§9.4). */
+  client: clientMetadataSchema
+    .optional()
+    .describe(
+      "Caller metadata the write carried — agent, session_id, custom keys. Absent for versions written before the caller sent any.",
+    ),
 });
 
 const versionsOp: OperationDescriptor = {
@@ -470,6 +485,7 @@ const versionsOp: OperationDescriptor = {
       .boolean()
       .optional()
       .describe("Attach each version's change log (unified diff from the previous version)"),
+    ...clientField,
   }),
   output: z.object({
     id: z.string(),
@@ -494,6 +510,7 @@ const reconstructOp: OperationDescriptor = {
   input: z.object({
     ...nodeSelectorShape,
     version: z.number().int().positive().describe("Version number to reconstruct"),
+    ...clientField,
   }),
   output: z.object({
     id: z.string(),
@@ -533,7 +550,7 @@ const verifyOp: OperationDescriptor = {
   name: "context_verify",
   namespace: "core",
   description: "Verify every document and checkpoint hash chain in the vault.",
-  input: z.object({}),
+  input: z.object({ ...clientField }),
   output: z.object({ valid: z.boolean(), errors: z.array(verifyError) }),
   errors: ["VALIDATION_FAILED"],
   aliases: ["verify_integrity"],
@@ -554,6 +571,7 @@ const initOp: OperationDescriptor = {
         "Also list every node. Off by default: the counts and tags below answer most opening questions, and a large vault's node list dwarfs them.",
       ),
     limit: z.number().int().positive().optional().describe("Max nodes to list, with include_nodes"),
+    ...clientField,
   }),
   output: z.object({
     context_md: z.string().nullable().describe("The vault's operating instructions, if it has any"),
@@ -596,7 +614,7 @@ const packsOp: OperationDescriptor = {
   name: "context_packs",
   namespace: "core",
   description: "List the context packs defined in the vault.",
-  input: z.object({}),
+  input: z.object({ ...clientField }),
   output: z.object({ packs: z.array(packSummary) }),
   errors: ["VALIDATION_FAILED"],
 };
@@ -633,7 +651,7 @@ const nestsOp: OperationDescriptor = {
   namespace: "core",
   description:
     "List every nest registered in the central registry — local vaults and remote MCP endpoints alike — with its alias, kind, endpoint, description, and whether it is the default. Use this to discover which nests exist before targeting one.",
-  input: z.object({}),
+  input: z.object({ ...clientField }),
   output: z.object({ nests: z.array(nestSummary) }),
   errors: ["CONFIG_ERROR", "VALIDATION_FAILED"],
 };
@@ -707,6 +725,7 @@ const importOp: OperationDescriptor = {
       .describe(
         "With `discover`: stamped as `author` on every imported document. The importing user, not the vault's own `author:` — which names someone who need not exist on this host.",
       ),
+    ...clientField,
   }),
   output: z.object({
     published: z.array(z.object({ id: z.string(), version: z.number().int().min(1) })),

--- a/packages/engine/src/api/index.ts
+++ b/packages/engine/src/api/index.ts
@@ -24,6 +24,14 @@ import {
 import { CORE_OPERATIONS } from "./core.js";
 
 export * from "./types.js";
+export {
+  clientField,
+  clientMetadataSchema,
+  CLIENT_METADATA_RESERVED_KEYS,
+  CLIENT_METADATA_MAX_CUSTOM_KEYS,
+  CLIENT_METADATA_MAX_VALUE_LENGTH,
+  type ClientMetadata,
+} from "./client.js";
 export { CORE_OPERATIONS } from "./core.js";
 export { CORE_EXECUTORS } from "./core-executors.js";
 export type { OperationContext, OperationExecutor } from "./context.js";

--- a/packages/engine/src/graph-query-engine.ts
+++ b/packages/engine/src/graph-query-engine.ts
@@ -9,6 +9,7 @@
  */
 
 import type {
+  ClientMetadata,
   ContextNode,
   ContextYaml,
   GraphQueryResult,
@@ -33,6 +34,12 @@ export interface GraphQueryOptions {
   full?: boolean;
   /** Include draft documents (default: false) */
   includeDrafts?: boolean;
+  /**
+   * Caller metadata (§9.4) — agent name, session id, custom keys — stamped on
+   * every access trace this query emits, so a §9.2 provenance record says which
+   * agent read the document, not just which document was read.
+   */
+  client?: ClientMetadata;
 }
 
 export class GraphQueryEngine {
@@ -143,6 +150,7 @@ export class GraphQueryEngine {
         checkpoint: currentCheckpoint,
         author: doc.frontmatter.author,
         editedAt: doc.frontmatter.updated_at,
+        client: options.client,
       });
     }
 
@@ -196,6 +204,7 @@ export class GraphQueryEngine {
       resolver,
       packLoader,
       currentCheckpoint,
+      client: options.client,
     });
 
     const result = await injector.inject(selector);

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -33,6 +33,7 @@ export type {
   CheckpointHistory,
   NestConfig,
   AccessTrace,
+  ClientMetadata,
   SourceHydrationTrace,
   TraceEntry,
   ValidationError,
@@ -137,6 +138,7 @@ export {
   packSchema,
   versionEntrySchema,
   documentHistorySchema,
+  clientMetadataSchema,
   checkpointSchema,
   checkpointHistorySchema,
   suggestionMetaSchema,
@@ -151,6 +153,9 @@ export {
   TAG_PATTERN,
   CHECKSUM_PATTERN,
   ZONE_ID_PATTERN,
+  CLIENT_METADATA_RESERVED_KEYS,
+  CLIENT_METADATA_MAX_CUSTOM_KEYS,
+  CLIENT_METADATA_MAX_VALUE_LENGTH,
 } from "./schemas.js";
 
 // Parser

--- a/packages/engine/src/injection.ts
+++ b/packages/engine/src/injection.ts
@@ -4,7 +4,7 @@
  * and returns documents with trace entries.
  */
 
-import type { ContextNode, ResolvedResult } from "./types.js";
+import type { ClientMetadata, ContextNode, ResolvedResult } from "./types.js";
 import { Resolver } from "./resolver.js";
 import { PackLoader } from "./packs.js";
 import { parseSelector } from "./selector/parser.js";
@@ -16,6 +16,12 @@ export interface InjectorOptions {
   resolver: Resolver;
   packLoader: PackLoader;
   currentCheckpoint: number;
+  /**
+   * Caller metadata (§9.4) stamped on every access trace this injector emits,
+   * so a §9.2 provenance record names the agent and session that read the
+   * document, not only the document.
+   */
+  client?: ClientMetadata;
 }
 
 export class ContextInjector {
@@ -23,12 +29,14 @@ export class ContextInjector {
   private packLoader: PackLoader;
   private traceLogger: TraceLogger;
   private currentCheckpoint: number;
+  private client?: ClientMetadata;
 
   constructor(options: InjectorOptions) {
     this.resolver = options.resolver;
     this.packLoader = options.packLoader;
     this.traceLogger = new TraceLogger();
     this.currentCheckpoint = options.currentCheckpoint;
+    this.client = options.client;
   }
 
   /**
@@ -66,6 +74,7 @@ export class ContextInjector {
         checkpoint: this.currentCheckpoint,
         author: doc.frontmatter.author,
         editedAt: doc.frontmatter.updated_at,
+        client: this.client,
       });
     }
 

--- a/packages/engine/src/publish.ts
+++ b/packages/engine/src/publish.ts
@@ -3,7 +3,12 @@
  * Ties together versioning, integrity, checkpoints, and index regeneration.
  */
 
-import type { ContextNode, Frontmatter, VersionEntry } from "./types.js";
+import type {
+  ClientMetadata,
+  ContextNode,
+  Frontmatter,
+  VersionEntry,
+} from "./types.js";
 import { NestStorage, assertSafeDocumentId } from "./storage.js";
 import { VersionManager } from "./versioning.js";
 import { CheckpointManager } from "./checkpoint.js";
@@ -15,6 +20,11 @@ import { mapInBatches } from "./concurrency.js";
 export interface PublishOptions {
   editedBy: string;
   note?: string;
+  /**
+   * Caller metadata recorded on the version entry this publish seals (§9.4) —
+   * which agent, in which session. Not hashed; see `VersionEntry.client`.
+   */
+  client?: ClientMetadata;
 }
 
 export interface PublishResult {
@@ -90,6 +100,7 @@ export async function publishDocument(
   const versionEntry = await versionManager.createVersion(node, options.editedBy, {
     note: options.note,
     publishedAt,
+    client: options.client,
   });
 
   // Create checkpoint. The published-docs and histories snapshots are gathered
@@ -223,6 +234,7 @@ export async function publishDocuments(
       const versionEntry = await versionManager.createVersion(node, options.editedBy, {
         note: options.note,
         publishedAt: new Date().toISOString(),
+        client: options.client,
       });
       published.push({
         id: docId,

--- a/packages/engine/src/schemas.ts
+++ b/packages/engine/src/schemas.ts
@@ -297,6 +297,48 @@ export const packSchema = z.object({
   audiences: z.array(z.string()).optional(),
 });
 
+// ─── Client (caller) metadata (§9.4) ─────────────────────────────────────────
+
+/** Reserved keys of {@link clientMetadataSchema}; everything else is custom. */
+export const CLIENT_METADATA_RESERVED_KEYS = ["agent", "session_id"] as const;
+/** How many CUSTOM keys a caller may attach beyond the reserved two. */
+export const CLIENT_METADATA_MAX_CUSTOM_KEYS = 16;
+/** Longest string value accepted for any key. */
+export const CLIENT_METADATA_MAX_VALUE_LENGTH = 512;
+
+/**
+ * Caller metadata attached to an API call — the calling agent's name, its
+ * session id, and any custom keys it wants recorded alongside the action.
+ *
+ * Bounds are not decoration. This object is written into the append-only
+ * version history and into access traces, so an unbounded one lets any caller
+ * grow a vault's audit trail without limit. Values are scalars for the same
+ * reason: a nested payload has no natural size, and YAML-round-tripping one
+ * through history.yaml would make the entry unreadable.
+ */
+export const clientMetadataSchema = z
+  .object({
+    agent: z.string().min(1).max(CLIENT_METADATA_MAX_VALUE_LENGTH).optional(),
+    session_id: z.string().min(1).max(CLIENT_METADATA_MAX_VALUE_LENGTH).optional(),
+  })
+  .catchall(
+    z.union([
+      z.string().max(CLIENT_METADATA_MAX_VALUE_LENGTH),
+      z.number(),
+      z.boolean(),
+    ]),
+  )
+  .superRefine((value, ctx) => {
+    const reserved = new Set<string>(CLIENT_METADATA_RESERVED_KEYS);
+    const custom = Object.keys(value).filter((key) => !reserved.has(key));
+    if (custom.length > CLIENT_METADATA_MAX_CUSTOM_KEYS) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `client metadata accepts at most ${CLIENT_METADATA_MAX_CUSTOM_KEYS} custom keys, got ${custom.length}`,
+      });
+    }
+  });
+
 export const versionEntrySchema = z.object({
   version: z.number().int().min(1),
   keyframe: z.boolean().optional(),
@@ -307,6 +349,8 @@ export const versionEntrySchema = z.object({
   note: z.string().optional(),
   content_hash: z.string().regex(CHECKSUM_PATTERN),
   chain_hash: z.string().regex(CHECKSUM_PATTERN),
+  // Annotation, not chained evidence — see VersionEntry.client in types.ts.
+  client: clientMetadataSchema.optional(),
 });
 
 export const documentHistorySchema = z.object({

--- a/packages/engine/src/schemas.ts
+++ b/packages/engine/src/schemas.ts
@@ -337,6 +337,24 @@ export const clientMetadataSchema = z
         message: `client metadata accepts at most ${CLIENT_METADATA_MAX_CUSTOM_KEYS} custom keys, got ${custom.length}`,
       });
     }
+    // Refuse a near-miss on a reserved key. `sessionId` is valid as a custom
+    // key and would be recorded — but NOT in the slot `context_versions` reads,
+    // so the write ends up silently un-attributed. That is the one failure an
+    // open catchall cannot catch on its own, and the caller cannot see it
+    // happen. Naming the intended key is cheaper than auditing the miss later.
+    for (const key of custom) {
+      const normalized = key.toLowerCase().replace(/[^a-z0-9]/g, "");
+      const collision = CLIENT_METADATA_RESERVED_KEYS.find(
+        (r) => r.replace(/[^a-z0-9]/g, "") === normalized,
+      );
+      if (collision) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: [key],
+          message: `client metadata key "${key}" looks like the reserved key "${collision}" — use "${collision}" exactly, or rename it`,
+        });
+      }
+    }
   });
 
 export const versionEntrySchema = z.object({

--- a/packages/engine/src/schemas.ts
+++ b/packages/engine/src/schemas.ts
@@ -363,6 +363,16 @@ export const clientMetadataSchema = z
     // open catchall cannot catch on its own, and the caller cannot see it
     // happen. Naming the intended key is cheaper than auditing the miss later.
     for (const key of custom) {
+      // Key NAMES are bounded like values: they land in the same append-only
+      // trail, and an empty key is unreadable in history.yaml.
+      if (key.trim().length === 0 || key.length > CLIENT_METADATA_MAX_VALUE_LENGTH) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: [key],
+          message: `client metadata keys must be non-empty and at most ${CLIENT_METADATA_MAX_VALUE_LENGTH} chars`,
+        });
+        continue;
+      }
       const normalized = key.toLowerCase().replace(/[^a-z0-9]/g, "");
       const collision = CLIENT_METADATA_RESERVED_KEYS.find(
         (r) => r.replace(/[^a-z0-9]/g, "") === normalized,
@@ -388,7 +398,13 @@ export const versionEntrySchema = z.object({
   content_hash: z.string().regex(CHECKSUM_PATTERN),
   chain_hash: z.string().regex(CHECKSUM_PATTERN),
   // Annotation, not chained evidence — see VersionEntry.client in types.ts.
-  client: clientMetadataSchema.optional(),
+  // Lenient on READ, deliberately: the input bounds above are enforced when a
+  // caller sends the block, not when a history is loaded. Reusing them here
+  // would let a future tightening (or a hand-edited entry) fail
+  // documentHistorySchema, which storage raises as CorruptHistoryError and
+  // historyOrRepair answers by quarantining the file and restarting the chain
+  // — a whole chain lost over an annotation that is not even hashed.
+  client: z.record(z.union([z.string(), z.number(), z.boolean()])).optional(),
 });
 
 export const documentHistorySchema = z.object({

--- a/packages/engine/src/tracing.ts
+++ b/packages/engine/src/tracing.ts
@@ -2,7 +2,12 @@
  * Audit trace logging (§9.2, §9.3).
  */
 
-import type { AccessTrace, SourceHydrationTrace, TraceEntry } from "./types.js";
+import type {
+  AccessTrace,
+  ClientMetadata,
+  SourceHydrationTrace,
+  TraceEntry,
+} from "./types.js";
 
 const DEFAULT_MAX_TRACES = 1000;
 
@@ -28,6 +33,8 @@ export class TraceLogger {
     checkpoint: number;
     author?: string;
     editedAt?: string;
+    /** Caller metadata from the read that triggered this access (§9.4). */
+    client?: ClientMetadata;
   }): AccessTrace {
     const trace: AccessTrace = {
       trace_type: "access",
@@ -37,6 +44,11 @@ export class TraceLogger {
       author: params.author,
       edited_at: params.editedAt,
       accessed_at: new Date().toISOString(),
+      // Omitted rather than set undefined when the caller sent none, so a trace
+      // serialized to an audit log carries no empty key.
+      ...(params.client && Object.keys(params.client).length > 0
+        ? { client: params.client }
+        : {}),
     };
     this.traces.push(trace);
     this.evictIfNeeded();

--- a/packages/engine/src/types.ts
+++ b/packages/engine/src/types.ts
@@ -324,6 +324,16 @@ export interface VersionEntry {
   note?: string;
   content_hash: string;
   chain_hash: string;
+  /**
+   * Caller metadata supplied with the write that produced this version (§9.4)
+   * — which agent, in which session, plus any custom keys.
+   *
+   * Deliberately NOT an input to `chain_hash` (§8.2): the chain covers the
+   * content and the authoring facts the spec names, and every history written
+   * before this field existed must keep verifying byte-for-byte. Treat it as an
+   * annotation on the entry, not as sealed evidence.
+   */
+  client?: ClientMetadata;
 }
 
 /** Document history file (§6.2) */
@@ -460,6 +470,31 @@ export interface VaultRegistry {
   remotes?: Record<string, RemoteNestSpec>;
 }
 
+/**
+ * Caller-supplied metadata attached to an API call (§9.4).
+ *
+ * `agent` and `session_id` are the two fields every caller is expected to send
+ * — they answer "which agent, in which session" for a read or a write. Any
+ * other key is custom, and travels verbatim.
+ *
+ * This is NOT identity: the engine never authenticates it, and never makes a
+ * decision from it. It is a label recorded alongside the action so an audit
+ * trail can attribute it. Authorization stays with the `RbacHook` and the
+ * `actor` on an operation context.
+ *
+ * Bounded by `clientMetadataSchema` (schemas.ts) — this is written into the
+ * append-only version history, so an unbounded payload would be a way to bloat
+ * a vault's audit trail.
+ */
+export interface ClientMetadata {
+  /** Name of the calling agent, e.g. "claude-code". */
+  agent?: string;
+  /** Identifier of the calling session, opaque to the engine. */
+  session_id?: string;
+  /** Custom keys, recorded verbatim. */
+  [key: string]: string | number | boolean | undefined;
+}
+
 /** Trace entry for document access (§9.2) */
 export interface AccessTrace {
   trace_type: "access";
@@ -469,6 +504,8 @@ export interface AccessTrace {
   author?: string;
   edited_at?: string;
   accessed_at: string;
+  /** Caller metadata supplied with the read that produced this trace (§9.4). */
+  client?: ClientMetadata;
 }
 
 /** Trace entry for source hydration (§9.3) */

--- a/packages/engine/src/versioning.ts
+++ b/packages/engine/src/versioning.ts
@@ -4,7 +4,12 @@
  */
 
 import { createPatch, applyPatch } from "diff";
-import type { ContextNode, DocumentHistory, VersionEntry } from "./types.js";
+import type {
+  ClientMetadata,
+  ContextNode,
+  DocumentHistory,
+  VersionEntry,
+} from "./types.js";
 import { computeContentHash, computeChainHash } from "./integrity.js";
 import { serializeDocument } from "./parser.js";
 import { NestStorage } from "./storage.js";
@@ -46,6 +51,9 @@ export class VersionManager {
     options: {
       note?: string;
       publishedAt?: string;
+      /** Caller metadata recorded on the entry (§9.4). Never hashed — see
+       *  `VersionEntry.client`. */
+      client?: ClientMetadata;
     } = {},
   ): Promise<VersionEntry> {
     const history = (await this.storage.readHistory(node.id)) || {
@@ -128,6 +136,12 @@ export class VersionManager {
       ...(options.note ? { note: options.note } : {}),
       content_hash: contentHash,
       chain_hash: chainHash,
+      // AFTER the hashes: `client` is an annotation on the entry, deliberately
+      // outside `computeChainHash`'s inputs so every history recorded before
+      // this field existed still verifies byte-for-byte.
+      ...(options.client && Object.keys(options.client).length > 0
+        ? { client: options.client }
+        : {}),
     };
 
     // APPEND, never rewrite. The entries already on disk are not reopened for

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -118,6 +118,27 @@ them over the legacy tools below.
 | `context_delete` | Delete a node and its version history; returns the deleted node's `title` |
 | `context_import` | Bulk create-and-publish. Takes `documents` (title + content) and/or `ids` (files already in the vault, published as-is) — a mixed batch seals **one** checkpoint and regenerates the index **once** |
 
+#### `client` — attributing a call
+
+Every tool above takes an optional `client` object naming the calling agent and
+its session, plus any custom scalar keys:
+
+```jsonc
+context_create({
+  title: "API Design",
+  content: "…",
+  client: { agent: "claude-code", session_id: "s-9f2" }
+})
+```
+
+A write that publishes records it on the version-history entry it seals, so
+`context_versions` can answer *which agent wrote v7, in which session*; a graph
+read stamps it on the access traces it emits. It is a label, never an identity
+claim — the server does not authenticate it and never authorizes from it — and
+it is not an input to any hash chain. Note that `client` describes the CALL;
+`metadata` on `context_create` / `context_update` is frontmatter and describes
+the DOCUMENT. See spec §9.4.
+
 ### Vault tools
 
 | Tool | Description |

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -133,9 +133,18 @@ context_create({
 
 A write that publishes records it on the version-history entry it seals, so
 `context_versions` can answer *which agent wrote v7, in which session*; a graph
-read stamps it on the access traces it emits. It is a label, never an identity
-claim — the server does not authenticate it and never authorizes from it — and
-it is not an input to any hash chain. Note that `client` describes the CALL;
+read stamps it on the access traces it emits.
+
+**You usually do not need to send it.** The server fills both fields from what
+the connection already tells it: `agent` from the `clientInfo.name` in your
+`initialize` handshake, and `session_id` from a per-process id — over stdio one
+server process is one client connection, so every call sharing that id really
+did come from one session. Anything you send wins, merged **per key**: supply
+just `agent` and you keep it while still getting a session id.
+
+It is a label, never an identity claim — `clientInfo.name` is your self-report,
+the server authenticates neither, and it never authorizes from either — and it
+is not an input to any hash chain. Note that `client` describes the CALL;
 `metadata` on `context_create` / `context_update` is frontmatter and describes
 the DOCUMENT. See spec §9.4.
 

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -135,12 +135,29 @@ A write that publishes records it on the version-history entry it seals, so
 `context_versions` can answer *which agent wrote v7, in which session*; a graph
 read stamps it on the access traces it emits.
 
+**Every field is optional** — `client` itself, and `agent`/`session_id` within
+it. Send none, one, or all.
+
 **You usually do not need to send it.** The server fills both fields from what
 the connection already tells it: `agent` from the `clientInfo.name` in your
 `initialize` handshake, and `session_id` from a per-process id — over stdio one
 server process is one client connection, so every call sharing that id really
 did come from one session. Anything you send wins, merged **per key**: supply
 just `agent` and you keep it while still getting a session id.
+
+| Env var | Effect |
+|---------|--------|
+| `CONTEXTNEST_NO_ATTRIBUTION=1` | Server derives nothing; nothing is recorded unless a caller sends its own `client` |
+| `CONTEXTNEST_AGENT` | Overrides the `agent` the handshake reports |
+| `CONTEXTNEST_SESSION_ID` | Overrides the per-process session id |
+
+Precedence per key: **caller > env > connection.** With attribution off and no
+caller value, the `client` key is left off the record entirely rather than
+written as `{}` — "not attributed" and "attributed to nobody" are different
+claims, and history should only make the first. The opt-out matters because
+what gets derived lands in an append-only history: an operator who does not
+want their client's name recorded in a vault needs to say so before the first
+write, not scrub it after.
 
 It is a label, never an identity claim — `clientInfo.name` is your self-report,
 the server authenticates neither, and it never authorizes from either — and it

--- a/packages/mcp-server/src/__tests__/catalog-binding.regression.test.ts
+++ b/packages/mcp-server/src/__tests__/catalog-binding.regression.test.ts
@@ -399,6 +399,44 @@ describe("[regression] catalog binding — write lifecycle via canonical ops", (
     expect(versions.versions.at(-1)!.client).toEqual(meta);
   });
 
+  it("fills agent + session_id from the MCP handshake when the caller sends none", async () => {
+    // Most agents will not know the field exists, and an audit trail that is
+    // empty by default is not much of one. The server knows the client's name
+    // from `initialize` and owns the stdio connection, so it can say both.
+    const created = await callJson(client, "context_create", {
+      title: "Server Attributed",
+      content: "body",
+    });
+    const versions = await callJson(client, "context_versions", { id: created.id });
+    const recorded = versions.versions.at(-1)!.client;
+    expect(recorded.agent).toBe("catalog-regression-test");
+    expect(recorded.session_id).toMatch(/^mcp-[0-9a-f-]{36}$/);
+  });
+
+  it("lets a caller override the defaults per key, not all-or-nothing", async () => {
+    const created = await callJson(client, "context_create", {
+      title: "Partial Override",
+      content: "body",
+      client: { agent: "downstream-agent" },
+    });
+    const versions = await callJson(client, "context_versions", { id: created.id });
+    const recorded = versions.versions.at(-1)!.client;
+    // The caller's agent wins…
+    expect(recorded.agent).toBe("downstream-agent");
+    // …and the session it did not supply is still filled in, rather than lost.
+    expect(recorded.session_id).toMatch(/^mcp-/);
+  });
+
+  it("keeps one session id across every call on a connection", async () => {
+    const a = await callJson(client, "context_create", { title: "Same Session A", content: "x" });
+    const b = await callJson(client, "context_create", { title: "Same Session B", content: "y" });
+    const [va, vb] = await Promise.all([
+      callJson(client, "context_versions", { id: a.id }),
+      callJson(client, "context_versions", { id: b.id }),
+    ]);
+    expect(va.versions.at(-1)!.client.session_id).toBe(vb.versions.at(-1)!.client.session_id);
+  });
+
   it("refuses malformed `client` metadata rather than writing an unvalidated one", async () => {
     // The SDK validates tool arguments against the published schema before the
     // handler runs, so this is rejected at the protocol layer rather than

--- a/packages/mcp-server/src/__tests__/catalog-binding.regression.test.ts
+++ b/packages/mcp-server/src/__tests__/catalog-binding.regression.test.ts
@@ -379,6 +379,44 @@ describe("[regression] catalog binding — write lifecycle via canonical ops", (
     expect(json.published.length).toBe(2);
     expect(json.failed.length).toBe(0);
   });
+
+  it("carries `client` metadata over the wire onto the version entry", async () => {
+    // The whole point of the field is cross-process attribution: an agent on
+    // the far side of stdio says who it is, and the vault's audit trail keeps
+    // it. Asserting it in-process would not prove the MCP tool schema accepts
+    // it — an unadvertised property is dropped before the executor sees it.
+    const meta = { agent: "regression-agent", session_id: "sess-catalog-1", attempt: 1 };
+    const created = await callJson(client, "context_create", {
+      title: "Attributed Write",
+      content: "body",
+      client: meta,
+    });
+    const versions = await callJson(client, "context_versions", {
+      id: created.id,
+      client: meta,
+    });
+    expect(getOperation("context_versions")!.output.safeParse(versions).success).toBe(true);
+    expect(versions.versions.at(-1)!.client).toEqual(meta);
+  });
+
+  it("refuses malformed `client` metadata rather than writing an unvalidated one", async () => {
+    // The SDK validates tool arguments against the published schema before the
+    // handler runs, so this is rejected at the protocol layer rather than
+    // reaching the engine's own VALIDATION_FAILED. Either way the contract that
+    // matters holds: a non-scalar never lands in the audit trail.
+    const { text, isError } = await callText(client, "context_create", {
+      title: "Bad Attribution",
+      content: "body",
+      client: { agent: { nested: "not a scalar" } },
+    });
+    expect(isError).toBe(true);
+    expect(text).toMatch(/client/);
+
+    const listed = await callJson(client, "context_list", {});
+    expect(listed.documents.some((d: { title: string }) => d.title === "Bad Attribution")).toBe(
+      false,
+    );
+  });
 });
 
 // ─── Alias adapter edge cases ───────────────────────────────────────────────

--- a/packages/mcp-server/src/__tests__/catalog-binding.regression.test.ts
+++ b/packages/mcp-server/src/__tests__/catalog-binding.regression.test.ts
@@ -65,11 +65,15 @@ async function freshVault(): Promise<string> {
   return dir;
 }
 
-async function connect(vaultPath: string): Promise<Client> {
+async function connect(
+  vaultPath: string,
+  extraEnv: Record<string, string> = {},
+): Promise<Client> {
   const env: Record<string, string> = { CONTEXTNEST_VAULT_PATH: vaultPath };
   for (const [k, v] of Object.entries(process.env)) {
     if (typeof v === "string") env[k] = v;
   }
+  Object.assign(env, extraEnv);
   const transport = new StdioClientTransport({
     command: process.execPath,
     args: [SERVER_ENTRY],
@@ -588,5 +592,72 @@ describe("[regression] catalog binding — structured error contract", () => {
 
     const getErr = await callError(client, "context_get", { id: "nodes/retired-probe" });
     expect(getErr.code).toBe("REJECTED_DOCUMENT");
+  });
+});
+
+
+// ─── Attribution is optional ────────────────────────────────────────────────
+
+describe("[regression] catalog binding — attribution is optional", () => {
+  let vault: string;
+
+  beforeAll(async () => {
+    vault = await freshVault();
+  });
+  afterAll(async () => {
+    await rm(vault, { recursive: true, force: true });
+  });
+
+  it("records nothing when CONTEXTNEST_NO_ATTRIBUTION=1", async () => {
+    const client = await connect(vault, { CONTEXTNEST_NO_ATTRIBUTION: "1" });
+    try {
+      const created = await callJson(client, "context_create", {
+        title: "Opted Out",
+        content: "body",
+      });
+      const versions = await callJson(client, "context_versions", { id: created.id });
+      // Absent, not an empty object: "not attributed" and "attributed to
+      // nobody" are different claims, and history should only make the first.
+      expect(versions.versions.at(-1)).not.toHaveProperty("client");
+    } finally {
+      await client.close();
+    }
+  });
+
+  it("still honours a caller's own client when the server adds none", async () => {
+    // Opting the SERVER out is not a gag order on the caller — a client that
+    // deliberately sends attribution has chosen to record it.
+    const client = await connect(vault, { CONTEXTNEST_NO_ATTRIBUTION: "1" });
+    try {
+      const created = await callJson(client, "context_create", {
+        title: "Caller Insisted",
+        content: "body",
+        client: { agent: "explicit-agent" },
+      });
+      const versions = await callJson(client, "context_versions", { id: created.id });
+      expect(versions.versions.at(-1)!.client).toEqual({ agent: "explicit-agent" });
+    } finally {
+      await client.close();
+    }
+  });
+
+  it("lets CONTEXTNEST_AGENT / CONTEXTNEST_SESSION_ID override what the connection reports", async () => {
+    const client = await connect(vault, {
+      CONTEXTNEST_AGENT: "operator-named",
+      CONTEXTNEST_SESSION_ID: "s-operator",
+    });
+    try {
+      const created = await callJson(client, "context_create", {
+        title: "Operator Named",
+        content: "body",
+      });
+      const versions = await callJson(client, "context_versions", { id: created.id });
+      expect(versions.versions.at(-1)!.client).toEqual({
+        agent: "operator-named",
+        session_id: "s-operator",
+      });
+    } finally {
+      await client.close();
+    }
   });
 });

--- a/packages/mcp-server/src/__tests__/catalog-binding.regression.test.ts
+++ b/packages/mcp-server/src/__tests__/catalog-binding.regression.test.ts
@@ -75,6 +75,11 @@ async function connect(
     if (typeof v === "string") env[k] = v;
   }
   delete env.CTX_NEST_HOME;
+  // A developer's ambient attribution would otherwise leak into the "derived
+  // from the handshake" assertions below.
+  delete env.CONTEXTNEST_AGENT;
+  delete env.CONTEXTNEST_SESSION_ID;
+  delete env.CONTEXTNEST_NO_ATTRIBUTION;
   env.CONTEXTNEST_VAULT_PATH = vaultPath;
   // Last, so a test's own override beats both the inherited environment and
   // the vault path set just above.
@@ -420,6 +425,21 @@ describe("[regression] catalog binding — write lifecycle via canonical ops", (
     const recorded = versions.versions.at(-1)!.client;
     expect(recorded.agent).toBe("catalog-regression-test");
     expect(recorded.session_id).toMatch(/^mcp-[0-9a-f-]{36}$/);
+  });
+
+  it("derives the same attribution for the deprecated write tools", async () => {
+    // create_document / update_document / publish_document call publishDocument
+    // directly, bypassing runOp. Without this, a client still on the legacy
+    // tools writes unattributed history while the catalog tools are attributed.
+    await callJson(client, "create_document", { path: "nodes/legacy-attributed", title: "Legacy" });
+    await callJson(client, "update_document", { path: "nodes/legacy-attributed", title: "Legacy v2" });
+    await callJson(client, "publish_document", { path: "nodes/legacy-attributed" });
+    const versions = await callJson(client, "context_versions", { id: "nodes/legacy-attributed" });
+    expect(versions.versions).toHaveLength(3);
+    for (const v of versions.versions) {
+      expect(v.client.agent).toBe("catalog-regression-test");
+      expect(v.client.session_id).toMatch(/^mcp-/);
+    }
   });
 
   it("lets a caller override the defaults per key, not all-or-nothing", async () => {

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -4,6 +4,7 @@
  */
 
 import { readFileSync } from "node:fs";
+import { randomUUID } from "node:crypto";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
@@ -106,6 +107,59 @@ function opCtx(): OperationContext {
   };
 }
 
+// ─── Caller attribution defaults (spec §9.4) ─────────────────────────────────
+//
+// A tool call carries a `client` block naming the calling agent and session.
+// Most callers will not populate it — an agent has no reason to know the field
+// exists — and an audit trail that is empty by default is not much of one. So
+// the server fills what it can from what the transport already knows.
+
+/**
+ * This server process's session id.
+ *
+ * Over stdio, one process IS one session: the client spawns us, talks, and we
+ * exit with it. MCP has no session identifier of its own to borrow, so minting
+ * one per process is the closest true statement we can make — every call
+ * carrying this id really did come from one uninterrupted client connection.
+ */
+const MCP_SESSION_ID = `mcp-${randomUUID()}`;
+
+/**
+ * Attribution derived from the MCP `initialize` handshake, for calls that
+ * supply none of their own. `clientInfo.name` is the client's self-report, the
+ * same trust level as a caller-supplied `agent` — which is why neither is ever
+ * used to authorize.
+ *
+ * Read per call rather than cached: the handshake completes after this module
+ * is evaluated, so a value captured at load time would always be undefined.
+ */
+function defaultClient(): Record<string, string> {
+  const info = server.server.getClientVersion();
+  return {
+    ...(info?.name ? { agent: info.name } : {}),
+    session_id: MCP_SESSION_ID,
+  };
+}
+
+/**
+ * Merge server defaults under whatever the caller sent. Per KEY, not per
+ * object: a caller that names its agent but no session still gets the session
+ * filled in, rather than losing it to an all-or-nothing choice.
+ */
+function withClientDefaults(input: Record<string, unknown>): Record<string, unknown> {
+  const supplied = input.client;
+  // A non-object `client` is the caller's error to hear about. Passing it
+  // through unchanged lets the catalog raise VALIDATION_FAILED, where spreading
+  // it into an object here would silently repair invalid input.
+  if (supplied !== undefined && (typeof supplied !== "object" || supplied === null || Array.isArray(supplied))) {
+    return input;
+  }
+  return {
+    ...input,
+    client: { ...defaultClient(), ...(supplied as Record<string, unknown> | undefined) },
+  };
+}
+
 function toolResult(payload: unknown) {
   return {
     content: [{ type: "text" as const, text: JSON.stringify(payload, null, 2) }],
@@ -130,7 +184,7 @@ function toolError(err: unknown) {
 /** Run a catalog operation and package the outcome as a tool result. */
 async function runOp(name: string, input: Record<string, unknown>) {
   try {
-    return toolResult(await api.run(name, input, opCtx()));
+    return toolResult(await api.run(name, withClientDefaults(input), opCtx()));
   } catch (err) {
     return toolError(err);
   }

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -937,6 +937,9 @@ tool(
         result = await publishDocument(storage, id, {
           editedBy: "mcp@contextnest.local",
           note: "Created via MCP server",
+          // Derived attribution only — the legacy tools take no `client` of
+          // their own (additive parity with the catalog tools, per CLAUDE.md).
+          client: defaultClient(),
         });
       } catch (err) {
         try {
@@ -1167,6 +1170,7 @@ tool(
       const result = await publishDocument(storage, id, {
         editedBy: "mcp@contextnest.local",
         note: "Updated via MCP server",
+        client: defaultClient(),
       });
 
       await regenerateIndex();
@@ -1246,6 +1250,7 @@ tool(
       const result = await publishDocument(storage, id, {
         editedBy: author,
         note,
+        client: defaultClient(),
       });
 
       await regenerateIndex();

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -125,19 +125,37 @@ function opCtx(): OperationContext {
 const MCP_SESSION_ID = `mcp-${randomUUID()}`;
 
 /**
+ * Whether the server derives attribution at all.
+ *
+ * Set CONTEXTNEST_NO_ATTRIBUTION=1 to turn it off. This is a real opt-out, not
+ * a tidiness knob: what the server derives is written into an append-only
+ * version history, so an operator who does not want their MCP client's name
+ * recorded in a vault permanently needs a way to say so BEFORE the first write,
+ * not a way to scrub it after. A caller that sends its own `client` is still
+ * honoured — that is the caller's choice to record, not ours to strip.
+ */
+const ATTRIBUTION_ENABLED = process.env.CONTEXTNEST_NO_ATTRIBUTION !== "1";
+
+/**
  * Attribution derived from the MCP `initialize` handshake, for calls that
  * supply none of their own. `clientInfo.name` is the client's self-report, the
  * same trust level as a caller-supplied `agent` — which is why neither is ever
  * used to authorize.
  *
+ * CONTEXTNEST_AGENT / CONTEXTNEST_SESSION_ID override what the connection
+ * reports, matching the CLI's env vars so an operator names the agent the same
+ * way on both surfaces. A caller's own value still beats both.
+ *
  * Read per call rather than cached: the handshake completes after this module
  * is evaluated, so a value captured at load time would always be undefined.
  */
 function defaultClient(): Record<string, string> {
+  if (!ATTRIBUTION_ENABLED) return {};
   const info = server.server.getClientVersion();
+  const agent = process.env.CONTEXTNEST_AGENT || info?.name;
   return {
-    ...(info?.name ? { agent: info.name } : {}),
-    session_id: MCP_SESSION_ID,
+    ...(agent ? { agent } : {}),
+    session_id: process.env.CONTEXTNEST_SESSION_ID || MCP_SESSION_ID,
   };
 }
 
@@ -154,10 +172,16 @@ function withClientDefaults(input: Record<string, unknown>): Record<string, unkn
   if (supplied !== undefined && (typeof supplied !== "object" || supplied === null || Array.isArray(supplied))) {
     return input;
   }
-  return {
-    ...input,
-    client: { ...defaultClient(), ...(supplied as Record<string, unknown> | undefined) },
-  };
+  const merged = { ...defaultClient(), ...(supplied as Record<string, unknown> | undefined) };
+  // No defaults and nothing supplied: leave `client` OFF the input entirely
+  // rather than sending `{}`. An empty object would write an empty `client:`
+  // key into history, which reads as "attributed to nobody" instead of "not
+  // attributed" — and the field is optional precisely so absence stays sayable.
+  if (Object.keys(merged).length === 0) {
+    const { client: _client, ...rest } = input;
+    return rest;
+  }
+  return { ...input, client: merged };
 }
 
 function toolResult(payload: unknown) {

--- a/plugins/__tests__/core.unit.test.ts
+++ b/plugins/__tests__/core.unit.test.ts
@@ -102,17 +102,29 @@ function additional(out: any): string | undefined {
 }
 
 // getConfig() reads real override files when the caller doesn't inject
-// cwd/homedir (sessionStart never does). Point the home and project dirs at an
-// empty temp dir so a developer's own ~/.contextnest/plugin-settings.json can't
-// leak into these assertions. os.homedir() reads $HOME on POSIX and
-// %USERPROFILE% on Windows — setting only HOME leaves Windows unisolated, where
-// a real pinned vault turns eight of these into failures.
+// cwd/homedir (sessionStart never does). Point the home dir at an empty temp
+// dir so a developer's own ~/.contextnest/plugin-settings.json can't leak into
+// these assertions. os.homedir() reads $HOME on POSIX and %USERPROFILE% on
+// Windows — setting only HOME leaves Windows unisolated, where a real pinned
+// vault turns eight of these into failures.
+//
+// Mutating process.env.CLAUDE_PROJECT_DIR does NOT isolate the project dir the
+// same way: getConfig(env, opts) resolves cwd as
+// `opts.cwd || env.CLAUDE_PROJECT_DIR || process.cwd()`, reading it off the
+// `env` PARAMETER, not off the process-global. Every call below passes its own
+// literal env object (to test one key in isolation), so the mutation here is
+// invisible to them and they fall through to the real process.cwd() — a
+// developer's actual checkout, .claude/contextnest.local.json included. Use
+// `cfg()`/`startSession()` below, which inject SANDBOX_DIR through that same
+// `env.CLAUDE_PROJECT_DIR` channel a real Claude Code hook invocation would
+// populate, instead of calling getConfig()/sessionStart() directly.
+let SANDBOX_DIR: string;
 const realEnv = { HOME: process.env.HOME, USERPROFILE: process.env.USERPROFILE, CLAUDE_PROJECT_DIR: process.env.CLAUDE_PROJECT_DIR };
 beforeAll(() => {
-  const empty = mkdtempSync(join(tmpdir(), "cn-no-settings-"));
-  process.env.HOME = empty;
-  process.env.USERPROFILE = empty;
-  process.env.CLAUDE_PROJECT_DIR = empty;
+  SANDBOX_DIR = mkdtempSync(join(tmpdir(), "cn-no-settings-"));
+  process.env.HOME = SANDBOX_DIR;
+  process.env.USERPROFILE = SANDBOX_DIR;
+  process.env.CLAUDE_PROJECT_DIR = SANDBOX_DIR;
 });
 afterAll(() => {
   for (const [key, value] of Object.entries(realEnv)) {
@@ -121,13 +133,35 @@ afterAll(() => {
   }
 });
 
+/**
+ * getConfig(), sandboxed against SANDBOX_DIR — every bare call below goes
+ * through this, not the raw import, so a real .claude/contextnest.local.json
+ * on the developer's own machine can never leak into an assertion (see the
+ * note above). Calls that already sandbox their own cwd/homedir via
+ * `tempSettings()`'s `opts` (the "settings override files" suite) call
+ * getConfig() directly and don't need this.
+ */
+function cfg(env: Record<string, string | undefined> = {}) {
+  return getConfig({ ...env, CLAUDE_PROJECT_DIR: SANDBOX_DIR });
+}
+
+/**
+ * sessionStart(), sandboxed the same way. `run({env})` has no opts parameter
+ * of its own to inject through — it calls getConfig(env) with none — so the
+ * only isolation channel available is env.CLAUDE_PROJECT_DIR itself, same as
+ * a real Claude Code invocation would provide.
+ */
+function startSession(args: Parameters<typeof sessionStart>[0]) {
+  return sessionStart({ ...args, env: { ...args.env, CLAUDE_PROJECT_DIR: SANDBOX_DIR } });
+}
+
 describe("getConfig", () => {
   it("defaults and Claude userConfig precedence", () => {
-    expect(getConfig({}).retrievalMode).toBe("search");
-    expect(getConfig({}).autoCapture).toBe(true);
-    expect(getConfig({}).captureMode).toBe("propose");
-    expect(getConfig({}).vault).toBe("");
-    expect(getConfig({}).ctxCommand).toBe("ctx");
+    expect(cfg({}).retrievalMode).toBe("search");
+    expect(cfg({}).autoCapture).toBe(true);
+    expect(cfg({}).captureMode).toBe("propose");
+    expect(cfg({}).vault).toBe("");
+    expect(cfg({}).ctxCommand).toBe("ctx");
 
     const env = {
       CLAUDE_PLUGIN_OPTION_RETRIEVAL_MODE: "QUERY",
@@ -135,7 +169,7 @@ describe("getConfig", () => {
       CLAUDE_PLUGIN_OPTION_VAULT: "work",
       CLAUDE_PLUGIN_OPTION_CTX_COMMAND: "/bin/ctx",
     };
-    const c = getConfig(env);
+    const c = cfg(env);
     expect(c.retrievalMode).toBe("query");
     expect(c.autoCapture).toBe(false);
     expect(c.vault).toBe("work");
@@ -143,7 +177,7 @@ describe("getConfig", () => {
   });
 
   it("generic CONTEXTNEST_* fallbacks when no Claude option is set", () => {
-    const c = getConfig({ CONTEXTNEST_RETRIEVAL_MODE: "agent", CONTEXTNEST_VAULT_ALIAS: "p" });
+    const c = cfg({ CONTEXTNEST_RETRIEVAL_MODE: "agent", CONTEXTNEST_VAULT_ALIAS: "p" });
     expect(c.retrievalMode).toBe("agent");
     expect(c.vault).toBe("p");
   });
@@ -376,18 +410,18 @@ describe("lib helpers", () => {
 
   it("vaultTargets: a registered pin is honoured; unpinned fans out; empty registry → [null]", () => {
     const ex = fakeExec([["vault list", [{ alias: "a", exists: true }, { alias: "b", exists: true }]]]);
-    expect(vaultTargets(getConfig({ CONTEXTNEST_VAULT_ALIAS: "a" }), ex)).toEqual(["a"]);
-    expect(vaultTargets(getConfig({}), ex)).toEqual(["a", "b"]);
-    expect(vaultTargets(getConfig({}), fakeExec([["vault list", []]]))).toEqual([null]);
+    expect(vaultTargets(cfg({ CONTEXTNEST_VAULT_ALIAS: "a" }), ex)).toEqual(["a"]);
+    expect(vaultTargets(cfg({}), ex)).toEqual(["a", "b"]);
+    expect(vaultTargets(cfg({}), fakeExec([["vault list", []]]))).toEqual([null]);
   });
 
   it("vaultTargets: a stale pin (not registered) falls back to auto-select, not a bad --vault", () => {
     const twoVaults = fakeExec([["vault list", [{ alias: "a", exists: true }, { alias: "b", exists: true }]]]);
     // "pin" isn't in the registry → behave as unpinned (fan out), never ["pin"].
-    expect(vaultTargets(getConfig({ CONTEXTNEST_VAULT_ALIAS: "pin" }), twoVaults)).toEqual(["a", "b"]);
+    expect(vaultTargets(cfg({ CONTEXTNEST_VAULT_ALIAS: "pin" }), twoVaults)).toEqual(["a", "b"]);
     // Registered but path missing (exists:false) is also not usable → fall back.
     const missing = fakeExec([["vault list", [{ alias: "gone", exists: false }]]]);
-    expect(vaultTargets(getConfig({ CONTEXTNEST_VAULT_ALIAS: "gone" }), missing)).toEqual([null]);
+    expect(vaultTargets(cfg({ CONTEXTNEST_VAULT_ALIAS: "gone" }), missing)).toEqual([null]);
   });
 
   // CU-wdqcq01c5v — the vault in the working directory used to be ignored
@@ -401,7 +435,7 @@ describe("lib helpers", () => {
       ]],
       ["vault which", { kind: "local", path: "/work/notes", source: "local" }],
     ]);
-    expect(vaultTargets(getConfig({}), ex)).toEqual([null, "demo", "crm"]);
+    expect(vaultTargets(cfg({}), ex)).toEqual([null, "demo", "crm"]);
   });
 
   it("vaultTargets: a cwd vault that is also registered is searched once, by alias, first", () => {
@@ -412,7 +446,7 @@ describe("lib helpers", () => {
       ]],
       ["vault which", { kind: "local", path: "/vaults/crm", source: "local" }],
     ]);
-    expect(vaultTargets(getConfig({}), ex)).toEqual(["crm", "demo"]);
+    expect(vaultTargets(cfg({}), ex)).toEqual(["crm", "demo"]);
   });
 
   it("vaultTargets: registry entries that are missing or live under os.tmpdir() are never targeted", () => {
@@ -427,19 +461,19 @@ describe("lib helpers", () => {
       ["vault list", registry],
       ["vault which", { kind: "local", path: "/elsewhere", source: "cwd" }],
     ]);
-    expect(vaultTargets(getConfig({}), noCwd)).toEqual(["demo"]);
+    expect(vaultTargets(cfg({}), noCwd)).toEqual(["demo"]);
     // Nothing eligible and no cwd vault → let ctx resolve, as with an empty registry.
     const nothing = fakeExec([
       ["vault list", registry.slice(0, 2)],
       ["vault which", { kind: "local", path: "/elsewhere", source: "cwd" }],
     ]);
-    expect(vaultTargets(getConfig({}), nothing)).toEqual([null]);
+    expect(vaultTargets(cfg({}), nothing)).toEqual([null]);
     // A cwd vault that happens to live under tmp is a deliberate choice → kept.
     const cwdInTmp = fakeExec([
       ["vault list", registry],
       ["vault which", { kind: "local", path: scratch, source: "local" }],
     ]);
-    expect(vaultTargets(getConfig({}), cwdInTmp)).toEqual(["scratch", "demo"]);
+    expect(vaultTargets(cfg({}), cwdInTmp)).toEqual(["scratch", "demo"]);
   });
 
   it("vaultTargets: the cwd vault counts against MAX_FANOUT_VAULTS", () => {
@@ -448,7 +482,7 @@ describe("lib helpers", () => {
       ["vault list", many],
       ["vault which", { kind: "local", path: "/work/notes", source: "local" }],
     ]);
-    const targets = vaultTargets(getConfig({}), ex);
+    const targets = vaultTargets(cfg({}), ex);
     expect(targets).toHaveLength(MAX_FANOUT_VAULTS);
     expect(targets[0]).toBeNull();
     expect(targets.slice(1)).toEqual(["v0", "v1", "v2", "v3"]);
@@ -459,7 +493,7 @@ describe("lib helpers", () => {
       ["vault list", [{ alias: "a", path: "/vaults/a", exists: true }, { alias: "b", path: "/vaults/b", exists: true }]],
       ["vault which", { kind: "local", path: "/work/notes", source: "local" }],
     ]);
-    expect(vaultTargets(getConfig({ CONTEXTNEST_VAULT_ALIAS: "a" }), ex)).toEqual(["a"]);
+    expect(vaultTargets(cfg({ CONTEXTNEST_VAULT_ALIAS: "a" }), ex)).toEqual(["a"]);
   });
 
   it("isVaultRegistered: true only for a registered, present alias", () => {
@@ -603,7 +637,7 @@ describe("retrieve", () => {
 
 describe("session-start", () => {
   it("warns when ctx is unavailable", () => {
-    const out = sessionStart({ input: {}, env: {}, exec: () => ({ status: 1, stdout: "", code: "ENOENT" }) });
+    const out = startSession({ input: {}, env: {}, exec: () => ({ status: 1, stdout: "", code: "ENOENT" }) });
     expect(additional(out)).toMatch(/not available/i);
   });
 
@@ -614,7 +648,7 @@ describe("session-start", () => {
         { alias: "home", description: "personal", exists: true },
       ]],
     ]);
-    const out = sessionStart({ input: {}, env: { CONTEXTNEST_VAULT_ALIAS: "home" }, exec: ex });
+    const out = startSession({ input: {}, env: { CONTEXTNEST_VAULT_ALIAS: "home" }, exec: ex });
     const ctx = additional(out)!;
     expect(ctx).toContain("`work`");
     expect(ctx).toContain("default");
@@ -625,7 +659,7 @@ describe("session-start", () => {
     const ex = fakeExec([
       ["vault list", [{ alias: "work", exists: true }, { alias: "home", exists: true }]],
     ]);
-    const out = sessionStart({ input: {}, env: { CONTEXTNEST_VAULT_ALIAS: "ghost" }, exec: ex });
+    const out = startSession({ input: {}, env: { CONTEXTNEST_VAULT_ALIAS: "ghost" }, exec: ex });
     const ctx = additional(out)!;
     expect(ctx).toMatch(/not a registered vault/i);
     expect(ctx).toContain("`ghost`");
@@ -639,7 +673,7 @@ describe("session-start", () => {
       ["vault list", [{ alias: "work", path: "/vaults/work", exists: true }]],
       ["vault which", { kind: "local", path: "/proj/notes", source: "local" }],
     ]);
-    const out = sessionStart({ input: { cwd: "/proj/notes" }, env: {}, exec: ex });
+    const out = startSession({ input: { cwd: "/proj/notes" }, env: {}, exec: ex });
     const ctx = additional(out)!;
     expect(ctx).toMatch(/working-directory vault/i);
     expect(ctx).toContain("/proj/notes");
@@ -651,7 +685,7 @@ describe("session-start", () => {
       ["vault list", [{ alias: "work", path: "/vaults/work", exists: true }]],
       ["vault which", { kind: "local", path: "/vaults/work", source: "local" }],
     ]);
-    const ctx = additional(sessionStart({ input: {}, env: {}, exec: ex }))!;
+    const ctx = additional(startSession({ input: {}, env: {}, exec: ex }))!;
     expect(ctx).toMatch(/working-directory vault/i);
     expect(ctx).toContain("`work`");
     expect(ctx).not.toMatch(/not registered/i);
@@ -662,11 +696,11 @@ describe("session-start", () => {
       ["vault list", [{ alias: "work", path: "/vaults/work", exists: true }]],
       ["vault which", { kind: "local", path: "/elsewhere", source: "default", alias: "work" }],
     ]);
-    expect(additional(sessionStart({ input: {}, env: {}, exec: ex }))).not.toMatch(/working-directory vault/i);
+    expect(additional(startSession({ input: {}, env: {}, exec: ex }))).not.toMatch(/working-directory vault/i);
   });
 
   it("notes local resolution when no vaults are registered", () => {
-    const out = sessionStart({ input: {}, env: {}, exec: fakeExec([["vault list", []]]) });
+    const out = startSession({ input: {}, env: {}, exec: fakeExec([["vault list", []]]) });
     expect(additional(out)).toMatch(/No vaults are registered/i);
   });
 });


### PR DESCRIPTION
## Summary

Adds `client` — optional caller attribution (agent name + session id, plus custom keys) on every read and write in the operation catalog, threaded through the engine, CLI, and MCP server. Also fixes a pre-existing test-isolation bug in the plugin test suite found while verifying this work locally.

## What's in here

**Engine catalog** (`packages/engine`)
- Every one of the 19 `core` operations accepts an optional `client: { agent?, session_id?, ...custom }` object (`packages/engine/src/api/client.ts`, wired into `core.ts`).
- Writes that publish (`context_create`, `context_update`, `context_publish`, `context_import`) record it on the version-history entry they seal — `context_versions` can answer "which agent wrote v7, in which session."
- Graph reads (`context_query`, `context_resolve`) stamp it on the §9.2 access traces they emit. (`context_search` bypasses the query engine for its ranked full-text index and emits no traces, so it doesn't get a stamp — documented as such.)
- Bounded (`clientMetadataSchema` in `schemas.ts`): scalar values ≤512 chars, ≤16 custom keys, and a near-miss on a reserved key (`sessionId`, `session-id`) is rejected rather than silently filed as a custom key.
- **Everything is optional** — the object and every field in it — pinned by a contract test across all 19 ops so a future schema tweak can't quietly make it mandatory.
- Deliberately **not** an input to `computeChainHash`, so history recorded before this field existed keeps verifying byte-for-byte.

**CLI** (`packages/cli`)
- Global `--agent <name>`, `--session <id>`, `--client <key=value>` (repeatable), with `CONTEXTNEST_AGENT`/`CONTEXTNEST_SESSION_ID` env fallbacks (per-key, so a flag can override just one).
- All 13 engine-API call sites route through one `cliApi()` wrapper so a new command can't ship unattributed by omission.
- `ctx history` renders the recorded client, distinct from `By:` (the authoring identity, not the caller).

**MCP server** (`packages/mcp-server`)
- Fills `agent` from the `initialize` handshake's `clientInfo.name` and `session_id` from a per-process id (stdio: one process = one connection) when the caller sends none — merged per key under whatever the caller supplies.
- `CONTEXTNEST_NO_ATTRIBUTION=1` opt-out (derivation only — never strips a caller's own explicit `client`), plus `CONTEXTNEST_AGENT`/`CONTEXTNEST_SESSION_ID` overrides, matching the CLI.
- With nothing to record, `client` is omitted entirely rather than sent as `{}` — "not attributed" and "attributed to nobody" are different claims.

**Spec** (`CONTEXT_NEST_SPEC.md`)
- New §9.4 (Client Metadata) with §9.4.1 (reserved/custom keys) and §9.4.2 (binding conventions — per-key merge, what each transport should derive fields from, and that a binding must never invent a value it can't stand behind).
- `client` field added to the §6.2 version-entry example.

**Test-isolation fix** (`plugins/__tests__/core.unit.test.ts`)
- Unrelated to the feature, found while verifying on a real dev checkout: several plugin config tests called `getConfig()`/`sessionStart()` with literal `env` objects that never reached the file's own sandbox (`getConfig` resolves cwd off the `env` *parameter*, not `process.env`), so on a machine with a real `.claude/contextnest.local.json` they silently read the developer's actual vault pin instead of the intended defaults. Fixed via two sandboxed wrappers (`cfg()`, `startSession()`) that inject the sandbox dir through the same `env.CLAUDE_PROJECT_DIR` channel a real hook invocation would use. No production code touched.

## Verification

- `pnpm build` — clean
- `pnpm lint` — clean (0 errors)
- `pnpm test` — 1212/1212 passed (up from 1206/6-failed before the plugin fix)
- `pnpm test:regression` — 307/307 passed (builds and drives the real CLI/MCP binaries)
- `pnpm plugins:check` — vendored plugin copies in sync

## Notable exclusions

- A write with `publish: false` seals no version entry, so its `client` reaches extension `authorize`/`onResult` hooks only, never disk.
- `context_search`'s rewrite (from `development`) to the ranked full-text index means it emits no access traces — `client` is accepted on the op and reaches extension hooks, but has nothing to stamp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
